### PR TITLE
Decode the documents path as UTF-8 rather than as Latin-1

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -219,13 +219,36 @@ void warningOkCancelBox(TCHAR const *const title, TCHAR const *const question,
 /// convention, and the getters cannot be called too early because there is no
 /// "too early".
 ///                                       (31.07.2026.) (SW port)
+///
+/// \note **fromUTF8(), not the `char const *` constructor**, and that one word is
+/// the whole of issue #28. `u8string()` ought to be unambiguous -- JUCE has a
+/// `String( char8_t const * )` overload that decodes UTF-8 -- but sst-plugininfra's
+/// `filesystem` target carries `-fno-char8_t` in its INTERFACE compile options
+/// (libs/sst/sst-plugininfra/libs/filesystem/CMakeLists.txt), and it propagates
+/// here. So `std::u8string` *is* `std::string`, `.c_str()` is a plain
+/// `char const *`, the `char8_t` overload does not exist to be chosen, and the
+/// call lands on `String( char const * )` -- which builds through
+/// `CharPointer_ASCII`, widening every *byte* to a code point before re-encoding
+/// the lot as UTF-8.
+///
+///   ASCII is a fixed point of that widening, which is why it survived to a
+/// release: it takes a home directory whose localised Documents folder is not
+/// ASCII. Under `ja_JP.UTF-8` the XDG answer came back as its own mojibake --
+/// `e3 83 89 ...` in, `c3 a3 c2 83 c2 89 ...` out -- which then matched no
+/// directory that existed, so the plugin helpfully created that one instead. The
+/// XDG lookup is byte-exact and was never at fault; only this conversion was.
+///
+///   Note that `String( char const * )` carries a `jassert` for precisely this,
+/// so a debug build on such a machine would have said so outright. Nobody had one.
+///                                       (09.08.2026.) (SW port)
 
 juce::File const &rootPath()
 {
-    static juce::File const path(sst::plugininfra::paths::bestDocumentsVendorFolderPathFor(
-                                     "Surge Synth Team", "SpectrumWorx")
-                                     .u8string()
-                                     .c_str());
+    static juce::File const path(
+        juce::String::fromUTF8(sst::plugininfra::paths::bestDocumentsVendorFolderPathFor(
+                                   "Surge Synth Team", "SpectrumWorx")
+                                   .u8string()
+                                   .c_str()));
     return path;
 }
 

--- a/src/gui/preset_browser/presetBrowser.cpp
+++ b/src/gui/preset_browser/presetBrowser.cpp
@@ -940,6 +940,27 @@ void PresetBrowser::refreshFactory()
             files_.add(Item{preset.c_str(), Item::Kind::Preset});
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// PresetBrowser::refreshUserDirectory()
+// -------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note `fromUTF8()`, for the same reason `rootPath()` needs it -- see the long
+/// note in gui.cpp. What `directory_iterator` hands back is whatever bytes the
+/// file system holds, and `juce::String( char const *, size_t )` would read them
+/// through `CharPointer_ASCII` and widen each one into its own code point. A
+/// preset named in anything but ASCII would list under a mangled name here, and
+/// then fail to be found again by it.
+///
+///   `nameLength` stays as it is: it is a count of bytes, and `bufferSizeBytes`
+/// is what the second parameter of `fromUTF8()` wants too. It is only the
+/// *interpretation* of those bytes that changes.
+///                                       (09.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
 void PresetBrowser::refreshUserDirectory()
 {
     files_.add(Item{"..", Item::Kind::Parent});
@@ -962,7 +983,7 @@ void PresetBrowser::refreshUserDirectory()
         if (isDirectory || std::_tcscmp(fileName.c_str() + nameLength, presetExtension) == 0)
         {
             item.kind = isDirectory ? Item::Kind::Folder : Item::Kind::Preset;
-            item.name = juce::String(fileName.c_str(), nameLength);
+            item.name = juce::String::fromUTF8(fileName.c_str(), static_cast<int>(nameLength));
             files_.add(item);
         }
     }

--- a/tests/gui/pathsTests.cpp
+++ b/tests/gui/pathsTests.cpp
@@ -24,13 +24,27 @@
 //------------------------------------------------------------------------------
 #include "gui/gui.hpp"
 
+#include <sst/plugininfra/paths.h>
+
 #include <catch2/catch_test_macros.hpp>
+
+#include <string>
 //------------------------------------------------------------------------------
 namespace
 {
 //------------------------------------------------------------------------------
 
 using namespace LE::SW;
+
+/// \note "Documents" in Japanese -- the reporter's locale in issue #28 -- written
+/// as the bytes rather than as the characters. The rest of this tree is ASCII
+/// but for an em dash and an acute accent, the case is about the bytes anyway,
+/// and this way it does not depend on the encoding of the file it is in. Six
+/// code points, three bytes each: `U+30C9 U+30AD U+30E5 U+30E1 U+30F3 U+30C8`.
+constexpr char const japaneseDocuments[]{"\xE3\x83\x89\xE3\x82\xAD\xE3\x83\xA5"
+                                         "\xE3\x83\xA1\xE3\x83\xB3\xE3\x83\x88"};
+
+constexpr int japaneseDocumentsCharacters{6};
 
 //------------------------------------------------------------------------------
 } // anonymous namespace
@@ -85,4 +99,90 @@ TEST_CASE("The user preset paths answer without an initialisation step", "[paths
     /// nor passes or fails depending on whether one is already there.
     CHECK(presets.getFileName() == "Presets");
     CHECK(presets.getParentDirectory() == root);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Issue #28, and the reason this file gained a second case. On a
+/// `ja_JP.UTF-8` desktop the plugin created `~/<mojibake>/SpectrumWorx` instead
+/// of finding the localised Documents folder XDG had correctly pointed it at.
+/// Nothing was wrong with the XDG lookup -- `paths_linux.cpp` parses
+/// `user-dirs.dirs` a byte at a time and hands the bytes back untouched. What
+/// was wrong was one conversion at the end of `rootPath()`: `juce::String`'s
+/// `char const *` constructor reads through `CharPointer_ASCII`, which widens
+/// each *byte* into its own code point and re-encodes the result as UTF-8. The
+/// long note in gui.cpp has why the `char8_t` overload that would have saved it
+/// is not there (`-fno-char8_t`, from sst-plugininfra's `filesystem` target --
+/// and this translation unit is built with it too, so what is checked here is
+/// what ships).
+///
+/// \note The character count is the assertion that actually bites. Byte
+/// equality catches it as well, but "six characters, not eighteen" is the
+/// difference between the two constructors stated directly: `CharPointer_ASCII`
+/// cannot produce six out of eighteen bytes, whatever else it does.
+///
+/// \note Still no side effect, in keeping with the case above -- these paths are
+/// built and parsed, never created, and none of them needs to exist. The last
+/// section is the one that would have failed on the reporter's machine and
+/// passes everywhere else, which is precisely why the first two are here: they
+/// fail on any machine, in any locale, the moment the conversion goes back.
+///                                       (09.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A non-ASCII documents folder survives the trip into juce::File", "[paths]")
+{
+    SECTION("UTF-8 bytes decode as characters rather than as Latin-1")
+    {
+        std::string const documents(japaneseDocuments);
+        auto const decoded(juce::String::fromUTF8(documents.c_str()));
+
+        INFO("decoded " << decoded);
+        CHECK(decoded.length() == japaneseDocumentsCharacters);
+        CHECK(decoded.toStdString() == documents);
+
+        /// \note The length parameter is a count of *bytes* -- which is what the
+        /// preset browser passes it, having measured a file name -- and not a
+        /// count of characters. Getting that wrong would truncate mid-sequence.
+        auto const counted(
+            juce::String::fromUTF8(documents.c_str(), static_cast<int>(documents.size())));
+        CHECK(counted == decoded);
+    }
+
+#ifndef _WIN32
+    SECTION("The whole of rootPath()'s conversion, on a path that has to be built")
+    {
+        /// \note The expression below is `rootPath()`'s, with a hand-made path
+        /// standing in for the one XDG answers with: a machine that runs this
+        /// almost certainly has an ASCII home directory, and ASCII is a fixed
+        /// point of the widening that was wrong. The bug only shows on bytes
+        /// above 0x7F, so the test has to bring its own.
+        std::string const expected(std::string("/home/tester/") + japaneseDocuments +
+                                   "/SpectrumWorx");
+
+        juce::File const file(juce::String::fromUTF8(fs::path{expected}.u8string().c_str()));
+
+        INFO("file " << file.getFullPathName());
+        CHECK(file.getFullPathName().toStdString() == expected);
+        CHECK(file.getFileName() == "SpectrumWorx");
+        CHECK(file.getParentDirectory().getFileName().length() == japaneseDocumentsCharacters);
+    }
+#endif // _WIN32
+
+#ifndef _WIN32
+    SECTION("rootPath() is byte for byte what sst-plugininfra answered")
+    {
+        /// \note The end-to-end invariant, and the one the reporter's machine
+        /// broke: whatever the waterfall picks, `rootPath()` must hand back those
+        /// bytes and no others. It says nothing on an ASCII machine, which is the
+        /// whole reason the two sections above exist -- but it is the only check
+        /// here that would have caught the bug in situ.
+        auto const answered(sst::plugininfra::paths::bestDocumentsVendorFolderPathFor(
+                                "Surge Synth Team", "SpectrumWorx")
+                                .u8string());
+
+        INFO("answered " << answered);
+        CHECK(GUI::rootPath().getFullPathName().toStdString() == answered);
+    }
+#endif // _WIN32
 }


### PR DESCRIPTION
`rootPath()` handed `fs::path::u8string().c_str()` straight to `juce::File`, whose `juce::String( char const * )` constructor reads through `CharPointer_ASCII`: every byte becomes its own code point, and the lot is re-encoded as UTF-8. What makes that the constructor chosen is `-fno-char8_t`, which sst-plugininfra's `filesystem` target carries in its INTERFACE compile options and which propagates here -- `std::u8string` is `std::string`, so the `String( char8_t const * )` overload that would have decoded UTF-8 correctly is not in the overload set to begin with.

ASCII is a fixed point of that widening, which is why it survived to a release: it takes a localised Documents folder that is not ASCII. Under `ja_JP.UTF-8` the XDG answer went in as `e3 83 89 ...` and came back as `c3 a3 c2 83 c2 89 ...`, matched no directory that existed, and the plugin created that one instead. The XDG lookup is byte-exact and was never at fault; only this conversion was.

`PresetBrowser::refreshUserDirectory()` had the same conversion on the file names coming off `directory_iterator`, so a preset named in anything but ASCII listed under a mangled name and then could not be found again by it.

The regression case is three sections: two that fail on any machine in any locale, and the end-to-end invariant that `rootPath()` is byte for byte what sst-plugininfra answered -- the only one of the three that would have failed in situ. Reverting either conversion reproduces the reporter's mojibake exactly, 18 characters where there should be 6.

382 registered cases, Debug, green.

Closes #28.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>