### PR TITLE
Run the test suite under clang-cl on Windows

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -14,9 +14,10 @@
 #                  out the per-format wrapping and with it the VST3 and
 #                  AudioUnit SDK fetches -- the test binaries link sw-dsp and
 #                  sw-impl and want none of it (verified: that configuration
-#                  writes no _deps/ at all). Linux runs a third leg, the Debug
-#                  one again under GCC 15, which is a compiler and not a
-#                  configuration and so costs one matrix entry rather than a job.
+#                  writes no _deps/ at all). Two of the legs are a compiler
+#                  rather than a configuration, and so cost a matrix entry
+#                  rather than a job: Linux Debug again under GCC 15, and
+#                  Windows Release again under clang-cl.
 #   build_plugin   the four bundles, and on anything but a pull request the
 #                  installer as well. Windows builds twice, MSVC and clang-cl;
 #                  the second is compiler coverage and ships nothing.
@@ -118,6 +119,22 @@ jobs:
             os: windows-latest
             config: Release
             cmake_args: -Ax64
+            use_gcc15: false
+
+          # The same runner and the same configuration, a different front end.
+          # clang-cl already builds the bundles in build_plugin below; what it
+          # has never done is *run* anything, so a codegen difference between the
+          # two Windows compilers -- the goldens are the part that would notice
+          # one -- has had nowhere to show up. It has to before clang-cl can be
+          # considered for the shipping binary.
+          #
+          #   Release only, for both of the reasons the MSVC leg is: the Debug
+          # hang noted above is a property of this runner and not of MSVC, and
+          # Release is the configuration that renders the goldens anyway.
+          - name: windows-x64-clang
+            os: windows-latest
+            config: Release
+            cmake_args: -Ax64 -TClangCL
             use_gcc15: false
 
           # Host architecture only. The bundles are universal; the tests are not
@@ -240,7 +257,9 @@ jobs:
           # what neither side alone has found.
           #
           # It ships nothing: the Windows download is MSVC's, so this leg stops
-          # at the four bundles and skips the installer and the artifact.
+          # at the four bundles and skips the installer and the artifact. The
+          # suite runs under clang-cl too, but in the test job above -- this one
+          # is the per-format wrapping, which that one turns off.
           #
           # Quiet, for now. The warning baseline is empty under MSVC -- and
           # clang-cl is MSVC as far as CMake's `if (MSVC)` is concerned -- so

--- a/doc/tech/effect_contract.md
+++ b/doc/tech/effect_contract.md
@@ -474,7 +474,7 @@ the group tuple (`effectIndexToGroupMapping.hpp:29`) and the name arrays
 > entries — `bandpass` gives `Bandpass` and `Bandstop`, `eximploder` gives four.
 >
 > The table is bracketed by `// clang-format off` / `on` for a reason worth
-> knowing: `tools/show-ui/CMakeLists.txt:136` parses it with
+> knowing: `tools/show-ui/CMakeLists.txt:140` parses it with
 > `string(REGEX MATCHALL "\n[ \t]*x\\([^\n]*\\)" …)` — the first `x(...)` after
 > each newline. Reflowed, the parse silently dropped to 40 of 57 and the UI suite
 > lost seventeen tests **without failing**. It did, on 05.08.2026. It now

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -92,24 +92,28 @@ target_compile_definitions(juce_audio_formats INTERFACE JUCE_USE_MP3AUDIOFORMAT=
 # settings above: a consumer's headers and this target's objects cannot disagree
 # about them, which is the ODR bug in the note above waiting to happen again.
 #
-# \note Two targets keep compiling their own copy, and neither is an oversight:
+# \note One target keeps compiling its own copy, and it is not an oversight:
+# clap_juce_shim, which is upstream in sst-clap-helpers, and which compiles its
+# nine modules with four settings of its own -- JUCE_MODAL_LOOPS_PERMITTED,
+# JUCE_COREGRAPHICS_DRAW_ASYNC, JUCE_REPORT_APP_USAGE and JUCE_USE_CAMERA. Those
+# it has, and this target does not, are what remains of the divergence the note
+# above describes. It changes nothing about what ships: the bundle resolves all
+# nine from libclap_juce_shim.a, exactly as it did when the alternative was
+# sw-impl's copy (which took the four from the shim's PUBLIC link), and takes
+# only juce_audio_basics and juce_audio_formats from here -- two modules the
+# shim does not build and that read none of the four. `nm -pa <bundle> | grep
+# OSO` is what answers this, per build.
 #
-#   - clap_juce_shim, which is upstream in sst-clap-helpers, and which compiles
-#     its nine modules with four settings of its own -- JUCE_MODAL_LOOPS_PERMITTED,
-#     JUCE_COREGRAPHICS_DRAW_ASYNC, JUCE_REPORT_APP_USAGE and JUCE_USE_CAMERA.
-#     Those it has, and this target does not, are what remains of the divergence
-#     the note above describes. It changes nothing about what ships: the bundle
-#     resolves all nine from libclap_juce_shim.a, exactly as it did when the
-#     alternative was sw-impl's copy (which took the four from the shim's PUBLIC
-#     link), and takes only juce_audio_basics and juce_audio_formats from here --
-#     two modules the shim does not build and that read none of the four.
-#     `nm -pa <bundle> | grep OSO` is what answers this, per build.
-#   - sw-show-ui, which defines _CONSOLE. juce_ApplicationBase.cpp compiles
-#     JUCEApplicationBase::main( argc, argv ) only outside the WinMain arm that
-#     macro selects between, and tools/show-ui/main.cpp calls it directly, so a
-#     copy built without it would not link on Windows.
+# \note sw-show-ui was the second such target, and the reason it was one did not
+# survive being looked at. It defined _CONSOLE so that its own copy would
+# compile JUCEApplicationBase::main( argc, argv ) rather than the WinMain arm --
+# but it also links sw-gui, which brings this target along PUBLIC, so both
+# copies were on its link line and every symbol in the shared modules was
+# defined twice. Three linkers never said so; lld-link did, on the first
+# clang-cl CI run. The tool takes JUCE from here now and calls the no-argument
+# overload, which is compiled outside that guard. See tools/show-ui.
 #
-#   JUCE_STANDALONE_APPLICATION is *not* what separates those two from this
+#   JUCE_STANDALONE_APPLICATION is *not* what separated those two from this
 # target, whatever the settings on sw-impl and sw-show-ui suggest: no module in
 # JUCE 8.0.12 reads it. It is left where it is rather than deleted here.
 #

--- a/tools/show-ui/CMakeLists.txt
+++ b/tools/show-ui/CMakeLists.txt
@@ -20,11 +20,23 @@ add_executable(sw-show-ui
 # \note sw-gui-resources -- which the skin and theme pages are made of -- was
 # named here too, and the linker answered "ignoring duplicate libraries". It
 # comes with sw-gui below, PUBLIC by way of sw-gui-widgets, headers included.
+#
+# \note juce::juce_gui_basics and juce::juce_gui_extra were named here as well,
+# and naming them is what made this tool compile its own copy of JUCE: a module
+# target is an INTERFACE library carrying its .cpp files as INTERFACE_SOURCES,
+# so linking one hands those sources to the consumer. sw-juce arrives anyway --
+# PUBLIC, along the same chain as sw-gui-resources above -- so both copies
+# reached the link line and every juce_gui_basics symbol was defined twice.
+#
+#   Nothing said so for a long time. link.exe, ld and ld64 pull an archive
+# member only to resolve a symbol that is still undefined, and this target's own
+# objects got there first, so sw-juce.lib's copies were never pulled. lld-link
+# pulls the member and then reports the collision, which is how the clang-cl CI
+# leg found it on the first run. Only juce_gui_basics is in the message; every
+# module those two drag in was being compiled twice.
 target_link_libraries(sw-show-ui PRIVATE
-        juce::juce_gui_basics
-        juce::juce_gui_extra
-
-        # The editor page, and the skin and theme pages under it.
+        # The editor page, and the skin and theme pages under it. JUCE comes
+        # with it -- compiled once, as sw-juce.
         sw-gui
 )
 
@@ -55,27 +67,19 @@ target_compile_definitions(sw-show-ui PRIVATE
         JUCE_MODAL_LOOPS_PERMITTED=0
 )
 
-# `_CONSOLE`, and PRIVATE to this executable -- the opposite of the rule above,
-# for the opposite reason. It is not a setting of the JUCE modules but a
-# statement about *this* binary: it is a console-subsystem program, which is
-# what a plain add_executable() produces and what ctest runs with `--render`.
+# \note `_CONSOLE` was defined here on Windows and is not any more. It was a
+# setting of this target's *own copy* of JUCE: juce_ApplicationBase.cpp guards
+# `JUCEApplicationBase::main( argc, argv )` with
+# `JUCE_WINDOWS && ! defined( _CONSOLE )` and offers WinMain otherwise, and
+# main.cpp names that overload directly. That copy is exactly what collided with
+# sw-juce (see the link note above), so the copy went and the macro with it.
 #
-#   JUCE reads it three times and gets all three right only if it is set.
-# juce_Initialisation.h picks `int main( argc, argv )` over `WinMain` for the
-# entry point; juce_ApplicationBase.cpp compiles the matching
-# `JUCEApplicationBase::main( argc, argv )` **only** in the same arm, and takes
-# the command line from those arguments rather than GetCommandLineW(); and it
-# skips an AttachConsole( ATTACH_PARENT_PROCESS ) that exists so a GUI app can
-# printf, which a console app has no need of.
-#
-#   main.cpp hand-expands START_JUCE_APPLICATION so that --render can run before
-# any of JUCE's application machinery, so it names that overload directly -- and
-# without this the Windows link failed on it, which is how a macro nobody reads
-# turns into an unresolved symbol. The plugin's own standalone must NOT have
-# this: clap-wrapper builds a GUI-subsystem app and wants JUCE's WinMain.
-if (WIN32)
-    target_compile_definitions(sw-show-ui PRIVATE _CONSOLE)
-endif ()
+#   This is still a console-subsystem program -- that is what a plain
+# add_executable() produces, and what ctest runs with `--render`. The macro was
+# never what made it one. main.cpp now calls the no-argument
+# `JUCEApplicationBase::main()`, which JUCE compiles outside that guard in every
+# configuration; the note there says what the argument-taking one added and why
+# none of it is missed on Windows.
 
 # Render every page offscreen. Cheap, needs no display, and it is the only
 # thing that notices a page which compiles but throws, asserts or draws

--- a/tools/show-ui/main.cpp
+++ b/tools/show-ui/main.cpp
@@ -325,10 +325,6 @@ int render(juce::String const &pageName, juce::File const &output)
 // What START_JUCE_APPLICATION expands to, opened up so that --render can run
 // before any of it: JUCEApplicationBase::main() creates an NSApplication on
 // macOS, which offscreen rendering neither needs nor should require.
-//
-// \note Naming the overload rather than letting the macro pick it is why this
-// tool defines _CONSOLE on Windows -- JUCE compiles this one only for a console
-// subsystem binary, and offers WinMain otherwise. See tools/show-ui/CMakeLists.txt.
 juce::JUCEApplicationBase *juce_CreateApplication();
 juce::JUCEApplicationBase *juce_CreateApplication() { return new ShowUIApplication(); }
 
@@ -349,5 +345,22 @@ int main(int argc, char *argv[])
     }
 
     juce::JUCEApplicationBase::createInstance = &juce_CreateApplication;
+
+    /// \note Two overloads, and Windows takes the other one. JUCE guards
+    /// `main( argc, argv )` with `JUCE_WINDOWS && ! defined( _CONSOLE )` and
+    /// compiles it only in the arm this build is not in: JUCE is built once, in
+    /// sw-juce, which is a library and defines no such thing. The no-argument
+    /// overload sits outside that guard and exists in every configuration.
+    ///
+    ///   Nothing is lost by taking it. What the argument-taking one adds is
+    /// juce_argc / juce_argv and, on macOS, initialiseNSApplication() -- and in
+    /// this arm JUCE reads the command line from GetCommandLineW() rather than
+    /// from those two, so on Windows there is nothing left to hand it. Off
+    /// Windows the guard never applies whatever _CONSOLE says, so those
+    /// platforms keep the overload that sets them.
+#if JUCE_WINDOWS
+    return juce::JUCEApplicationBase::main();
+#else
     return juce::JUCEApplicationBase::main(argc, const_cast<char const **>(argv));
+#endif
 }


### PR DESCRIPTION
The clang-cl leg has only ever compiled and linked the bundles. Release is where the goldens render, so this is the configuration in which a codegen difference between the two Windows compilers would show up -- which it has to before clang-cl can be considered for the shipping binary.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>