### PR TITLE
Compile JUCE once rather than in every target that links it

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -68,6 +68,99 @@ target_compile_definitions(juce_core INTERFACE JUCE_USE_CURL=0 JUCE_WEB_BROWSER=
 # one this whole tree is already built with.
 target_compile_definitions(juce_audio_formats INTERFACE JUCE_USE_MP3AUDIOFORMAT=1)
 
+################################################################################
+# sw-juce -- the one target that compiles JUCE.
+#
+#   A JUCE module target is an INTERFACE library carrying its own .cpp files as
+# INTERFACE_SOURCES, so linking one does not link a library: it hands those
+# sources to the *consumer*, which compiles them itself. Every target that named
+# a module compiled JUCE, and a PUBLIC link passed the sources on to compile
+# again -- 72 JUCE translation units in a build that needs ten of them.
+#
+#   This target compiles them once and gives everyone else the same modules'
+# usage requirements with the sources left behind. The link below is PRIVATE,
+# which CMake records as $<LINK_ONLY:juce::...>: it stays on a consumer's link
+# line -- so the macOS frameworks, Linux's -latomic and the pkg-config packages
+# still arrive -- while the sources, include paths and defines that would come
+# with it do not. The three a consumer does need are copied across explicitly.
+#
+#   Per module rather than just the two at the root of the dependency graph:
+# $<TARGET_PROPERTY:tgt,INTERFACE_X> reads that one target's property and does
+# not walk its dependencies, so juce_gui_extra alone would forward none of
+# juce_core's -- which is where JUCE_USE_CURL, JUCE_MODULE_AVAILABLE_* and the
+# DEBUG/NDEBUG pair live. Copying them keeps one source of truth for the
+# settings above: a consumer's headers and this target's objects cannot disagree
+# about them, which is the ODR bug in the note above waiting to happen again.
+#
+# \note Two targets keep compiling their own copy, and neither is an oversight:
+#
+#   - clap_juce_shim, which is upstream in sst-clap-helpers, and which compiles
+#     its nine modules with four settings of its own -- JUCE_MODAL_LOOPS_PERMITTED,
+#     JUCE_COREGRAPHICS_DRAW_ASYNC, JUCE_REPORT_APP_USAGE and JUCE_USE_CAMERA.
+#     Those it has, and this target does not, are what remains of the divergence
+#     the note above describes. It changes nothing about what ships: the bundle
+#     resolves all nine from libclap_juce_shim.a, exactly as it did when the
+#     alternative was sw-impl's copy (which took the four from the shim's PUBLIC
+#     link), and takes only juce_audio_basics and juce_audio_formats from here --
+#     two modules the shim does not build and that read none of the four.
+#     `nm -pa <bundle> | grep OSO` is what answers this, per build.
+#   - sw-show-ui, which defines _CONSOLE. juce_ApplicationBase.cpp compiles
+#     JUCEApplicationBase::main( argc, argv ) only outside the WinMain arm that
+#     macro selects between, and tools/show-ui/main.cpp calls it directly, so a
+#     copy built without it would not link on Windows.
+#
+#   JUCE_STANDALONE_APPLICATION is *not* what separates those two from this
+# target, whatever the settings on sw-impl and sw-show-ui suggest: no module in
+# JUCE 8.0.12 reads it. It is left where it is rather than deleted here.
+#
+# \note What this widens: a consumer sees all eight modules' headers rather than
+# the closure of the one it used to name. The boundary that matters is sw-dsp,
+# which links no JUCE at all and does not link this either --
+# tests/checkNoJuceInDSP.cmake fails the build if that changes.
+################################################################################
+
+set(swJuceModules
+        juce_core juce_events juce_data_structures juce_graphics
+        juce_gui_basics juce_gui_extra juce_audio_basics juce_audio_formats)
+
+# One translation unit of its own, so the target has a source of a language
+# CMake can name. JUCE's arrive through the link below. file(CONFIGURE) rather
+# than file(WRITE) because it leaves the file alone when the content has not
+# changed, and rewriting it would recompile JUCE on every configure.
+set(swJuceUnit "${CMAKE_CURRENT_BINARY_DIR}/swJuceUnit.cpp")
+file(CONFIGURE OUTPUT "${swJuceUnit}"
+     CONTENT "// JUCE is compiled here. See sw-juce in libs/CMakeLists.txt.\n")
+
+add_library(sw-juce STATIC "${swJuceUnit}")
+
+foreach (swJuceModule IN LISTS swJuceModules)
+    target_link_libraries(sw-juce PRIVATE juce::${swJuceModule})
+
+    target_include_directories(sw-juce INTERFACE
+            $<TARGET_PROPERTY:juce::${swJuceModule},INTERFACE_INCLUDE_DIRECTORIES>)
+    target_compile_definitions(sw-juce INTERFACE
+            $<TARGET_PROPERTY:juce::${swJuceModule},INTERFACE_COMPILE_DEFINITIONS>)
+    target_compile_options(sw-juce INTERFACE
+            $<TARGET_PROPERTY:juce::${swJuceModule},INTERFACE_COMPILE_OPTIONS>)
+
+    # A module's Linux pkg-config packages are a target of their own, hung off
+    # the module's link interface -- and its include paths and cflags are on the
+    # compile side of the line the PRIVATE link draws, so they need the same
+    # treatment one hop further out. Only juce_graphics has any (freetype2 and
+    # fontconfig), and only on Linux, which is why the existence test: the
+    # target is created by juce_add_module() or not at all. The libraries
+    # themselves come through the link interface and need nothing here.
+    #
+    # Untested from this machine -- macOS creates none of these -- so if a Linux
+    # build fails on a missing freetype header, this is the line to read first.
+    if (TARGET juce::pkgconfig_${swJuceModule}_LINUX_DEPS)
+        target_include_directories(sw-juce INTERFACE
+                $<TARGET_PROPERTY:juce::pkgconfig_${swJuceModule}_LINUX_DEPS,INTERFACE_INCLUDE_DIRECTORIES>)
+        target_compile_options(sw-juce INTERFACE
+                $<TARGET_PROPERTY:juce::pkgconfig_${swJuceModule}_LINUX_DEPS,INTERFACE_COMPILE_OPTIONS>)
+    endif ()
+endforeach ()
+
 add_subdirectory(sst/sst-cpputils)
 add_subdirectory(sst/sst-basic-blocks)
 add_subdirectory(sst/sst-plugininfra)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,11 @@ target_link_libraries(sw-impl PRIVATE
         sst-plugininfra::version_information
         sst::clap_juce_shim
         sst::clap_juce_shim_headers
-        juce::juce_gui_basics
+
+        # spectrumWorxCLAP.cpp opens the editor. It reached JUCE through
+        # juce::juce_gui_basics and so compiled the module here as well; sw-juce
+        # is the same headers with the sources already built.
+        sw-juce
 )
 
 # clap_juce_shim.h is included from spectrumWorxCLAP.hpp, and the ADD_SHIM_*

--- a/src/dsp.cmake
+++ b/src/dsp.cmake
@@ -239,10 +239,14 @@ target_link_libraries(sw-io PUBLIC sw-dsp)
 # The factory samples, which are in the binary beside the banks.
 target_link_libraries(sw-io PRIVATE sw::assets)
 
-# The audio file decoder, replacing the DirectShow and ExtAudioFile ones. PUBLIC
-# because it compiles juce_audio_basics and juce_audio_formats into whatever
-# links sw-io, and the plugin's own translation units have to agree with it.
-target_link_libraries(sw-io PUBLIC juce::juce_audio_formats)
+# The audio file decoder, replacing the DirectShow and ExtAudioFile ones.
+# PUBLIC because sample.cpp's header names juce::AudioFormatManager, so whatever
+# links sw-io has to see the same headers and the same JUCE settings it does.
+#
+# \note This read `juce::juce_audio_formats`, and that is what made every target
+# above sw-io compile juce_audio_formats and juce_audio_basics for itself. The
+# module is inside sw-juce now; see libs/CMakeLists.txt.
+target_link_libraries(sw-io PUBLIC sw-juce)
 
 # \note JUCE's module settings -- JUCE_USE_MP3AUDIOFORMAT as well as
 # JUCE_USE_CURL and JUCE_WEB_BROWSER -- were set here, PUBLIC, on the reasoning

--- a/src/gui.cmake
+++ b/src/gui.cmake
@@ -18,10 +18,11 @@ sw_force_include_odr_header(sw-gui-resources)
 
 target_include_directories(sw-gui-resources PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-# juce_gui_basics rather than juce_graphics: Theme is a LookAndFeel_V2. The
-# other four modules come transitively.
+# sw-juce rather than juce::juce_gui_basics -- Theme is a LookAndFeel_V2, so
+# juce_graphics is not enough, and naming a module target here is what used to
+# make this target compile JUCE. See libs/CMakeLists.txt.
 target_link_libraries(sw-gui-resources
-        PUBLIC juce::juce_gui_basics
+        PUBLIC sw-juce
         # assertionHandler.cpp prints a stack trace with the message.
         PRIVATE sw::assets sst-plugininfra
 )


### PR DESCRIPTION
A JUCE module target carries its own sources as INTERFACE_SOURCES, so naming one makes the consumer compile that module -- and a PUBLIC link passes the sources on to compile again. Eight targets did, for 72 JUCE translation units in a build that needs ten of them.

sw-juce compiles them once and hands everyone else the same modules' include paths, defines and options with the sources left behind, which is what the PRIVATE link buys: $<LINK_ONLY:> keeps the frameworks and the pkg-config libraries on a consumer's link line without the compile side coming with them. sw-gui-resources, sw-io and sw-impl name it instead of a module; clap_juce_shim and sw-show-ui keep their own copy.

29 translation units now, and what ships is unchanged: the bundle still resolves the nine GUI and core modules from clap_juce_shim, and takes only the two audio modules -- which read none of its settings -- from here.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>