### PR TITLE
Drive the LFO clock at meters other than four four

### DIFF
--- a/doc/tech/how-lfo-rates-work.md
+++ b/doc/tech/how-lfo-rates-work.md
@@ -114,8 +114,32 @@ The *meter* is a different matter and is not fixed, because it is not broken: a
 synced period snaps to the divisions the meter has, so the same preset genuinely
 loads to a different period in three four. `snapSyncedPeriodScale()` reads
 `Timer::measureNumerator()` and that is still a process-global static, which
-makes it a hazard for a test binary in the way the tempo used to be. Nothing
-drives a meter other than 4/4 outside `lfoTests.cpp`'s scope guard.
+makes it a hazard for a test binary in the way the tempo used to be. Every case
+that drives another meter therefore puts 4/4 back on the way out — the
+`ScopedHostTiming` guard in `lfoTests.cpp`, and a block with no transport at all
+in the two CLAP cases.
+
+The meters those cases drive are 3/4, 6/8 and 5/4, which is issue #14. What each
+of them can hold falls out of "a whole number of beats that divides the bar":
+
+| meter | synced periods, in bars |
+|---|---|
+| 4/4 | ¼, ½, 1 |
+| 3/4 | ⅓, 1 |
+| 6/8 | ⅙, ⅓, ½, 1 |
+| 5/4 | ⅕, 1 |
+
+Five is prime, so 5/4 has a beat and a bar and nothing between them. And a bar of
+3/4 and a bar of 6/8 are both six eighth notes, but only one of them can hold a
+half-bar period — which is the shortest statement of why the numerator is not a
+detail.
+
+**The denominator reaches nothing.** `updateLFOTiming()` builds the bar out of
+`tsig_num` beats of `60 / tempo` seconds, and CLAP's tempo is quarter notes per
+minute, so a 6/8 bar is three seconds at 120 BPM where a musician counting it
+would say a second and a half. The *ratios* a 6/8 LFO snaps to are right; the bar
+they are ratios of is twice as long as the written one. Nothing depends on
+changing it and nothing has asked, so it is written down rather than fixed.
 
 Two more things the format does that are easy to trip over:
 
@@ -188,6 +212,16 @@ tempo. Issue #11 has it. The parameter layer no longer reads them for
 anything but the snap grid, which is what made the corpus digests order-dependent
 and is the half that mattered most.
 
+**A meter change resnaps one of the two Programs.**
+`Processor::updateModuleLFOs()` walks the modules the audio thread owns;
+`programMain_` — what `paramsValue` and `stateSave` answer from, and what the LFO
+panel draws — is not among them and nothing else resnaps it. So after a meter
+change the engine runs a period the host cannot read and the host reads a period
+the meter cannot hold: a session saved then stores the old number, and loading it
+back is what finally reconciles them. Measured by `A host that opens in five four
+does not move the period it was given` (`tests/clap/pluginTests.cpp`), which pins
+it as behaviour rather than endorsing it.
+
 ## 8. Reading order
 
 1. `le/parameters/lfo.hpp` — the enums, and the SDK-facing interface
@@ -195,4 +229,7 @@ and is the half that mattered most.
 3. `le/parameters/lfoImpl.cpp` — `getValue()`, `snapSyncedPeriodScale()`, and the
    two preset conversions
 4. `tests/parameters/lfoTests.cpp` — the waveform table, the snapping, the clock
-5. `tests/gui/lfoDisplayTests.cpp` — that an edit in the panel reaches the engine
+   and the four meters
+5. `tests/clap/pluginTests.cpp`, `[clap][lfo]` — the same clock with the meter
+   arriving as a `clap_event_transport`
+6. `tests/gui/lfoDisplayTests.cpp` — that an edit in the panel reaches the engine

--- a/src/le/parameters/lfoImpl.cpp
+++ b/src/le/parameters/lfoImpl.cpp
@@ -731,9 +731,13 @@ LFOImpl::Timer::Timer() { reset(); }
 /// \note Reported for the measure numerator as well as the bar duration, not just
 /// the arm that was failing: the same sentence is true of both -- there was
 /// nothing to change *from* -- and the synced arm resnaps the period on a
-/// numerator change for the same reason the free arm rescales it. Nothing in the
-/// suite drives a meter other than 4/4, so that half is reasoned rather than
-/// measured; see issue #14.
+/// numerator change for the same reason the free arm rescales it. That half was
+/// reasoned rather than measured until 10.08.2026, nothing in the suite having
+/// driven a meter other than 4/4; `A host that opens in five four is stating its
+/// meter rather than changing it` (`tests/parameters/lfoTests.cpp`) and its twin
+/// through the plugin in `tests/clap/pluginTests.cpp` are what measure it. Both
+/// go red on a revert of this line, dragging a quarter-of-a-bar period onto the
+/// new meter's grid on the first block.
 ///                                           (03.08.2026.) (SW port)
 ///
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/clap/pluginTests.cpp
+++ b/tests/clap/pluginTests.cpp
@@ -125,6 +125,27 @@ float liveModuleParameter(clap_plugin const &plugin, std::uint8_t const moduleIn
     return pModule->getBaseParameter(parameterIndex);
 }
 
+/// \brief The period, in bars, that the *engine's* LFO \p lfoIndex on module
+/// \p moduleIndex is running at.
+///
+/// \note The engine's copy rather than `clap_plugin_params::get_value`, which
+/// answers from the main thread's Program. A meter change resnaps the LFOs the
+/// audio thread owns -- `Processor::updateModuleLFOs()`, once per block -- and
+/// reaches nothing else, so asking the host-facing side whether a resnap happened
+/// is asking the copy it did not happen to. \see liveModuleParameter, which
+/// reaches the same object for the same reason.
+float engineLFOPeriodScale(clap_plugin const &plugin, std::uint8_t const moduleIndex,
+                           std::uint8_t const lfoIndex)
+{
+    auto *const pHelper(static_cast<LE::SW::PluginHelper *>(plugin.plugin_data));
+    REQUIRE(pHelper != nullptr);
+    auto &implementation(*static_cast<LE::SW::SpectrumWorxCLAP *>(pHelper));
+    auto const pModule(
+        implementation.program().moduleChain().moduleAs<LE::SW::Module>(moduleIndex));
+    REQUIRE(pModule);
+    return pModule->lfo(lfoIndex).periodScale();
+}
+
 /// \brief A module parameter's static description, for a value inside its range.
 LE::Parameters::RuntimeInformation const &moduleParameterInfo(clap_plugin const &plugin,
                                                               std::uint8_t const moduleIndex,
@@ -1296,6 +1317,208 @@ TEST_CASE("A playing transport drives the LFO from song position", "[clap][lfo]"
 
     CHECK(midBar != barZero);
     CHECK(barOne == barZero);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Meters other than four four
+// ---------------------------
+//
+//   Issue #14: `SWTest::transportAt()` hardcoded `tsig_num = 4`, so every case
+// that drove a transport at all drove the one meter in which a beat is a quarter
+// of a bar. Two things go unmeasured that way -- the bar the clock counts, and
+// the grid a synced period snaps to -- and the second of them is a *stored,
+// host-visible parameter* that `updateForNewTimingInformation()` will move.
+//
+//   `tests/parameters/lfoTests.cpp` has the unit half, over four meters and both
+// directions of the change. These two are the same claims through the plugin,
+// where the meter arrives as a `clap_event_transport` rather than as an argument.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The LFO clock follows the host into three four, six eight and five four", "[clap][lfo]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **The denominator reaches nothing.** `updateLFOTiming()` builds the
+    /// bar out of `tsig_num` beats of `60 / tempo` seconds each, and CLAP's tempo
+    /// is quarter notes per minute -- so six eight arrives as six beats to the
+    /// bar and its bar is three seconds at 120 BPM, where a musician counting it
+    /// would say a second and a half. The numbers below are what the engine does
+    /// today rather than an endorsement of it; three four and five four, whose
+    /// beat *is* a quarter note, have no such question about them.
+    ///
+    ///   It matters less than it looks: what the meter decides is the LFO grid,
+    /// and six divisions of a bar is what a bar of six eight has however long the
+    /// bar is. A host in six eight gets the right *ratios* and a bar of twice the
+    /// length.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    constexpr float sampleRate{48000};
+    constexpr std::uint32_t blockSize{512};
+    constexpr double tempo{120};
+
+    Entry const entry;
+
+    struct Meter
+    {
+        std::uint16_t beatsPerBar;
+        std::uint16_t beatUnit;
+    };
+
+    for (auto const meter : {Meter{3, 4}, Meter{6, 8}, Meter{5, 4}})
+    {
+        auto const beatsPerBar(meter.beatsPerBar);
+        CAPTURE(beatsPerBar, meter.beatUnit);
+
+        ActivePlugin plugin(sampleRate, blockSize);
+        auto const &params(parameters(*plugin));
+
+        OneParameterEvent const fillSlotOne(parameterID(moduleChainType, 0), 0);
+        params.flush(&*plugin, &*fillSlotOne, &discardedOutputEvents());
+        plugin.pumpMainThread();
+
+        OneParameterEvent const enable(lfoParameterID(0, 0, lfoEnabled), 1);
+        params.flush(&*plugin, &*enable, &discardedOutputEvents());
+        plugin.pumpMainThread();
+
+        std::vector<float> leftIn(blockSize, 0.0f), rightIn(blockSize, 0.0f);
+        std::vector<float> leftOut(blockSize), rightOut(blockSize);
+
+        /// \brief What the LFO reads with the song parked at \p beats, in this
+        /// meter. \see the four four case above, which this is the shape of.
+        auto const valueAtBeat([&](double const beats) {
+            auto const playing(transportAt(tempo, beats, CLAP_TRANSPORT_IS_PLAYING,
+                                           meter.beatsPerBar, meter.beatUnit));
+            plugin.process(leftIn, rightIn, leftOut, rightOut, &playing);
+            return liveModuleParameter(*plugin, 0, 1 /*Gain*/);
+        });
+
+        // A default LFO is a one-bar sine, and a bar is as many beats as the
+        // host says -- three, six, five -- rather than always four.
+        auto const barLine(valueAtBeat(0));
+        auto const midBar(valueAtBeat(beatsPerBar / 2.0));
+        auto const nextBarLine(valueAtBeat(beatsPerBar));
+
+        CHECK(midBar != barLine);
+        CHECK(nextBarLine == barLine);
+
+        // ...and the clock the rest of the engine reads says the same thing.
+        using Timer = LE::Parameters::LFOImpl::Timer;
+        CHECK(Timer::measureNumerator() == beatsPerBar);
+        CHECK_THAT(Timer::basePeriod(), Catch::Matchers::WithinAbs(beatsPerBar * 60 / tempo, 1e-6));
+
+        /// \note And back to the assumed 120 BPM 4/4 before the next meter, which
+        /// is what a block with no transport at all *is*. `Timer`'s tempo and
+        /// meter are process-wide statics -- issue #11 -- so a case that left five
+        /// four behind would change what every later case in the binary measures.
+        plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr);
+    }
+
+    CHECK(LE::Parameters::LFOImpl::Timer::measureNumerator() == 4);
+}
+
+TEST_CASE("A host that opens in five four does not move the period it was given", "[clap][lfo]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Issue #14's own paragraph, through the plugin: the meter half of
+    /// `Timer::establishedChange()` was reasoned rather than measured. A session
+    /// that opens in five four is not a host *changing* the meter, so the stored
+    /// period stays where the user left it -- and a genuine change, later in the
+    /// same session, resnaps it.
+    ///
+    /// \note A quarter of a bar is the period to store, because it is on four
+    /// four's grid and on neither of the two below: five four has a beat and a
+    /// bar and nothing between them, six eight has a third. So a resnap that
+    /// should not happen is visible and one that should has somewhere to go.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    constexpr float sampleRate{48000};
+    constexpr std::uint32_t blockSize{512};
+    constexpr double tempo{120};
+    constexpr float quarterOfABar{0.25f};
+
+    Entry const entry;
+    ActivePlugin plugin(sampleRate, blockSize);
+    auto const &params(parameters(*plugin));
+
+    OneParameterEvent const fillSlotOne(parameterID(moduleChainType, 0), 0);
+    params.flush(&*plugin, &*fillSlotOne, &discardedOutputEvents());
+    plugin.pumpMainThread();
+
+    /// \note The editor's route, which is how a user sets a period: applied to the
+    /// main thread's Program and queued for the engine, the flush below being what
+    /// lands it there. Written *before any block has run*, so the plugin has never
+    /// seen a transport and the snapping this write does is against the engine's
+    /// assumed four four -- which the REQUIRE is the check of, not an aside.
+    editorHostOf(*plugin).editParameter(
+        LE::SW::ParameterID{LE::Plugins::ParameterID{lfoParameterID(0, 0, lfoPeriodScale)}},
+        quarterOfABar);
+    params.flush(&*plugin, &noInputEvents(), &discardedOutputEvents());
+    plugin.pumpMainThread();
+    REQUIRE_THAT(engineLFOPeriodScale(*plugin, 0, 0),
+                 Catch::Matchers::WithinAbs(quarterOfABar, 1e-6));
+
+    double hostVisibleBefore{-1};
+    REQUIRE(params.get_value(&*plugin, lfoParameterID(0, 0, lfoPeriodScale), &hostVisibleBefore));
+
+    std::vector<float> leftIn(blockSize, 0.0f), rightIn(blockSize, 0.0f);
+    std::vector<float> leftOut(blockSize), rightOut(blockSize);
+
+    // The first block this plugin ever processes, and the host is in five four.
+    auto const inFiveFour(transportAt(tempo, 0, CLAP_TRANSPORT_IS_PLAYING, 5, 4));
+    plugin.process(leftIn, rightIn, leftOut, rightOut, &inFiveFour);
+
+    REQUIRE(LE::Parameters::LFOImpl::Timer::measureNumerator() == 5);
+    CHECK_THAT(engineLFOPeriodScale(*plugin, 0, 0),
+               Catch::Matchers::WithinAbs(quarterOfABar, 1e-6));
+
+    // ...and more of the same meter is still not a change.
+    for (unsigned block(0); block < 4; ++block)
+    {
+        auto const later(transportAt(tempo, block + 1.0, CLAP_TRANSPORT_IS_PLAYING, 5, 4));
+        plugin.process(leftIn, rightIn, leftOut, rightOut, &later);
+    }
+    CHECK_THAT(engineLFOPeriodScale(*plugin, 0, 0),
+               Catch::Matchers::WithinAbs(quarterOfABar, 1e-6));
+
+    // A meter change in the middle of the session is one, and six eight has a
+    // third of a bar for a quarter of one to land on.
+    auto const inSixEight(transportAt(tempo, 5, CLAP_TRANSPORT_IS_PLAYING, 6, 8));
+    plugin.process(leftIn, rightIn, leftOut, rightOut, &inSixEight);
+
+    REQUIRE(LE::Parameters::LFOImpl::Timer::measureNumerator() == 6);
+    CAPTURE(engineLFOPeriodScale(*plugin, 0, 0));
+    CHECK_THAT(engineLFOPeriodScale(*plugin, 0, 0), Catch::Matchers::WithinAbs(1.0 / 3, 1e-4));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **And what the host reads is still the period before the resnap.**
+    /// `Processor::updateModuleLFOs()` walks the modules the *audio thread* owns;
+    /// `programMain_` -- which is what `paramsValue` and `stateSave` answer from
+    /// -- is not among them, and nothing else resnaps it. So a meter change
+    /// leaves the two copies holding two different periods, and it is the
+    /// engine's that is heard.
+    ///
+    ///   Pinned as what the code does rather than asserted as what it should do.
+    /// It is arguably wrong in both directions -- a session saved after a meter
+    /// change stores a period the meter cannot hold, and the LFO panel draws that
+    /// stored one rather than the one running -- and pinning it is what makes a
+    /// decision about it visible when somebody makes one. \see
+    /// `doc/tech/threading_model.md` on the two copies, and
+    /// `doc/tech/how-lfo-rates-work.md` §4 on what a meter does to a stored
+    /// period.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    double hostVisibleAfter{-1};
+    REQUIRE(params.get_value(&*plugin, lfoParameterID(0, 0, lfoPeriodScale), &hostVisibleAfter));
+    CAPTURE(hostVisibleBefore, hostVisibleAfter);
+    CHECK(hostVisibleAfter == hostVisibleBefore);
+
+    // Back to the assumed 120 BPM 4/4 for whatever runs next; see the case above.
+    plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr);
+    CHECK(LE::Parameters::LFOImpl::Timer::measureNumerator() == 4);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/clap/testHost.hpp
+++ b/tests/clap/testHost.hpp
@@ -937,13 +937,30 @@ inline clap_param_info lfoPeriodParameter(clap_plugin const &plugin,
     return {};
 }
 
-/// \brief A host's transport, at \p tempo in 4/4, parked at \p positionInBeats.
+/// \brief A host's transport, at \p tempo in \p beatsPerBar / \p beatUnit,
+/// parked at \p positionInBeats.
 ///
 /// \note Shared rather than per file since 03.08.2026: `pluginTests.cpp` had it,
 /// and the LFO cases need one too -- and need it at a tempo that is *not* the
 /// engine's assumed 120, which is where the periods stop being rescaled.
+///
+/// \note The meter is a parameter rather than a hardcoded 4/4 since 10.08.2026,
+/// which is issue #14: `tsig_num` is what reaches the engine as the measure
+/// numerator, and every division a synced LFO period can land on is a divisor of
+/// it -- so an arm of `updateForNewTimingInformation()` and the meter half of
+/// `Timer::establishedChange()` had nothing in the suite driving them. The
+/// default is still 4/4, so a caller that does not care reads as it always did.
+///
+/// \note `beatUnit` reaches nothing: the engine's bar is `tsig_num` beats of
+/// `60 / tempo` seconds, and CLAP's tempo is in quarter notes per minute
+/// whatever the denominator says. It is set anyway because a transport that
+/// announced `CLAP_TRANSPORT_HAS_TIME_SIGNATURE` with a zero denominator would
+/// be describing no meter at all -- 6/8 has to arrive as 6/8 rather than as 6/4
+/// for the case naming it to be about anything.
 inline clap_event_transport transportAt(double const tempo, double const positionInBeats,
-                                        std::uint32_t const extraFlags)
+                                        std::uint32_t const extraFlags,
+                                        std::uint16_t const beatsPerBar = 4,
+                                        std::uint16_t const beatUnit = 4)
 {
     clap_event_transport transport{};
     transport.header.size = sizeof(transport);
@@ -952,8 +969,8 @@ inline clap_event_transport transportAt(double const tempo, double const positio
     transport.flags = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_TIME_SIGNATURE |
                       CLAP_TRANSPORT_HAS_BEATS_TIMELINE | extraFlags;
     transport.tempo = tempo;
-    transport.tsig_num = 4;
-    transport.tsig_denom = 4;
+    transport.tsig_num = beatsPerBar;
+    transport.tsig_denom = beatUnit;
     transport.song_pos_beats = static_cast<clap_beattime>(positionInBeats * CLAP_BEATTIME_FACTOR);
     return transport;
 }

--- a/tests/parameters/lfoTests.cpp
+++ b/tests/parameters/lfoTests.cpp
@@ -20,8 +20,11 @@
 ///       snap and clamps instead.
 ///     - **`LowerBound > UpperBound`**, which is not an error -- the setter
 ///       drags the other bound with it and says that it did.
-///     - **a meter that is not 4/4**, which nothing in the suite has ever driven
-///       and which issue #14 records as the unmeasured half of a landed fix.
+///     - **the meters that are not 4/4** -- 3/4, 6/8 and 5/4, which nothing in
+///       the suite drove until 10.08.2026 and which issue #14 is about: the
+///       meter decides the grid a synced period snaps to, and the claim that a
+///       host merely *stating* its meter must not resnap anything was reasoned
+///       rather than measured.
 ///
 /// \note The waveform table is a golden in the shape `parameterTableTests.cpp`
 /// established, and for the same reason: eleven small functions whose output is
@@ -244,6 +247,57 @@ bool updateRequested()
 {
     auto const *const requested(std::getenv("SW_LFO_TABLE_UPDATE"));
     return requested && (*requested != '\0') && (*requested != '0');
+}
+
+//------------------------------------------------------------------------------
+// Meters
+//------------------------------------------------------------------------------
+
+/// \brief A bar of \p beatsPerBar beats at the reference 120 BPM, where a beat
+/// is half a second whatever the meter says.
+///
+/// \note Which is also what the plugin computes from a CLAP transport --
+/// `tsig_num` beats of `60 / tempo` -- and it is the whole of what the meter is
+/// to the engine. The *denominator* reaches nothing, so a bar of six eight is six
+/// beats here rather than the three quarter notes a musician counts. See the
+/// note on `The LFO clock follows the host into three four, six eight and five
+/// four` in `tests/clap/pluginTests.cpp`, which is where that arrives.
+constexpr float barOf(std::uint8_t const beatsPerBar)
+{
+    return 0.5f * static_cast<float>(beatsPerBar);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Every distinct period a quarter-note-synced LFO can hold in the meter
+/// currently in force, sweeping requests from one beat up to one bar.
+///
+/// \note A sweep rather than a handful of requests with their answers written
+/// next to them: what is being asked is which periods are *reachable*, and an
+/// implementation that answered three chosen requests correctly and everything
+/// else with the request itself would pass the second kind of case.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+std::vector<float> snapGridOfTheCurrentMeter()
+{
+    auto const beatsPerBar(LFOImpl::Timer::measureNumeratorFloat());
+    constexpr unsigned int steps{200};
+
+    std::vector<float> grid;
+    for (unsigned int step(0); step <= steps; ++step)
+    {
+        auto const oneBeat(1 / beatsPerBar);
+        auto const wanted(oneBeat +
+                          (1 - oneBeat) * static_cast<float>(step) / static_cast<float>(steps));
+        auto const snapped(LFOImpl::snapPeriodScale(wanted, LFO::Quarter).first);
+        if (std::ranges::none_of(grid, [snapped](float const already) {
+                return std::abs(already - snapped) < 1e-4f;
+            }))
+            grid.push_back(snapped);
+    }
+    std::ranges::sort(grid);
+    return grid;
 }
 
 //------------------------------------------------------------------------------
@@ -641,11 +695,10 @@ TEST_CASE("The snapped period follows the host's meter", "[lfo]")
 
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note **Nothing in the suite had ever driven a meter other than 4/4**,
-    /// which issue #14 records as the unmeasured half of a landed fix. It
-    /// matters here more than anywhere: `snapSyncedPeriodScale()` divides by
-    /// `measureNumerator()` throughout, so a period scale is bars and the beats
-    /// it can land on are the ones the meter has.
+    /// \note Where the meter first mattered, and the shortest form of it:
+    /// `snapSyncedPeriodScale()` divides by `measureNumerator()` throughout, so a
+    /// period scale is bars and the beats it can land on are the ones the meter
+    /// has. The case below takes the same claim over four meters at once.
     ///
     ///   In 3/4 a bar is three beats, so one beat is a third of a bar and there
     /// is no such thing as the quarter-of-a-bar that 4/4 snaps to.
@@ -674,6 +727,148 @@ TEST_CASE("The snapped period follows the host's meter", "[lfo]")
     /// behind would change what every later case in the binary measures. See
     /// ScopedHostTiming.
     CHECK(LFOImpl::Timer::measureNumerator() == 4);
+}
+
+TEST_CASE("Three four, six eight and five four each snap to a grid of their own", "[lfo]")
+{
+    ScopedHostTiming const timing;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Issue #14 asks for a meter other than 4/4 somewhere in the suite;
+    /// this is the half of it that is about the *grid*. `snapSyncedPeriodScale()`
+    /// asks which whole numbers of beats divide the bar, so the meter decides the
+    /// set of periods a synced LFO can hold at all -- and the case above says
+    /// that of three four while leaving the impression that a meter is a meter.
+    ///
+    ///   The three below say it is not. Five four is the sharp one: five is
+    /// prime, so a bar holds exactly two synced periods -- one beat and the whole
+    /// bar -- and every request between them lands on one or the other. And the
+    /// pair worth having next to each other is three four against six eight: a
+    /// bar of each is six eighth notes, and only one of them can hold a half-bar
+    /// period, which is what makes them two meters rather than one written twice.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto const gridIn([](std::uint8_t const beatsPerBar) {
+        ScopedHostTiming const meter(barOf(beatsPerBar), beatsPerBar);
+        REQUIRE(LFOImpl::Timer::measureNumerator() == beatsPerBar);
+        return snapGridOfTheCurrentMeter();
+    });
+
+    auto const isTheGrid([](std::vector<float> const &grid, std::vector<float> const &expected) {
+        INFO("reachable: " << row(grid) << "  --  expected: " << row(expected));
+        REQUIRE(grid.size() == expected.size());
+        for (std::size_t index(0); index < grid.size(); ++index)
+            CHECK(grid[index] == Catch::Approx(expected[index]).margin(1e-4));
+    });
+
+    constexpr float sixth{1.0f / 6}, fifth{1.0f / 5}, third{1.0f / 3};
+
+    // Four four, which everything else in the suite drives, for comparison.
+    isTheGrid(gridIn(4), {0.25f, 0.5f, 1.0f});
+    // Three: a beat or a bar, and nothing between them.
+    isTheGrid(gridIn(3), {third, 1.0f});
+    // Six: the richest of the four, and the only one with a half bar and a third.
+    isTheGrid(gridIn(6), {sixth, third, 0.5f, 1.0f});
+    // Five: prime, so a beat or a bar. Not an oversight -- there is no whole
+    // number of beats between one and five that divides five.
+    isTheGrid(gridIn(5), {fifth, 1.0f});
+
+    /// \note And the same request read in each meter, which is the statement the
+    /// four grids above are made of but is worth having on one line: asking for
+    /// half a bar gets half a bar in four four and six eight, a third of one in
+    /// three four, and a fifth in five four.
+    auto const halfABarIn([](std::uint8_t const beatsPerBar) {
+        ScopedHostTiming const meter(barOf(beatsPerBar), beatsPerBar);
+        return LFOImpl::snapPeriodScale(0.5f, LFO::Quarter).first;
+    });
+    CHECK(halfABarIn(4) == Catch::Approx(0.5f));
+    CHECK(halfABarIn(6) == Catch::Approx(0.5f));
+    CHECK(halfABarIn(3) == Catch::Approx(third).margin(1e-4));
+    CHECK(halfABarIn(5) == Catch::Approx(fifth).margin(1e-4));
+
+    // Every guard above went out of scope with the statement that made it.
+    CHECK(LFOImpl::Timer::measureNumerator() == 4);
+}
+
+TEST_CASE("A host that opens in five four is stating its meter rather than changing it", "[lfo]")
+{
+    ScopedHostTiming const timing;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The other half of issue #14, and the one it was filed about.
+    /// `establishedChange()` reports no meter change on the first update after a
+    /// reset, on the argument that there was nothing to change *from* -- the same
+    /// argument the bar duration makes, and reasoned rather than measured because
+    /// nothing in the suite drove a meter other than 4/4.
+    ///
+    ///   What it protects is what the tempo half protects. A synced period is
+    /// resnapped when the numerator changes, so treating "the host has finally
+    /// said five four" as a change would move a stored, host-visible parameter on
+    /// the first block of every session that is not in four four -- which is the
+    /// exact shape of the four `clap-cpp-validator` state failures the tempo half
+    /// fixed, one meter over.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    LFOImpl::Timer timer;
+    timer.reset();
+
+    LFOImpl synced;
+    synced.parameters().get<LFOImpl::SyncTypes>().setValue(LFO::Quarter);
+    /// A quarter of a bar: on four four's grid, and on neither of the two meters
+    /// below. So a resnap that should not happen is visible, and one that should
+    /// has somewhere to go.
+    synced.setPeriodScale(0.25f);
+
+    /// \note And a free one alongside it, at the same period, told the same three
+    /// things: its period is a duration and the host's meter is none of its
+    /// business, in either direction. The case below says that of a meter
+    /// *change*; nothing said it of the update that establishes one.
+    LFOImpl free;
+    free.parameters().get<LFOImpl::SyncTypes>().setValue(LFO::Free);
+    free.setPeriodScale(0.25f);
+
+    // The first thing this host ever says, and it is in five four.
+    auto const established(timer.updatePositionAndTimingInformation(0, barOf(5), 5));
+    CHECK_FALSE(established.measureNumeratorChanged());
+    CHECK_FALSE(established.timingInfoChanged());
+
+    synced.updateForNewTimingInformation(established);
+    free.updateForNewTimingInformation(established);
+    CHECK(synced.periodScale() == Catch::Approx(0.25f));
+    CHECK(free.periodScale() == Catch::Approx(0.25f));
+
+    // The same meter again is not a change either.
+    auto const again(timer.updatePositionAndTimingInformation(1, barOf(5), 5));
+    CHECK_FALSE(again.timingInfoChanged());
+    synced.updateForNewTimingInformation(again);
+    free.updateForNewTimingInformation(again);
+    CHECK(synced.periodScale() == Catch::Approx(0.25f));
+    CHECK(free.periodScale() == Catch::Approx(0.25f));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And the other direction, on the numerator *alone*: six eight over a
+    /// bar of the same 2.5 seconds is 144 BPM, so the bar duration does not move
+    /// and only the grid does. Written that way deliberately -- a meter change
+    /// that also changed the tempo would leave `barDurationChanged()` true, and
+    /// `updateForNewTimingInformation()` would then be resnapping for a reason
+    /// this case could not tell apart from the one it is about.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    auto const meterOnly(timer.updatePositionAndTimingInformation(2, barOf(5), 6));
+    CHECK_FALSE(meterOnly.barDurationChanged());
+    CHECK(meterOnly.measureNumeratorChanged());
+    CHECK(meterOnly.timingInfoChanged());
+
+    synced.updateForNewTimingInformation(meterOnly);
+    free.updateForNewTimingInformation(meterOnly);
+    CAPTURE(synced.periodScale(), free.periodScale());
+    CHECK(synced.periodScale() == Catch::Approx(1.0f / 3).margin(1e-4));
+    CHECK(free.periodScale() == Catch::Approx(0.25f));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The transport helper hardcoded a four four time signature, so nothing in the suite ever asked what a bar is worth anywhere else -- neither the bar the clock counts nor the grid a synced LFO period snaps to. The claim that a host merely stating its meter must not resnap a stored period was reasoned rather than measured; a revert of it now turns two cases red at both levels.

Adds three four, six eight and five four as unit cases over the snap grid and the establishing update, and as CLAP cases where the meter arrives on a transport. Two things the measurement turned up are written down rather than changed: the time signature denominator reaches nothing, so a six eight bar is twice as long as the written one, and a meter change resnaps the engine's Program and not the copy the host reads.

Closes #14.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>