### PR TITLE
Show the factory banks that hold only a sub-folder

### DIFF
--- a/src/gui/preset_browser/presetBrowser.cpp
+++ b/src/gui/preset_browser/presetBrowser.cpp
@@ -947,10 +947,15 @@ void PresetBrowser::refreshRoot()
 //
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note FactoryPresets::banks() is every directory that holds presets, as a
-/// path relative to the root, so the children of the current bank are the ones
-/// that start with it and have no further separator. Three of the fifteen banks
-/// have a sub-folder, which is why this is a filter rather than a lookup.
+/// \note FactoryPresets::banks() is every directory under the preset root, as a
+/// path relative to it, so the children of the current bank are the ones that
+/// start with it and have no further separator. Three of the fifteen banks have
+/// a sub-folder, which is why this is a filter rather than a lookup.
+///
+/// \note What this reads from banks() has to include the directories that lead
+/// to presets without holding any -- a grandchild is skipped here on the
+/// understanding that its parent is a row the user can open, and for those three
+/// banks there was no such row. See collectBanks() in factoryPresets.cpp.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/le/spectrumworx/factoryPresets.cpp
+++ b/src/le/spectrumworx/factoryPresets.cpp
@@ -61,23 +61,41 @@ std::optional<std::string> presetName(std::string const &fileName)
 
 namespace
 {
-/// Depth-first, appending every directory below \p path that holds presets.
-void collectBanks(cmrc::embedded_filesystem const &filesystem, std::string const &path,
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Depth-first, appending every directory below \p path that holds
+/// presets **or leads to one**.
+///
+/// \return whether \p path has any preset under it, at any depth.
+///
+/// \note The second half of that is not a nicety. This listed only the
+/// directories that hold a `.swp` themselves, and `Martin Walker`,
+/// `CinningBao` and `Syndicate Synthetique` hold nothing but a sub-folder -- so
+/// the list named `Martin Walker/Gamma Shift` and never `Martin Walker`, and the
+/// browser shows a child only once its parent has been opened. There was no row
+/// to open: three of the fifteen banks, 110 of the 303 presets, were in the
+/// binary and unreachable from the interface.
+///                                           (10.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+bool collectBanks(cmrc::embedded_filesystem const &filesystem, std::string const &path,
                   std::string const &relative, std::vector<std::string> &found)
 {
-    bool holdsPresets{false};
+    bool leadsToPresets{false};
     for (auto const &entry : filesystem.iterate_directory(path))
     {
         if (entry.is_directory())
-            collectBanks(filesystem, path + '/' + entry.filename(),
-                         relative.empty() ? entry.filename() : relative + '/' + entry.filename(),
-                         found);
+            leadsToPresets |= collectBanks(
+                filesystem, path + '/' + entry.filename(),
+                relative.empty() ? entry.filename() : relative + '/' + entry.filename(), found);
         else if (presetName(entry.filename()))
-            holdsPresets = true;
+            leadsToPresets = true;
     }
 
-    if (holdsPresets && !relative.empty())
+    if (leadsToPresets && !relative.empty())
         found.push_back(relative);
+    return leadsToPresets;
 }
 } // anonymous namespace
 

--- a/src/le/spectrumworx/factoryPresets.hpp
+++ b/src/le/spectrumworx/factoryPresets.hpp
@@ -35,13 +35,18 @@ namespace LE::SW::FactoryPresets
 /// The extension the banks are written in, without the dot.
 inline constexpr std::string_view extension{"swp"};
 
-/// \brief Every bank that holds presets, sorted, as a path relative to the
-/// preset root -- `"Echoes"`, and also `"CinningBao/SideChainables"`.
+/// \brief Every bank, sorted, as a path relative to the preset root --
+/// `"Echoes"`, and also `"CinningBao"` and `"CinningBao/SideChainables"`.
 ///
 /// \note Flat rather than a tree, and nested rather than one level. Three of the
-/// fifteen banks have a sub-folder, which the browser shows as a folder, so
-/// neither simplification was available: "the fifteen factory banks" is
-/// eighteen directories.
+/// fifteen banks hold a sub-folder rather than presets, which the browser shows
+/// as a folder, so neither simplification was available: "the fifteen factory
+/// banks" is eighteen directories.
+///
+/// \note **A bank that holds no presets of its own is still a bank**, and those
+/// three hold none. Listing only the directories with a `.swp` in them left the
+/// browser no row to open them by -- see collectBanks(). presets() answers with
+/// an empty list for such a bank; isBank() says yes.
 std::vector<std::string> banks();
 
 /// \brief The preset names in \p bank, sorted, without the extension.

--- a/tests/gui/overlayPanelTests.cpp
+++ b/tests/gui/overlayPanelTests.cpp
@@ -592,8 +592,13 @@ TEST_CASE("Every factory bank draws, and draws something of its own", "[gui][ove
 
     auto const closed(rendered(editor));
 
+    /// \note Eighteen, not fifteen. It read `>= 15` while banks() was answering
+    /// with exactly the fifteen directories that hold a `.swp` -- so the sweep
+    /// passed over a listing three banks short of what the plugin ships, which is
+    /// the shape of failure this case was written to catch.
+    ///                                       (10.08.2026.) (SW port)
     auto const banks(LE::SW::FactoryPresets::banks());
-    REQUIRE(banks.size() >= 15);
+    REQUIRE(banks.size() >= 18);
 
     /// \note Hashed rather than kept: eighteen 563 x 376 ARGB images is 15 MB,
     /// and what is being asked is only whether any two agree.

--- a/tests/presets/presetCorpusTests.cpp
+++ b/tests/presets/presetCorpusTests.cpp
@@ -61,6 +61,7 @@
 #include <fstream>
 #include <iterator>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -103,6 +104,28 @@ std::vector<std::pair<std::string, std::filesystem::path>> corpus()
 
     std::ranges::sort(found, {}, &std::pair<std::string, std::filesystem::path>::first);
     return found;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Every directory under the preset root that has a preset somewhere
+/// below it, sorted, relative to the root -- which is what banks() must answer
+/// with, row for row.
+///
+/// \note Ancestors included, and that is the whole point of it. `Martin Walker`
+/// holds no preset of its own, only `Martin Walker/Gamma Shift`, and a listing
+/// that leaves the parent out leaves the browser no row to open the child by.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+std::vector<std::string> bankDirectories()
+{
+    std::set<std::string> found;
+    for (auto const &[key, path] : corpus())
+        for (auto separator(key.find('/')); separator != std::string::npos;
+             separator = key.find('/', separator + 1))
+            found.insert(key.substr(0, separator));
+    return {found.begin(), found.end()};
 }
 
 /// \note One engine per preset, not one reused across all 303. Loading a preset
@@ -375,6 +398,20 @@ TEST_CASE("The embedded factory banks are the committed files", "[preset-corpus]
         embeddedCount += FactoryPresets::presets(bank).size();
     }
     CHECK(embeddedCount == files.size()); // no bank quietly left out of the glob
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And the directories themselves, set against set. The count above
+    /// cannot see this one: a bank that holds nothing but a sub-folder
+    /// contributes no presets to it, so all three of them could go missing from
+    /// the listing with the total still reading 303 -- which is exactly what
+    /// happened. 110 of these presets were in the binary, byte-for-byte correct,
+    /// and unreachable from the browser, because banks() named
+    /// `Martin Walker/Gamma Shift` and never `Martin Walker`.
+    ///                                       (10.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(FactoryPresets::banks() == bankDirectories());
 
     for (auto const &[key, path] : files)
     {


### PR DESCRIPTION
Martin Walker, CinningBao and Syndicate Synthetique hold no preset of their own, only a sub-folder, and the bank listing named only the directories with a .swp in them -- so it carried "Martin Walker/Gamma Shift" and never "Martin Walker". The browser shows a child once its parent has been opened, and there was no parent row to open: three of the fifteen banks, 110 of the 303 presets, were in the binary and unreachable from the interface.

A directory that leads to presets is a bank too. The browser needed no change; it was being handed a short list.

The corpus test could not see this -- it summed the presets per bank against 303, and a bank that holds none contributes nothing to that sum -- so it now compares the listing against the directories on disk, ancestors included, and the GUI bank sweep asks for the eighteen its own comment always claimed rather than fifteen.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>