### PR TITLE
Move the preset and settings panel to the left, and let strips be dragged onto each other

### DIFF
--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -77,7 +77,7 @@ SharedModuleControls::SharedModuleControls()
     addToParentAndShow(*this, frequencyRange_);
 
     setBounds(77, 80, 116, 79);
-    addToParentAndShow(editor(), *this);
+    addToParentAndShow(editor().mainArea(), *this);
 
     updateForEngineSetupChanges(editor().engineSetup());
 }

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -104,7 +104,7 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
 
       in_(*this, 18, 37), out_(*this, 18, 110), mix_(*this, 18, 185),
 
-      moduleMenuButton_(*this), gradient_(*this),
+      moduleMenuButton_(*this), dropIndicator_(mainArea_),
 
       /// \todo Reimplement these Alex's widgets.
       ///                                       (22.09.2009.) (Domagoj Saric)
@@ -112,8 +112,8 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
       //cSpectrumDisplay( CRect( 0, 0, 235, 129 ).offset( 222, 17 ), this, SpectrumDisplay, 0, capture ),
 
       // buttons...
-      preset_(*this, resourceArtwork<PresetOn>(), resourceArtwork<PresetOff>()),
-      settingsButton_(*this, resourceArtwork<SettingsOn>(), resourceArtwork<SettingsOff>())
+      preset_(mainArea_, resourceArtwork<PresetOn>(), resourceArtwork<PresetOff>()),
+      settingsButton_(mainArea_, resourceArtwork<SettingsOn>(), resourceArtwork<SettingsOff>())
 {
     using LE::Parameters::IndexOf;
     using namespace GlobalParameters;
@@ -147,14 +147,11 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
     // http://www.kvraudio.com/forum/viewtopic.php?t=141313
     // http://lists.steinberg.net:8100/Lists/vst-plugins/Message/17785.html
     // http://www.u-he.com/vstsource
-    setSizeFromImage(*this, resourceArtwork<EditorBackground>());
-    LE_ASSERT_MSG(getWidth() == estimatedWidth && getHeight() == artworkHeight,
+    LE_ASSERT_MSG(mainArea_.getWidth() == estimatedWidth && mainArea_.getHeight() == artworkHeight,
                   "the skin and the editor's constants disagree");
-    // ...and the strip under the skin that says when this binary was built.
-    setSize(getWidth(), getHeight() + buildStampHeight);
+    // The skin, and the strip under it that says when this binary was built.
+    setSize(mainArea_.getWidth(), mainArea_.getHeight() + buildStampHeight);
 
-    gradient_.setInvisible();
-    gradient_.setSize(ModuleUI::width, ModuleUI::height);
     moduleMenuButton_.moveToSlot(0);
 
     sampleArea_.setBounds(75, 307, 115, 20);
@@ -408,6 +405,11 @@ void SpectrumWorxEditor::layOutPanels()
                           ((panelPlacement_ == PanelPlacement::expandContract) && pPanel));
 
     auto const ownColumn(setPanelColumnVisible(wantColumn));
+
+    /// \note The skin moves and the panel does not follow it: the column is at
+    /// the left edge either way, and an overlay is a position *in* the skin --
+    /// which is the editor's own coordinates only while there is no column.
+    mainArea_.setTopLeftPosition(ownColumn ? mainAreaX : 0, 0);
     if (pPanel)
         pPanel->setTopLeftPosition(ownColumn ? panelColumnX : overlayX, overlayY);
 }
@@ -555,72 +557,201 @@ void SpectrumWorxEditor::parentHierarchyChanged()
         grabKeyboardFocus();
 }
 
-void SpectrumWorxEditor::moduleDrag(ModuleUI &moduleUI, juce::MouseEvent const &event)
+////////////////////////////////////////////////////////////////////////////////
+//
+// Reordering the rack
+// -------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   A strip can be dropped in two ways and they do different things. On another
+/// strip it changes places with it, and nothing else moves; between two of them,
+/// or at either end, it is inserted there and everything from there on shifts
+/// along. Which of the two a given point means is moduleDropAt()'s answer, drawn
+/// by DropIndicator and carried out by applyModuleDrop() -- one function each, so
+/// that what the user is shown while dragging and what happens when they let go
+/// cannot disagree.
+///
+/// \note The middle half of a strip is a swap and its outer quarters are inserts,
+/// which is what makes both reachable without aiming: an insert is a gap, and a
+/// gap with no width to it is a target nobody can hit. The zone also runs half a
+/// strip past each end of the rack, so dropping at the front or the back does not
+/// need the strip to be over the rack at all.
+///
+/// \note And the point all of that is measured at is the **dragged strip's own
+/// middle**, not the pointer. \see draggedStripCentre().
+///                                           (14.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
 {
-    if (isDragAndDropActive())
-    {
-        unsigned int const halfModuleWidth(ModuleUI::width / 2);
+constexpr int slotWidth{ModuleUI::width + ModuleUI::distance};
 
-        juce::Rectangle<int> const &sourceRect(moduleUI.getBounds());
+/// How far outside the rack a drop still counts: far enough to reach the gaps at
+/// either end, not so far that a drag let go across the editor lands one.
+constexpr int dropMargin{ModuleUI::width / 2};
 
-        juce::Rectangle<int> const leftRect(ModuleUI::horizontalOffset, ModuleUI::verticalOffset,
-                                            sourceRect.getX() -
-                                                (halfModuleWidth + ModuleUI::distance) - 1 -
-                                                ModuleUI::horizontalOffset,
-                                            ModuleUI::height);
+/// How much of each end of a strip means "between this one and its neighbour".
+constexpr int insertZone{slotWidth / 4};
+} // anonymous namespace
 
-        unsigned int const emptyModuleSpaceBegin(moduleMenuButton_.getX() - 4);
-        unsigned int const rightRectStart(sourceRect.getRight() + ModuleUI::distance +
-                                          halfModuleWidth + 1);
-        unsigned int const rightRectEnd(emptyModuleSpaceBegin + halfModuleWidth);
-        juce::Rectangle<int> const rightRect(rightRectStart, ModuleUI::verticalOffset,
-                                             rightRectEnd - rightRectStart, ModuleUI::height);
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::draggedStripCentre()
+// ----------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   A drag is aimed with the strip, not with the pointer. Somebody who picked a
+/// strip up by its left edge is carrying the whole thing, and what they are
+/// lining up against the rack is the middle of what they can see -- which is the
+/// column the eject `X` is drawn in, that marker being centred on the strip. It
+/// is also where JUCE's drag image is: `startDragging()` snapshots the strip and
+/// offsets the ghost by the grab, so the ghost sits where the strip would be.
+///
+///   Deciding the drop from the pointer instead put the answer out by however far
+/// from the middle it was picked up -- up to half a strip, which is exactly the
+/// width of a swap zone. Carrying a strip until it covered another one and being
+/// told "insert to the left of it" is what that looked like, and which way it was
+/// wrong depended on which edge had been grabbed.
+///                                           (14.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
 
-        juce::Point<int> const mousePosition(
-            this->getLocalPoint(nullptr, event.getScreenPosition()));
+juce::Point<int> SpectrumWorxEditor::draggedStripCentre(juce::Point<int> const pointer,
+                                                        juce::Point<int> const grabbedAt)
+{
+    /// \note The strip itself has not moved -- it stays in its slot for the whole
+    /// drag -- so this is where it *would* be: the pointer, less where in the
+    /// strip it was picked up, plus half a strip.
+    return pointer - grabbedAt + juce::Point<int>(ModuleUI::width / 2, ModuleUI::height / 2);
+}
 
-        bool const showGradient(leftRect.contains(mousePosition) ||
-                                rightRect.contains(mousePosition));
+/// \brief The above, with the two coordinate conversions a mouse event needs.
+///
+/// \note `grabbedAt` is put through the strip rather than taken off the event,
+/// because `MouseEvent::getMouseDownPosition()` is relative to whichever
+/// component the event was delivered to.
+juce::Point<int> SpectrumWorxEditor::draggedStripCentre(ModuleUI const &moduleUI,
+                                                        juce::MouseEvent const &event) const
+{
+    return draggedStripCentre(
+        mainArea_.getLocalPoint(nullptr, event.getScreenPosition()),
+        moduleUI.getLocalPoint(event.eventComponent, event.getMouseDownPosition()));
+}
 
-        if (showGradient)
-        {
-            unsigned int const firstGradientOffset(ModuleUI::horizontalOffset -
-                                                   (halfModuleWidth + (ModuleUI::distance / 2)));
+SpectrumWorxEditor::ModuleDrop
+SpectrumWorxEditor::moduleDropAt(std::uint8_t const sourceSlot,
+                                 juce::Point<int> const position) const
+{
+    ModuleDrop drop;
 
-            unsigned int const gradientIndex((mousePosition.getX() - firstGradientOffset) /
-                                             (ModuleUI::width + ModuleUI::distance));
-            LE_ASSERT(gradient_.getHeight() == ModuleUI::height);
-            LE_ASSERT(gradient_.getWidth() == ModuleUI::width);
+    auto const strips(nextAvailableModuleSlot_);
+    if ((strips < 2) || (sourceSlot >= strips))
+        return drop; // Nothing to reorder, or a strip that is on its way out.
 
-            unsigned int const gradientOffset(
-                firstGradientOffset + (gradientIndex * (ModuleUI::width + ModuleUI::distance)));
-            gradient_.setTopLeftPosition(gradientOffset, ModuleUI::verticalOffset);
-            LE_ASSERT(!gradient_.getBounds().intersects(sourceRect));
-        }
-        gradient_.setIsVisible(showGradient);
-    }
+    juce::Rectangle<int> const rack(ModuleUI::horizontalOffset, ModuleUI::verticalOffset,
+                                    strips * slotWidth, ModuleUI::height);
+    if (!rack.expanded(dropMargin).getIntersection(mainArea_.getLocalBounds()).contains(position))
+        return drop;
+
+    auto const alongTheRack(position.getX() - ModuleUI::horizontalOffset);
+
+    /// \note The two margins first: past either end of the rack there is no strip
+    /// to be over, so the only thing a drop there can mean is the gap it is past.
+    if (alongTheRack < 0)
+        drop = {ModuleDrop::insert, 0};
+    else if (alongTheRack >= (strips * slotWidth))
+        drop = {ModuleDrop::insert, strips};
     else
     {
-        gradient_.toFront(true);
-        gradient_.setAlwaysOnTop(true);
+        auto const slot(static_cast<std::uint8_t>(alongTheRack / slotWidth));
+        auto const acrossTheStrip(alongTheRack % slotWidth);
 
+        if (acrossTheStrip < insertZone)
+            drop = {ModuleDrop::insert, slot};
+        else if (acrossTheStrip >= (slotWidth - insertZone))
+            drop = {ModuleDrop::insert, static_cast<std::uint8_t>(slot + 1)};
+        else
+            drop = {ModuleDrop::swap, slot};
+    }
+
+    /// \note And the drops that would change nothing, which are three: swapping a
+    /// strip with itself, and the two gaps either side of it -- it is already in
+    /// both. Answering "nothing" for those is what stops the indicator offering a
+    /// move the user would not see happen.
+    bool const pointless(
+        (drop.action == ModuleDrop::swap)
+            ? (drop.slot == sourceSlot)
+            : ((drop.slot == sourceSlot) || (drop.slot == std::uint8_t(sourceSlot + 1))));
+    if (pointless)
+        return {};
+
+    return drop;
+}
+
+void SpectrumWorxEditor::moduleDrag(ModuleUI &moduleUI, juce::MouseEvent const &event)
+{
+    if (!isDragAndDropActive())
+    {
         startDragging(juce::var(), &moduleUI);
+        return;
+    }
+
+    showModuleDrop(moduleDropAt(moduleUI.slot(), draggedStripCentre(moduleUI, event)));
+}
+
+void SpectrumWorxEditor::showModuleDrop(ModuleDrop const drop)
+{
+    switch (drop.action)
+    {
+    case ModuleDrop::swap:
+        dropIndicator_.showSwap(drop.slot);
+        break;
+    case ModuleDrop::insert:
+        dropIndicator_.showInsert(drop.slot);
+        break;
+    case ModuleDrop::nothing:
+        dropIndicator_.hide();
+        break;
     }
 }
 
 void SpectrumWorxEditor::moduleDragEnd(ModuleUI &moduleUI, juce::MouseEvent const &event)
 {
-    juce::Point<int> const mousePosition(this->getLocalPoint(nullptr, event.getScreenPosition()));
+    /// \note Asked again rather than remembered from the last moduleDrag(): the
+    /// two answers are the same function of the same point, and a click that never
+    /// became a drag has no last answer to remember. Such a click leaves the strip
+    /// exactly where it was, which moduleDropAt() calls "nothing".
+    auto const drop(moduleDropAt(moduleUI.slot(), draggedStripCentre(moduleUI, event)));
 
-    bool const dragAborted(!gradient_.isVisible() ||
-                           !gradient_.getBounds().contains(mousePosition));
-    gradient_.setInvisible();
-    /// \note moduleDrag() raises this to always-on-top and nothing lowered it,
-    /// so a panel opened after any drag painted underneath it. Only matters now
-    /// the panels are children rather than desktop windows.
-    ///                                       (01.08.2026.) (SW port)
-    gradient_.setAlwaysOnTop(false);
-    if (dragAborted)
+    dropIndicator_.hide();
+
+    applyModuleDrop(moduleUI.slot(), drop);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::applyModuleDrop()
+// -------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The rack is told first and the engine second, which is the order every
+/// edit takes now: the strips move here so the drag ends where the user let go,
+/// and resyncModuleRack() puts them where the chain says once the engine has
+/// caught up. They agree either way -- this is the same permutation, applied to
+/// the same two orderings. The host is told last, because what it is told is read
+/// back out of the rack.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::applyModuleDrop(std::uint8_t const sourceSlot, ModuleDrop const drop)
+{
+    LE_ASSERT(isThisTheGUIThread());
+
+    if (drop.action == ModuleDrop::nothing)
         return;
 
     /// \note We have to block automation here because of FMOD's MVC
@@ -634,49 +765,83 @@ void SpectrumWorxEditor::moduleDragEnd(ModuleUI &moduleUI, juce::MouseEvent cons
     Host2PluginInteropControler::AutomationBlocker const automationBlocker(
         /*host*/ moduleChainOwner /*mrmlj*/ ());
 
-    LE_ASSERT(!gradient_.getBounds().intersects(moduleUI.getBounds()));
-    unsigned int const slotWidth(ModuleUI::width + ModuleUI::distance);
-    unsigned int const sourceX(moduleUI.getX());
-    unsigned int targetX(gradient_.getX());
-    bool const moveLeft(static_cast<unsigned int>(gradient_.getRight()) < sourceX);
-    int const gradientToTargetOffset((ModuleUI::width + ModuleUI::distance) / 2);
-    targetX -= moveLeft ? -gradientToTargetOffset : +gradientToTargetOffset;
-    LE_ASSERT((signed(targetX - sourceX) % signed(slotWidth)) == 0);
+    if (drop.action == ModuleDrop::swap)
+        swapModuleSlots(sourceSlot, drop.slot);
+    else
+    {
+        /// \note A gap index is one more than the slot to its left, and taking the
+        /// source strip out closes every gap after it -- so a gap beyond the
+        /// source names a slot one lower once the strip has left.
+        moveModuleSlot(sourceSlot, static_cast<std::uint8_t>(
+                                       (drop.slot > sourceSlot) ? (drop.slot - 1) : drop.slot));
+    }
 
-    std::uint8_t const sourceIndex((sourceX - ModuleUI::horizontalOffset) / slotWidth);
-    std::uint8_t const targetIndex((targetX - ModuleUI::horizontalOffset) / slotWidth);
-    if (sourceIndex == targetIndex)
-        return;
+    refreshModuleRackAsync();
+}
 
-    /// \note The rack is told first and the engine second, which is the order
-    /// every edit takes now: the strips move here so the drag ends where the
-    /// user let go, and resyncModuleRack() puts them where the chain says once
-    /// the engine has caught up. They agree either way -- this is the same
-    /// permutation, applied to the same two orderings.
-    ///                                       (02.08.2026.) (SW port)
-    std::int8_t const from(static_cast<std::int8_t>(sourceIndex));
-    std::int8_t const to(static_cast<std::int8_t>(targetIndex));
-    std::int8_t const step(from < to ? -1 : +1);
+void SpectrumWorxEditor::moveModuleSlot(std::uint8_t const from, std::uint8_t const to)
+{
+    LE_ASSERT(from != to);
+
+    auto const first(static_cast<std::int8_t>(from));
+    auto const last(static_cast<std::int8_t>(to));
+    std::int8_t const step(first < last ? -1 : +1);
     for (auto &pRegion : moduleRegions_)
     {
         if (!pRegion)
             continue;
         auto const slot(static_cast<std::int8_t>(pRegion->slot()));
-        if (slot == from)
-            pRegion->moveToSlot(static_cast<std::uint8_t>(to));
-        else if ((slot >= std::min(from, to)) && (slot <= std::max(from, to)))
+        if (slot == first)
+            pRegion->moveToSlot(to);
+        else if ((slot >= std::min(first, last)) && (slot <= std::max(first, last)))
             pRegion->moveToSlot(static_cast<std::uint8_t>(slot + step));
     }
 
-    editorHost().editModuleMove(sourceIndex, targetIndex);
+    editorHost().editModuleMove(from, to);
 
     host().gestureBegin("Drag module");
-    for (std::uint8_t slot(std::min(sourceIndex, targetIndex));
-         slot <= std::max(sourceIndex, targetIndex); ++slot)
+    for (std::uint8_t slot(std::min(from, to)); slot <= std::max(from, to); ++slot)
         host().moduleChangedByUser(slot, effectInRackSlot(slot));
     host().gestureEnd();
+}
 
-    refreshModuleRackAsync();
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Two moves, because a move is the only reordering primitive the chain
+/// has and a swap of two strips that are not neighbours is not one. Taking the
+/// first to where the second is drags the second back one place -- everything
+/// between them shifted left to close the gap -- so bringing it from there to
+/// where the first was puts the block between them back where it started. For
+/// neighbours the first move is already the swap and the second is a no-op, which
+/// is why it is skipped rather than special-cased.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::swapModuleSlots(std::uint8_t const a, std::uint8_t const b)
+{
+    LE_ASSERT(a != b);
+
+    auto const first(std::min(a, b));
+    auto const second(std::max(a, b));
+
+    auto *const pFirst(regionInRackSlot(first));
+    auto *const pSecond(regionInRackSlot(second));
+    LE_ASSERT_MSG(pFirst && pSecond, "A swap of a slot with no strip in it.");
+    if (!pFirst || !pSecond)
+        return;
+
+    pFirst->moveToSlot(second);
+    pSecond->moveToSlot(first);
+
+    editorHost().editModuleMove(first, second);
+    if (auto const displaced(static_cast<std::uint8_t>(second - 1)); displaced != first)
+        editorHost().editModuleMove(displaced, first);
+
+    /// \note Only the two, unlike a move: nothing between them changed slots.
+    host().gestureBegin("Swap modules");
+    host().moduleChangedByUser(first, effectInRackSlot(first));
+    host().moduleChangedByUser(second, effectInRackSlot(second));
+    host().gestureEnd();
 }
 
 void SpectrumWorxEditor::setLastModulePosition(std::uint_fast8_t const slotIndex)
@@ -733,47 +898,107 @@ void drawMainAreaText(juce::Graphics &graphics, EditorMainAreaText const &text)
 }
 } //anonymous namespace
 
-void SpectrumWorxEditor::paint(juce::Graphics &graphics)
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::MainArea
+// ----------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+SpectrumWorxEditor::MainArea::MainArea()
 {
-    auto const &background(resourceArtwork<EditorBackground>());
-    GUI::paintImage(graphics, background);
+    setSizeFromImage(*this, resourceArtwork<EditorBackground>());
+    setOpaque(true);
 
-    ////////////////////////////////////////////////////////////////////////////
-    ///
-    /// \note The skin is 563 px wide and an editor with a panel column is not,
-    /// so the column is the bitmap's last pixel column stretched across it.
-    /// That column is the skin's outer surround -- flat, top to bottom, because
-    /// the rounded rectangle holding the module strips ends ten pixels before
-    /// it -- so stretching it is what "the panel sits on the same chrome" looks
-    /// like, and it stays right for a skin that changes the colour. The
-    /// alternative was a constant here that a new skin would silently disagree
-    /// with. This component is opaque, so something has to cover it.
-    ///                                       (06.08.2026.) (SW port)
-    ///
-    ////////////////////////////////////////////////////////////////////////////
+    /// \note Neither wanted nor grabbed: this is a background, and the component
+    /// a click on it should focus is the editor. JUCE walks up to the first
+    /// parent that wants the keyboard, which is what this being transparent to
+    /// both flags leaves in place.
+    setWantsKeyboardFocus(false);
+    setMouseClickGrabsKeyboardFocus(false);
 
-    /// \note background.getHeight() rather than getHeight(): the editor is taller
-    /// than its artwork by the build-stamp bar, and that bar runs the full width
-    /// in one piece.
-    if (auto const extra(getWidth() - background.getWidth()); extra > 0)
-        background.drawScaled(graphics, {background.getWidth(), 0, extra, background.getHeight()},
-                              {background.getWidth() - 1, 0, 1, background.getHeight()});
+    addToParentAndShow(editor(), *this);
+}
+
+SpectrumWorxEditor &SpectrumWorxEditor::MainArea::editor()
+{
+    return Utility::ParentFromMember<SpectrumWorxEditor, MainArea,
+                                     &SpectrumWorxEditor::mainArea_>()(*this);
+}
+
+SpectrumWorxEditor const &SpectrumWorxEditor::MainArea::editor() const
+{
+    return const_cast<MainArea &>(*this).editor();
+}
+
+void SpectrumWorxEditor::MainArea::paint(juce::Graphics &graphics)
+{
+    auto &editor(this->editor());
+
+    GUI::paintImage(graphics, resourceArtwork<EditorBackground>());
 
     juce::Font const &moduleNameFont(Theme::singleton().blueFont());
     juce::Font const &sampleNameFont(DrawableText::defaultFont());
     juce::Font const &controlTextFont(Theme::singleton().whiteFont());
 
-    mainAreaTexts[0].pText = &string(activeModuleName);
+    mainAreaTexts[0].pText = &editor.string(activeModuleName);
     mainAreaTexts[0].pFont = &moduleNameFont;
-    mainAreaTexts[1].pText = &string(activeControlName);
+    mainAreaTexts[1].pText = &editor.string(activeControlName);
     mainAreaTexts[1].pFont = &controlTextFont;
-    mainAreaTexts[2].pText = &string(activeControlValue);
+    mainAreaTexts[2].pText = &editor.string(activeControlValue);
     mainAreaTexts[2].pFont = &controlTextFont;
-    mainAreaTexts[3].pText = &string(currentSampleName);
+    mainAreaTexts[3].pText = &editor.string(currentSampleName);
     mainAreaTexts[3].pFont = &sampleNameFont;
 
     for (auto const &text : mainAreaTexts)
         drawMainAreaText(graphics, text);
+}
+
+/// \note The logo, and it is this component's rather than the editor's because
+/// the rectangle is a position in the skin -- which is what this component's
+/// coordinates are and what the editor's stopped being when the panel column
+/// went to the left.
+void SpectrumWorxEditor::MainArea::mouseDown(juce::MouseEvent const &event)
+{
+    juce::Rectangle<int> const logoArea(12, 290, 51, 63);
+    if (logoArea.contains(event.x, event.y))
+    {
+        /// \note Was 3, and there are three tabs. JUCE clamps an out of range
+        /// index to -1, so clicking the logo raised the panel with *no* page
+        /// selected -- an empty transparent window over the desktop, which is
+        /// why nobody saw it, and an empty panel over the editor now. The About
+        /// page this means is index 2.
+        ///                                   (01.08.2026.) (SW port)
+        editor().showSettings(aboutPageIndex);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note What is left of the editor once the skin is a child of it: the column
+/// the panel sits in, and the build-stamp bar.
+///
+///   The column is the bitmap's *first* pixel column stretched across it. That
+/// column is the skin's outer surround -- flat, top to bottom, because the
+/// rounded rectangle holding the knobs starts a few pixels inside it -- so
+/// stretching it is what "the panel sits on the same chrome" looks like, and it
+/// stays right for a skin that changes the colour. The alternative was a constant
+/// here that a new skin would silently disagree with. This component is opaque,
+/// so something has to cover it.
+///                                           (06.08.2026, mirrored 14.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::paint(juce::Graphics &graphics)
+{
+    auto const &background(resourceArtwork<EditorBackground>());
+
+    /// \note background.getHeight() rather than getHeight(): the editor is taller
+    /// than its artwork by the build-stamp bar, and that bar runs the full width
+    /// in one piece.
+    if (auto const column(mainArea_.getX()); column > 0)
+        background.drawScaled(graphics, {0, 0, column, background.getHeight()},
+                              {0, 0, 1, background.getHeight()});
 
     paintBuildStamp(graphics);
 }
@@ -838,7 +1063,8 @@ void LE_NOINLINE SpectrumWorxEditor::updateString(String const stringID,
     string(stringID) = updatedString;
 
     using namespace Constants::Layout;
-    repaint(textBoxHorizontalOffset, stringVerticalOffset, textBoxWidth, stringHeight);
+    /// \note The skin's coordinates, which are the main area's. \see MainArea.
+    mainArea_.repaint(textBoxHorizontalOffset, stringVerticalOffset, textBoxWidth, stringHeight);
 }
 
 void SpectrumWorxEditor::setActiveModuleName(juce::String const &newName)
@@ -1432,21 +1658,6 @@ void SpectrumWorxEditor::destroyChainGUIs()
     setLastModulePosition(0);
 }
 
-void SpectrumWorxEditor::mouseDown(juce::MouseEvent const &event)
-{
-    juce::Rectangle<int> const logoArea(12, 290, 51, 63);
-    if (logoArea.contains(event.x, event.y))
-    {
-        /// \note Was 3, and there are three tabs. JUCE clamps an out of range
-        /// index to -1, so clicking the logo raised the panel with *no* page
-        /// selected -- an empty transparent window over the desktop, which is
-        /// why nobody saw it, and an empty panel over the editor now. The About
-        /// page this means is index 2.
-        ///                                   (01.08.2026.) (SW port)
-        showSettings(aboutPageIndex);
-    }
-}
-
 /// \note `settings_` may already be up without the user having opened it -- it is
 /// what alwaysVisible rests on -- so this only builds a panel when there is none,
 /// and lights the button either way.
@@ -1637,7 +1848,7 @@ void SpectrumWorxEditor::createModuleRegion(LE::Utility::IntrusivePtr<Module> co
             LE_ASSERT_MSG(false, "Module region construction threw; the slot has no strip.");
             return;
         }
-        addToParentAndShow(*this, *pRegion);
+        addToParentAndShow(mainArea_, *pRegion);
         return;
     }
 
@@ -1880,7 +2091,7 @@ void SpectrumWorxEditor::updateModuleParameterAndNotifyHost(ModuleUI &moduleUI,
 }
 
 SpectrumWorxEditor::ModuleMenuButton::ModuleMenuButton(SpectrumWorxEditor &parent)
-    : BitmapButton(parent, resourceArtwork<AddModule>(), resourceArtwork<AddModule>(),
+    : BitmapButton(parent.mainArea(), resourceArtwork<AddModule>(), resourceArtwork<AddModule>(),
                    Theme::singleton().blueColour())
 {
 }
@@ -1896,8 +2107,9 @@ void SpectrumWorxEditor::ModuleMenuButton::moveToSlot(std::uint8_t const slotInd
 
 void SpectrumWorxEditor::ModuleMenuButton::clicked()
 {
-    SpectrumWorxEditor &editor(
-        *LE::Utility::polymorphicDowncast<SpectrumWorxEditor *>(this->getParentComponent()));
+    /// \note fromChild() rather than a downcast of the parent: the parent is the
+    /// main area now, not the editor. \see MainArea.
+    SpectrumWorxEditor &editor(SpectrumWorxEditor::fromChild(*this));
     LE_ASSERT(editor.nextAvailableModuleSlot_ < SW::Constants::maxNumberOfModules);
     /// \note The menu no longer blocks, so the editor can be torn down while it
     /// is open -- a host closing the window under it. A SafePointer to it, and
@@ -1913,18 +2125,79 @@ void SpectrumWorxEditor::ModuleMenuButton::clicked()
         });
 }
 
-SpectrumWorxEditor::Gradient::Gradient(juce::Component &parent)
-    : gradient_(juce::Colours::transparentWhite, 0, 0, juce::Colours::transparentWhite,
-                static_cast<float>(ModuleUI::width), 0, false)
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::DropIndicator
+// ---------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+SpectrumWorxEditor::DropIndicator::DropIndicator(juce::Component &parent)
 {
-    gradient_.addColour(0.5, juce::Colours::darkgrey);
+    /// \note Neither focusable nor clickable: it is drawn over the rack during a
+    /// drag, and a drag is delivered to the strip it started on.
+    setWantsKeyboardFocus(false);
+    setInterceptsMouseClicks(false, false);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And on top for good, rather than raised and lowered around each
+    /// drag. It has to be above the module strips or a swap's fill is painted
+    /// over by the strip it is marking -- and it is built before any strip
+    /// exists, so ordinary z-order puts it underneath every one of them.
+    ///
+    ///   The raise-and-lower this replaces was there because the thing being
+    /// raised was a child of the *editor*, alongside the panels, so a stale
+    /// always-on-top left it painting over an open preset browser. It is a child
+    /// of the main area now and a panel is a sibling of that, so there is nothing
+    /// left for it to rise above.
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    setAlwaysOnTop(true);
+
     addToParentAndShow(parent, *this);
+    setInvisible();
 }
 
-void SpectrumWorxEditor::Gradient::paint(juce::Graphics &graphics)
+void SpectrumWorxEditor::DropIndicator::showSwap(std::uint8_t const slotIndex)
 {
-    graphics.setGradientFill(gradient_);
-    graphics.fillAll();
+    insert_ = false;
+    setBounds(ModuleUI::horizontalOffset + (slotIndex * slotWidth), ModuleUI::verticalOffset,
+              ModuleUI::width, ModuleUI::height);
+    setVisible();
+}
+
+/// \note Taller than a strip, by a few pixels at each end. A strip is already
+/// outlined in the skin's blue, so a line exactly as tall as one reads as a
+/// thicker border on whichever strip the eye assigns it to; overrunning both is
+/// what makes it a divider between them instead.
+void SpectrumWorxEditor::DropIndicator::showInsert(std::uint8_t const gapIndex)
+{
+    insert_ = true;
+    setBounds(ModuleUI::horizontalOffset + (gapIndex * slotWidth) - (lineWidth / 2),
+              ModuleUI::verticalOffset - lineOverrun, lineWidth,
+              ModuleUI::height + (2 * lineOverrun));
+    setVisible();
+}
+
+/// \note The skin's own blue for both, brightened for the line so that four
+/// pixels of it read as an edge against the rack rather than as part of it, and
+/// laid over the target strip for a swap so that what is underneath still shows
+/// through -- which is what says *which* strip is being pointed at.
+void SpectrumWorxEditor::DropIndicator::paint(juce::Graphics &graphics)
+{
+    auto const blue(Theme::blueColour());
+
+    if (insert_)
+    {
+        graphics.fillAll(blue.brighter(0.85f));
+        return;
+    }
+
+    graphics.fillAll(blue.withAlpha(0.35f));
+    graphics.setColour(blue);
+    graphics.drawRect(getLocalBounds(), 2);
 }
 
 namespace
@@ -2056,7 +2329,7 @@ void SpectrumWorxEditor::LFODisplay::setupForControl(ModuleControlBase &control,
 
     updateAllControls();
 
-    addToParentAndShow(editor(), *this);
+    addToParentAndShow(editor().mainArea(), *this);
 
     repaint();
 }
@@ -2250,7 +2523,7 @@ void SpectrumWorxEditor::LFODisplay::paint(juce::Graphics &graphics)
     LE_ASSERT(editor().activeControl() != nullptr);
     LE_ASSERT(editor().activeControl() == &control());
     LE_ASSERT(control().isActive());
-    LE_ASSERT(getParentComponent() == &editor());
+    LE_ASSERT(getParentComponent() == &editor().mainArea());
 
     {
         graphics.setFont(DrawableText::defaultFont());
@@ -2551,7 +2824,7 @@ SpectrumWorxEditor &SpectrumWorxEditor::LFODisplay::editor()
     SpectrumWorxEditor &editor(
         Utility::ParentFromOptionalMember<SpectrumWorxEditor, LFODisplay,
                                           &SpectrumWorxEditor::lfoDisplay_, false>()(*this));
-    LE_ASSERT((&editor == this->getParentComponent()) || !this->getParentComponent());
+    LE_ASSERT((&editor.mainArea() == this->getParentComponent()) || !this->getParentComponent());
     return editor;
 }
 
@@ -2589,7 +2862,7 @@ SpectrumWorxEditor::LFODisplay const &SpectrumWorxEditor::LFODisplay::Period::pa
 SpectrumWorxEditor::SampleArea::SampleArea()
 {
     setMouseCursor(juce::MouseCursor::PointingHandCursor);
-    addToParentAndShow(editor(), *this);
+    addToParentAndShow(editor().mainArea(), *this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -147,6 +147,10 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// panelColumnX below for the two places it can be.
     ///                                       (06.08.2026.) (SW port)
     ///
+    /// \note The column is on the **left** and the skin moves right to make room
+    /// for it. \see MainArea, which is what moves.
+    ///                                       (14.08.2026.) (SW port)
+    ///
     ////////////////////////////////////////////////////////////////////////////
 
     enum class PanelPlacement : std::uint8_t
@@ -484,10 +488,22 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// The skin's right margin, the module strips ending at overlayX + overlayWidth.
     static constexpr unsigned short panelMargin{estimatedWidth - (overlayX + overlayWidth)};
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
     /// \brief The editor with a column of its own for the panel, and where the
-    /// panel goes in it: the same margin either side as the strips have.
-    static constexpr unsigned short expandedWidth{estimatedWidth + panelMargin + overlayWidth};
-    static constexpr unsigned short panelColumnX{estimatedWidth};
+    /// two things in it go: the panel against the left edge, the skin to the
+    /// right of it, each with the margin the strips already have.
+    ///
+    /// \note The column used to be on the right, which cost nothing to lay out --
+    /// every offset in the skin is measured from an origin that did not move --
+    /// and put the panel a user opens the plugin for at the far edge of the
+    /// window. It is on the left now and the skin is what moves. \see mainArea().
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr unsigned short panelColumnX{panelMargin};
+    static constexpr unsigned short mainAreaX{panelColumnX + overlayWidth};
+    static constexpr unsigned short expandedWidth{mainAreaX + estimatedWidth};
 
   private:
     void newSampleFileSelected(fs::path const &);
@@ -540,7 +556,8 @@ class SpectrumWorxEditor final : private SkinLifetime,
     void paintBuildStamp(juce::Graphics &) const;
 
   private: // JUCE Component overrides.
-    void mouseDown(juce::MouseEvent const &) override;
+    /// \note Only what is outside the skin: the panel column's chrome and the
+    /// build-stamp bar. The skin itself is MainArea's. \see the definition.
     void paint(juce::Graphics &) override;
     void parentHierarchyChanged() override;
 
@@ -661,6 +678,47 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     SharedModuleControls &sharedModuleControls() { return *sharedModuleControls_; }
 
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The skin, and every widget laid out in its pixels.
+    ///
+    ///   Everything but a panel is parented here rather than to the editor, and
+    /// that is the whole of what moving the panel column to the left cost: the
+    /// skin's 563 x 376 coordinate system is this component's, so no offset in it
+    /// moved and none of them has to know whether there is a column. The editor
+    /// slides this right by mainAreaX when there is one and paints what is left of
+    /// itself -- the column's chrome and the build-stamp bar.
+    ///
+    /// \note It is also the component the zoom note above wants: one content child
+    /// carrying everything, which is where a transform would go.
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    class MainArea final : public WidgetBase<>
+    {
+      public:
+        MainArea();
+
+      private: // JUCE Component overrides.
+        void paint(juce::Graphics &) override;
+        /// \brief The logo, which opens the About page. \see the definition.
+        void mouseDown(juce::MouseEvent const &) override;
+
+      private:
+        SpectrumWorxEditor &editor();
+        SpectrumWorxEditor const &editor() const;
+    }; // class MainArea
+
+    /// \brief Where every widget but a panel lives. \see MainArea.
+    ///
+    /// \note Public because a strip, the shared controls and the LFO display are
+    /// all built outside this class and parent themselves to it -- and because a
+    /// test that means to click the skin has to click this rather than the editor.
+    MainArea &mainArea() { return mainArea_; }
+    MainArea const &mainArea() const { return mainArea_; }
+
   private:
     ////////////////////////////////////////////////////////////////////////////
     /// \internal
@@ -679,23 +737,138 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     ////////////////////////////////////////////////////////////////////////////
     /// \internal
-    /// \class Gradient
+    /// \class DropIndicator
+    ///
+    /// \brief Where a dragged strip would land: over the strip it would change
+    /// places with, or in the gap it would be inserted into.
+    ///
+    /// \note One component for both, because only one of the two can be showing
+    /// and because the two are answers to the same question -- which is asked
+    /// once, by moduleDropAt(), and drawn here.
+    ///
+    /// \note What replaced a `Gradient`: a 68 px block of transparent-to-grey
+    /// straddling a slot boundary, which was the only drop this editor had and
+    /// so did not have to say which of two it was.
+    ///                                       (14.08.2026.) (SW port)
     ////////////////////////////////////////////////////////////////////////////
 
-    /// \note Holds a ColourGradient rather than deriving from one: JUCE 8 marks
-    /// it final.
-    class Gradient final : public WidgetBase
+    class DropIndicator final : public WidgetBase<>
     {
       public:
-        Gradient(juce::Component &parent);
-        ~Gradient() {}
+        explicit DropIndicator(juce::Component &parent);
+
+        /// \brief Over the strip in \p slotIndex, which a drop would exchange the
+        /// dragged one with.
+        void showSwap(std::uint8_t slotIndex);
+
+        /// \brief In the gap before \p gapIndex, 0 to maxNumberOfModules, which a
+        /// drop would shift the strips apart at.
+        void showInsert(std::uint8_t gapIndex);
+
+        void hide() { setInvisible(); }
+
+        /// The insert line's width -- even, so that it straddles the gap -- and
+        /// how far past the strips it runs at each end. \see showInsert().
+        static constexpr int lineWidth{6};
+        static constexpr int lineOverrun{5};
 
       private: // JUCE component overrides.
         void paint(juce::Graphics &) override;
 
       private:
-        juce::ColourGradient gradient_;
-    }; // class Gradient
+        bool insert_{false};
+    }; // class DropIndicator
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What letting go of a dragged strip somewhere would do.
+    ///
+    /// \note A value rather than a state the drag keeps, so that the question is
+    /// asked the same way twice: moduleDrag() asks it to draw the indicator and
+    /// moduleDragEnd() asks it again to act. What the user is shown and what
+    /// happens are then the same function of the same point, rather than a
+    /// drawing and an interpretation of that drawing -- which is what the code
+    /// this replaced did, recovering the target slot from where it had put a
+    /// gradient block.
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    struct ModuleDrop
+    {
+        enum Action : std::uint8_t
+        {
+            /// Outside the drop zone, or a drop that would not move anything.
+            nothing,
+            /// Exchange the dragged strip with the one in `slot`.
+            swap,
+            /// Put the dragged strip in the gap `slot`, shifting the rest along.
+            insert
+        }; // enum Action
+
+        Action action{nothing};
+
+        /// A slot index for `swap`; a gap index, 0 to the number of strips, for
+        /// `insert`.
+        std::uint8_t slot{0};
+    }; // struct ModuleDrop
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Where the strip a drag is carrying would be: \p pointer, in the
+    /// skin's coordinates, less where in the strip it was \p grabbedAt, plus half
+    /// a strip.
+    ///
+    ///   Which is the column the eject `X` is drawn in, that marker being centred
+    /// on the strip -- and it is what a drop is aimed with rather than the
+    /// pointer. \see the definition.
+    ///
+    /// \note Public and static so that a test can compose it with moduleDropAt():
+    /// what went wrong here is that the two disagreed, and that is a question
+    /// about the pair rather than about either.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static juce::Point<int> draggedStripCentre(juce::Point<int> pointer,
+                                               juce::Point<int> grabbedAt);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What a drop with the dragged strip's middle at \p position -- in
+    /// the skin's coordinates, which are mainArea()'s -- would do to the strip in
+    /// \p sourceSlot. \see draggedStripCentre() for what \p position is.
+    ///
+    /// \note Public so that a test can ask it. Driving this by mouse needs a real
+    /// drag, which needs a window and a `MouseInputSource` that a synthesised
+    /// event does not touch (see tests/gui/moduleControlFocusTests.cpp), and the
+    /// geometry is the half of a drop that can be wrong in a way nobody notices.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ModuleDrop moduleDropAt(std::uint8_t sourceSlot, juce::Point<int> position) const;
+
+    /// \brief Shows what \p drop would do -- a filled target strip for a swap, a
+    /// line in a gap for an insert -- or takes the indication away.
+    ///
+    /// \note Public for the same reason as moduleDropAt(): the only other way to
+    /// this is a live JUCE drag, and what a drag *draws* is the half of it a user
+    /// reads before committing to anything.
+    void showModuleDrop(ModuleDrop drop);
+
+    /// \brief Carries \p drop out on the strip in \p sourceSlot: the rack first,
+    /// then the engine, then the host. Public for the same reason as
+    /// moduleDropAt(). \see the definition.
+    void applyModuleDrop(std::uint8_t sourceSlot, ModuleDrop drop);
+
+  private:
+    /// \brief The above, with the two coordinate conversions a mouse event needs.
+    juce::Point<int> draggedStripCentre(ModuleUI const &, juce::MouseEvent const &) const;
+
+    /// \brief Exchanges the strips in two slots, which is two moves. \see the
+    /// definition.
+    void swapModuleSlots(std::uint8_t a, std::uint8_t b);
+
+    /// \brief Moves the strip in \p from to \p to, shifting everything between.
+    void moveModuleSlot(std::uint8_t from, std::uint8_t to);
 
   public:
     ////////////////////////////////////////////////////////////////////////////
@@ -1018,11 +1191,14 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     std::uint8_t nextAvailableModuleSlot_;
 
+    /// \note Before every widget below, all of which parent themselves to it.
+    MainArea mainArea_;
+
     EditorKnob in_, out_, mix_;
 
     ModuleMenuHolder const moduleMenu_;
     ModuleMenuButton moduleMenuButton_;
-    Gradient gradient_;
+    DropIndicator dropIndicator_;
 
     /// \note Was public, for the 2016 loader thread's completion callback to
     /// reach. There is no loader thread now, so it is nobody's but the editor's

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1026,7 +1026,7 @@ Knob::param_type Knob::getNormalisedValue() const
 }
 
 EditorKnob::EditorKnob(SpectrumWorxEditor &parent, unsigned int const x, unsigned int const y)
-    : Knob(parent, x, y, 0, 0), parameterIndex_(0)
+    : Knob(parent.mainArea(), x, y, 0, 0), parameterIndex_(0)
 {
     setScrollWheelEnabled(true);
     setWantsKeyboardFocus(false);
@@ -1126,10 +1126,9 @@ void EditorKnob::stoppedDragging() noexcept
     Knob::stoppedDragging();
 }
 
-SpectrumWorxEditor &EditorKnob::editor()
-{
-    return *LE::Utility::polymorphicDowncast<SpectrumWorxEditor *>(this->getParentComponent());
-}
+/// \note fromChild() rather than a downcast of the parent, which is the main
+/// area rather than the editor. \see SpectrumWorxEditor::MainArea.
+SpectrumWorxEditor &EditorKnob::editor() { return SpectrumWorxEditor::fromChild(*this); }
 
 TitledComboBox::TitledComboBox(juce::Component &parent, unsigned int const x, unsigned int const y,
                                char const *const title)

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -372,7 +372,7 @@ ModuleUI::ModuleUI(SpectrumWorxEditor &editor, LE::Utility::IntrusivePtr<SW::Mod
     /// createGUI() did the same thing with an `editor.addChildComponent()` under
     /// `#ifndef NDEBUG`, for the same reason and only in a checked build.
     ///                                       (02.08.2026.) (SW port)
-    editor_.addChildComponent(this);
+    editor_.mainArea().addChildComponent(this);
 
     pWidgets_ = createModuleWidgets(module().effectTypeIndex(), *this);
     LE_ASSERT_MSG(pWidgets_ != nullptr, "No widgets for this effect index.");
@@ -456,30 +456,57 @@ void ModuleUI::paint(juce::Graphics &graphics)
     paintImage(graphics,
                isActive ? resourceArtwork<ModuleBgSelected>() : resourceArtwork<ModuleBg>());
     graphics.setColour(Theme::singleton().blueColour());
-    graphics.drawHorizontalLine(height - 30, static_cast<float>(ModuleUI::border),
+    graphics.drawHorizontalLine(nameRule, static_cast<float>(ModuleUI::border),
                                 Math::convert<float>(getWidth() - ModuleUI::border));
 
     graphics.setFont(Theme::singleton().whiteFont());
-    graphics.drawFittedText(getName(), 3, height - 30, width - 6, 28, juce::Justification::centred,
-                            3, 0.6f);
+    graphics.drawFittedText(getName(), 3, nameRule, width - 6, 28, juce::Justification::centred, 3,
+                            0.6f);
+}
+
+/// \note It was every pixel no control happened to cover, which made a drag of
+/// the gaps between knobs: a slip off a knob moved the module instead of the
+/// value. The eject button's own bottom edge rather than a constant, so a skin
+/// that resizes the `X` moves the band with it.
+bool ModuleUI::isDragHandle(juce::Point<int> const position) const
+{
+    if (!getLocalBounds().contains(position))
+        return false;
+    return (position.getY() < eject_.getBottom()) || (position.getY() >= nameRule);
+}
+
+/// \note The open flat hand, not the pointing finger: the finger is the web-link
+/// cursor and means "click this".
+void ModuleUI::updateCursorFor(juce::Point<int> const position)
+{
+    setMouseCursor(isDragHandle(position) ? juce::MouseCursor::DraggingHandCursor
+                                          : juce::MouseCursor::NormalCursor);
 }
 
 void ModuleUI::mouseDrag(juce::MouseEvent const &event)
 {
-    if (event.mods.isLeftButtonDown())
+    /// \note Where the mouse went *down*, not where it is: a drag that began on a
+    /// handle stays a drag wherever it is carried, and one that began anywhere
+    /// else never becomes one.
+    if (event.mods.isLeftButtonDown() && isDragHandle(event.getMouseDownPosition()))
         editor().moduleDrag(*this, event);
 }
 
 void ModuleUI::mouseUp(juce::MouseEvent const &event) noexcept
 {
-    editor().moduleDragEnd(*this, event);
+    if (isDragHandle(event.getMouseDownPosition()))
+        editor().moduleDragEnd(*this, event);
 }
 
-void ModuleUI::mouseEnter(juce::MouseEvent const &)
+void ModuleUI::mouseEnter(juce::MouseEvent const &event)
 {
+    updateCursorFor(event.getPosition());
+
     if (selectionTracksMouseMovements())
         activate();
 }
+
+void ModuleUI::mouseMove(juce::MouseEvent const &event) { updateCursorFor(event.getPosition()); }
 
 void ModuleUI::mouseExit(juce::MouseEvent const &event) noexcept
 {

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -337,6 +337,11 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
     /// \brief Which slot this strip is drawn in, as last set by moveToSlot().
     std::uint8_t slot() const { return slot_; }
 
+    /// \brief Whether \p position -- in this strip's coordinates -- is somewhere
+    /// it can be picked up by: the row the eject `X` is in, or the name under the
+    /// blue rule. Public because it is also what the cursor says.
+    bool isDragHandle(juce::Point<int> position) const;
+
     /// \note Was `static ModuleUI *selectedModule()` over a file-scope pointer,
     /// with a 2011 note arguing that a static was safe "even if there are multiple
     /// effect editor instances open" because no two windows can have focus at
@@ -384,12 +389,20 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
     void deactivate();
     bool selectionTracksMouseMovements() const;
 
+  private:
+    /// \brief A hand over a drag handle and the arrow everywhere else. \see
+    /// isDragHandle().
+    void updateCursorFor(juce::Point<int> position);
+
   private: // JUCE Component overrides.
     void paint(juce::Graphics &) override;
 
     void mouseDrag(juce::MouseEvent const &) override;
     void mouseEnter(juce::MouseEvent const &) override;
     void mouseExit(juce::MouseEvent const &) noexcept override;
+    /// \note Only the cursor. JUCE reveals it right after delivering this, which
+    /// is what lets one component carry two.
+    void mouseMove(juce::MouseEvent const &) override;
     void mouseUp(juce::MouseEvent const &) noexcept override;
 
     void focusGained(FocusChangeType) override;
@@ -426,6 +439,14 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
     static std::uint8_t const width = 68;
     static std::uint8_t const distance = 0;
     static std::uint8_t const border = 4;
+
+    /// \brief The blue rule across the bottom of a strip: the effect's controls
+    /// are above it and its name is below.
+    ///
+    /// \note Was `height - 30` written out in paint(), twice. It is a boundary two
+    /// things now depend on -- what is drawn, and where the strip can be picked up
+    /// -- so it is a name.
+    static std::uint16_t const nameRule = height - 30;
 
     static std::uint8_t const baseWidgets = 2;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(sw-plugin-tests
         gui/buildStampTests.cpp
         gui/lfoDisplayTests.cpp
         gui/moduleControlFocusTests.cpp
+        gui/moduleDragTests.cpp
         gui/overlayPanelTests.cpp
         gui/pathsTests.cpp
         gui/skinTests.cpp

--- a/tests/gui/moduleDragTests.cpp
+++ b/tests/gui/moduleDragTests.cpp
@@ -1,0 +1,626 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// moduleDragTests.cpp
+/// -------------------
+///
+///   Dragging a module strip somewhere else in the rack, which is two gestures
+/// wearing one drag: dropped **on** another strip the two change places, dropped
+/// **between** two -- or past either end -- it is inserted there and the rest
+/// shift along.
+///
+///   Both halves are asked here, and separately, because they fail separately.
+/// `moduleDropAt()` decides which of the two a point means and is pure geometry;
+/// `applyModuleDrop()` carries one out and is a permutation of the chain. A swap
+/// that reads as an insert and an insert that permutes wrongly are different
+/// bugs, and only the second is visible in the audio.
+///
+/// \note Not driven by a mouse. A JUCE drag needs a window, a
+/// `MouseInputSource` that a synthesised event does not touch, and a drag image
+/// on the desktop -- see the note on `eventOver` in moduleControlFocusTests.cpp
+/// for what a hand-built event does and does not reach. What a drag *decides* and
+/// what it *does* are both reachable without one, and they are the parts that can
+/// be wrong.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module: the module chain downcasts a
+/// node to it, and this is the header with the complete type.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "gui/modules/moduleUI.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using Editor = GUI::SpectrumWorxEditor;
+using Drop = Editor::ModuleDrop;
+using Strip = GUI::ModuleUI;
+
+constexpr int slotWidth{Strip::width + Strip::distance};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///   Every point below is where the **dragged strip's middle** is, which is what
+/// a drop is aimed with -- not where the pointer is. \see
+/// SpectrumWorxEditor::draggedStripCentre(), and the last case in this file for
+/// the difference.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+/// The middle of the strip drawn in \p slot, which is what a swap is aimed at.
+juce::Point<int> overSlot(std::uint8_t const slot)
+{
+    return {Strip::horizontalOffset + (slot * slotWidth) + (slotWidth / 2),
+            Strip::verticalOffset + (Strip::height / 2)};
+}
+
+/// The gap before \p slot, which is what an insert is aimed at.
+juce::Point<int> overGap(std::uint8_t const gap)
+{
+    return {Strip::horizontalOffset + (gap * slotWidth),
+            Strip::verticalOffset + (Strip::height / 2)};
+}
+
+/// \brief What a drag reports when the strip it is carrying has been brought to
+/// \p stripTopLeft, having been picked up \p grabbedAt within it.
+///
+/// \note Written from where the strip is rather than from where the pointer is,
+/// because that is what the user is looking at: JUCE carries a snapshot of the
+/// strip offset by the grab, so this is the position of the thing on screen.
+Editor::ModuleDrop dropWithStripAt(Editor const &editor, std::uint8_t const sourceSlot,
+                                   juce::Point<int> const stripTopLeft,
+                                   juce::Point<int> const grabbedAt)
+{
+    return editor.moduleDropAt(sourceSlot,
+                               Editor::draggedStripCentre(stripTopLeft + grabbedAt, grabbedAt));
+}
+
+/// Where the strip in \p slot sits when it is not being dragged anywhere.
+juce::Point<int> slotTopLeft(std::uint8_t const slot)
+{
+    return {Strip::horizontalOffset + (slot * slotWidth), Strip::verticalOffset};
+}
+
+/// A mouse move to \p point within \p component, hand-built. \see
+/// moduleControlFocusTests.cpp for what a synthesised event does and does not do.
+juce::MouseEvent moveTo(juce::Component &component, juce::Point<int> const point)
+{
+    auto const at(point.toFloat());
+    return juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(), at,
+                            juce::ModifierKeys(), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &component,
+                            &component, juce::Time(), at, juce::Time(), 1, false);
+}
+
+/// \brief The cursor JUCE would show at \p point in \p strip: the component the
+/// point lands on, resolved through the look and feel.
+juce::MouseCursor cursorOver(Strip &strip, juce::Point<int> const point)
+{
+    auto *const pTarget(strip.getComponentAt(point));
+    /// \note No assertion, so that the sweep below can call this 24 344 times and
+    /// still report one number. `getComponentAt()` answers with the component
+    /// itself where nothing else is, so a point inside always lands on something,
+    /// and `NoCursor` matches neither answer the sweep allows.
+    if (pTarget == nullptr)
+        return juce::MouseCursor(juce::MouseCursor::NoCursor);
+
+    /// \note The move first, and only where JUCE would deliver one: the strip
+    /// carries two cursors and picks between them in `mouseMove`, so asking
+    /// without having moved there reads whatever the last move left behind.
+    if (pTarget == &strip)
+        static_cast<juce::Component &>(strip).mouseMove(moveTo(strip, point));
+
+    return pTarget->getLookAndFeel().getMouseCursorFor(*pTarget);
+}
+
+/// Whether a drag could start at \p point: the strip's own to handle, and one of
+/// the two bands it offers as a handle. \see ModuleUI::mouseDrag().
+bool draggableAt(Strip &strip, juce::Point<int> const point)
+{
+    return (strip.getComponentAt(point) == &strip) && strip.isDragHandle(point);
+}
+
+/// \brief An editor with \p effects, one strip each, in the order given.
+///
+/// \note Different effects on purpose: the whole question below is which module
+/// ends up where, and a rack of three identical ones cannot answer it.
+///
+/// \note Overlay placement, so that the skin's coordinates are the editor's --
+/// every point above is a position in the skin, and an editor with a panel
+/// column draws the skin 201 px to the right of its own origin.
+Editor &rackOf(SWTest::Instance &instance, std::vector<std::uint8_t> const &effects)
+{
+    instance.openEditor(Editor::PanelPlacement::overlay);
+    auto &editor(instance.editor());
+    for (auto const effect : effects)
+        editor.addUserAddedModule(effect);
+    /// \note By hand: adding a module ends in a posted resync and a test has no
+    /// message loop to deliver it. \see twoInstanceTests.cpp.
+    editor.resyncModuleRack();
+    return editor;
+}
+
+/// What the chain is playing, as effect indices, which is the answer that matters.
+std::vector<int> chainOrder(SWTest::Instance const &instance)
+{
+    auto &chain(const_cast<SWTest::Instance &>(instance).core().program().moduleChain());
+    std::vector<int> order;
+    for (std::uint8_t slot(0); slot < chain.size(); ++slot)
+        order.push_back(chain.moduleAs<SW::Module>(slot)->effectTypeIndex());
+    return order;
+}
+
+/// The same question of the rack, which is what the user is looking at.
+std::vector<int> rackOrder(Editor &editor, std::size_t const strips)
+{
+    std::vector<int> order;
+    for (std::uint8_t slot(0); slot < strips; ++slot)
+        order.push_back(editor.regionInRackSlot(slot)->module().effectTypeIndex());
+    return order;
+}
+
+std::string describe(std::vector<int> const &order)
+{
+    std::string text;
+    for (auto const effect : order)
+        text += std::to_string(effect) + " ";
+    return text;
+}
+
+/// The editor as an image, which is what a user sees. \see overlayPanelTests.cpp.
+juce::Image rendered(Editor &editor)
+{
+    juce::Image image(juce::Image::ARGB, editor.getWidth(), editor.getHeight(), true);
+    juce::Graphics graphics(image);
+    editor.paintEntireComponent(graphics, true);
+    return image;
+}
+
+/// What fraction of \p area two renders disagree about.
+double differenceOver(juce::Image const &left, juce::Image const &right,
+                      juce::Rectangle<int> const &area)
+{
+    juce::Image::BitmapData const leftPixels(left, juce::Image::BitmapData::readOnly);
+    juce::Image::BitmapData const rightPixels(right, juce::Image::BitmapData::readOnly);
+
+    std::size_t different{0};
+    for (int y(area.getY()); y < area.getBottom(); ++y)
+        for (int x(area.getX()); x < area.getRight(); ++x)
+            different += (leftPixels.getPixelColour(x, y) != rightPixels.getPixelColour(x, y));
+
+    return double(different) / double(area.getWidth() * area.getHeight());
+}
+
+/// Where the strip in \p slot is drawn.
+juce::Rectangle<int> slotRectangle(std::uint8_t const slot)
+{
+    return {Strip::horizontalOffset + (slot * slotWidth), Strip::verticalOffset, Strip::width,
+            Strip::height};
+}
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Which of the two a point means
+// ------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The middle of a strip is a swap and its edges are inserts", "[gui][modules][drag]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2, 3}));
+
+    // Dragging the first strip. Over the middle of another one: change places.
+    for (std::uint8_t target(1); target < 4; ++target)
+    {
+        CAPTURE(target);
+        auto const drop(editor.moduleDropAt(0, overSlot(target)));
+        CHECK(drop.action == Drop::swap);
+        CHECK(int(drop.slot) == target);
+    }
+
+    // On a boundary between two: go between them. A gap is named by the slot to
+    // its right, so the gap before slot 2 is gap 2.
+    for (std::uint8_t gap(2); gap < 4; ++gap)
+    {
+        CAPTURE(gap);
+        auto const drop(editor.moduleDropAt(0, overGap(gap)));
+        CHECK(drop.action == Drop::insert);
+        CHECK(int(drop.slot) == gap);
+    }
+
+    /// \note And a gap has width, which is the point of it. A gap that had to be
+    /// hit exactly is one no user reaches, so the outer quarter of each strip
+    /// belongs to the gap beside it -- these two points are 16 px either side of
+    /// the boundary and both mean the same insert.
+    CHECK(editor.moduleDropAt(0, overGap(2).translated(-16, 0)).action == Drop::insert);
+    CHECK(int(editor.moduleDropAt(0, overGap(2).translated(-16, 0)).slot) == 2);
+    CHECK(editor.moduleDropAt(0, overGap(2).translated(+16, 0)).action == Drop::insert);
+    CHECK(int(editor.moduleDropAt(0, overGap(2).translated(+16, 0)).slot) == 2);
+}
+
+TEST_CASE("Either end of the rack is reachable without being on it", "[gui][modules][drag]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The two drops with nothing to aim at. "Before the first strip" and
+    /// "after the last" are gaps at the edge of the rack, and half of each is
+    /// outside it -- so a zone that stopped at the rack would make the two ends
+    /// the hardest places in it to reach, which is the wrong way round: moving
+    /// something to the front or the back of a chain is the commonest thing
+    /// anyone does to one.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    // Dragging the last strip to the front, from off the left end of the rack.
+    auto const beforeTheRack(editor.moduleDropAt(2, overGap(0).translated(-24, 0)));
+    CHECK(beforeTheRack.action == Drop::insert);
+    CHECK(int(beforeTheRack.slot) == 0);
+
+    // ...and the first strip to the back, from off the right end of it.
+    auto const afterTheRack(editor.moduleDropAt(0, overGap(3).translated(+24, 0)));
+    CHECK(afterTheRack.action == Drop::insert);
+    CHECK(int(afterTheRack.slot) == 3);
+
+    // Further out than that is a drag let go somewhere else, and does nothing.
+    CHECK(editor.moduleDropAt(0, {0, Strip::verticalOffset}).action == Drop::nothing);
+    CHECK(editor.moduleDropAt(0, overGap(3).translated(+120, 0)).action == Drop::nothing);
+    // The empty slots past the last strip are not part of the rack either.
+    CHECK(editor.moduleDropAt(0, overSlot(4)).action == Drop::nothing);
+}
+
+TEST_CASE("A drop that would move nothing is not offered", "[gui][modules][drag]")
+{
+    /// \note Three points mean "leave it where it is": the strip itself, and the
+    /// gap either side of it -- it is already in both. Offering any of them would
+    /// light the indicator for a move the user then does not see happen.
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    CHECK(editor.moduleDropAt(1, overSlot(1)).action == Drop::nothing);
+    CHECK(editor.moduleDropAt(1, overGap(1)).action == Drop::nothing);
+    CHECK(editor.moduleDropAt(1, overGap(2)).action == Drop::nothing);
+
+    // Its neighbours are still swaps, which is what says the three above are
+    // about the source strip rather than about the middle of the rack.
+    CHECK(editor.moduleDropAt(1, overSlot(0)).action == Drop::swap);
+    CHECK(editor.moduleDropAt(1, overSlot(2)).action == Drop::swap);
+
+    /// \note And a rack of one has nowhere to go at all -- worth saying, because
+    /// it is the state every editor starts in after the first module is added.
+    SWTest::Instance alone;
+    auto &lonely(rackOf(alone, {0}));
+    CHECK(lonely.moduleDropAt(0, overSlot(0)).action == Drop::nothing);
+    CHECK(lonely.moduleDropAt(0, overGap(1)).action == Drop::nothing);
+}
+
+TEST_CASE("Where a strip was picked up does not move the drop", "[gui][modules][drag]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The reported fault, and the reason the point above is the strip's
+    /// middle rather than the pointer's. A drop decided from the pointer is out
+    /// by however far from the middle the strip was picked up -- up to half a
+    /// strip, which is the exact width of a swap zone. Carrying a strip until it
+    /// sits over another one and being told "insert to the left of it" is what
+    /// that looks like, and which way it was wrong depended on which edge had
+    /// been grabbed.
+    ///
+    ///   Swept across the strip rather than sampled at three points: the fault
+    /// grows with the distance from the middle, so a case that only tried the
+    /// middle would have passed against the code that had it.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2, 3}));
+
+    for (int grabX(0); grabX < Strip::width; ++grabX)
+    {
+        CAPTURE(grabX);
+        juce::Point<int> const grabbedAt(grabX, Strip::height / 2);
+
+        // The strip carried until it covers slot 2: change places with it.
+        auto const onto(dropWithStripAt(editor, 0, slotTopLeft(2), grabbedAt));
+        CHECK(onto.action == Drop::swap);
+        CHECK(int(onto.slot) == 2);
+
+        /// \note And straddling the boundary between slots 2 and 3, which is what
+        /// "between these two" looks like when the thing being aimed is a strip:
+        /// half of it over each.
+        auto const between(
+            dropWithStripAt(editor, 0, slotTopLeft(2).translated(slotWidth / 2, 0), grabbedAt));
+        CHECK(between.action == Drop::insert);
+        CHECK(int(between.slot) == 3);
+    }
+
+    /// \note And the strip left where it started is "nothing", whichever edge it
+    /// was picked up by -- which is what a click on a strip is.
+    for (int grabX(0); grabX < Strip::width; ++grabX)
+    {
+        CAPTURE(grabX);
+        CHECK(dropWithStripAt(editor, 1, slotTopLeft(1), {grabX, Strip::height / 2}).action ==
+              Drop::nothing);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What the strip says can be picked up
+// ------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The cursor is a hand exactly where a strip can be picked up", "[gui][modules][drag]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Every point in the strip, because the claim is an "exactly": the
+    /// cursor has to be a hand where a drag would start and an arrow everywhere
+    /// else, and the second half is the one that used to be wrong. Counted rather
+    /// than asserted per point -- 68 x 358 is 24 344 of them and one number is
+    /// easier to read than 24 344 green ticks.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1}));
+
+    auto *const pStrip(editor.regionInSlot(0));
+    REQUIRE(pStrip != nullptr);
+    auto &strip(*pStrip);
+
+    std::size_t disagreed{0}, handles{0}, deadSpace{0}, controls{0};
+    for (int y(0); y < Strip::height; ++y)
+        for (int x(0); x < Strip::width; ++x)
+        {
+            juce::Point<int> const point(x, y);
+            bool const canDrag(draggableAt(strip, point));
+
+            if (strip.getComponentAt(point) != &strip)
+                ++controls;
+            else
+                ++(canDrag ? handles : deadSpace);
+
+            disagreed +=
+                (cursorOver(strip, point) != (canDrag ? juce::MouseCursor::DraggingHandCursor
+                                                      : juce::MouseCursor::NormalCursor));
+        }
+
+    CHECK(disagreed == 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note All three kinds of point exist, which is what stops the sweep passing
+    /// on a strip that is all one thing. `deadSpace` is the new one and the reason
+    /// this case was rewritten: the strip's own uncovered area used to *be* the
+    /// draggable region, so a slip of a few pixels off a knob moved the module
+    /// instead of the value. Those pixels are the strip's and are not a handle.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(handles > 0);
+    CHECK(deadSpace > 0);
+    CHECK(controls > 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // The two bands, named. The sweep says the cursor agrees with the rule; these
+    // say the rule is the one that was asked for.
+    ////////////////////////////////////////////////////////////////////////////
+
+    // The top corner, beside the eject `X` rather than on it.
+    CHECK(draggableAt(strip, {1, 1}));
+    CHECK(cursorOver(strip, {1, 1}) == juce::MouseCursor::DraggingHandCursor);
+
+    // The effect's name, under the blue rule.
+    juce::Point<int> const name(Strip::width / 2, Strip::height - 2);
+    CHECK(draggableAt(strip, name));
+    CHECK(cursorOver(strip, name) == juce::MouseCursor::DraggingHandCursor);
+
+    /// \note And the rule is exactly where the strip draws it: one pixel above is
+    /// the effect's, one pixel below is the handle's.
+    CHECK(strip.isDragHandle({1, Strip::nameRule}));
+    CHECK_FALSE(strip.isDragHandle({1, Strip::nameRule - 1}));
+
+    /// \note The top band follows the eject button's artwork rather than a
+    /// constant, so it is held to a shape rather than to a number: tall enough to
+    /// hit, and nowhere near the effect's controls.
+    CHECK(strip.isDragHandle({1, 10}));
+    CHECK_FALSE(strip.isDragHandle({1, Strip::height / 4}));
+
+    // A control, which is not a place a drag starts...
+    auto const knob(strip.effectSpecificParameterControl(0).widget().getBounds().getCentre());
+    CHECK_FALSE(draggableAt(strip, knob));
+    CHECK(cursorOver(strip, knob) == juce::MouseCursor::NormalCursor);
+
+    // ...and neither is the strip beside one, which is what changed.
+    juce::Point<int> const beside(0, Strip::nameRule - 1);
+    REQUIRE(strip.getComponentAt(beside) == &strip);
+    CHECK_FALSE(draggableAt(strip, beside));
+    CHECK(cursorOver(strip, beside) == juce::MouseCursor::NormalCursor);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What the drop does
+// ------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   The rack and the chain, both, and they are not the same check. The rack is
+/// told first so that the strips move where the user let go of them, and the
+/// engine is told second; a permutation applied to one and not the other is a
+/// window that looks right and plays the old order.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Dropping a strip on another changes the two places", "[gui][modules][drag]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2, 3, 4}));
+
+    REQUIRE(chainOrder(instance) == std::vector<int>{0, 1, 2, 3, 4});
+
+    // Not neighbours, which is the case a single move cannot express.
+    editor.applyModuleDrop(1, {Drop::swap, 3});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{0, 3, 2, 1, 4});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{0, 3, 2, 1, 4});
+
+    // Neighbours, where the swap is a move and the second one would be a no-op.
+    editor.applyModuleDrop(0, {Drop::swap, 1});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{3, 0, 2, 1, 4});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{3, 0, 2, 1, 4});
+
+    // ...and the ends, which is the widest swap the rack has.
+    editor.applyModuleDrop(4, {Drop::swap, 0});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{4, 0, 2, 1, 3});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{4, 0, 2, 1, 3});
+}
+
+TEST_CASE("Dropping a strip between two shifts the rest along", "[gui][modules][drag]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2, 3, 4}));
+
+    REQUIRE(chainOrder(instance) == std::vector<int>{0, 1, 2, 3, 4});
+
+    // The first to the back: everything else moves down one.
+    editor.applyModuleDrop(0, {Drop::insert, 5});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{1, 2, 3, 4, 0});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{1, 2, 3, 4, 0});
+
+    // The last to the front: everything else moves up one.
+    editor.applyModuleDrop(4, {Drop::insert, 0});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{0, 1, 2, 3, 4});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{0, 1, 2, 3, 4});
+
+    /// \note A gap beyond the source names a slot one lower once the strip has
+    /// left it, and this is the case that tells a right answer from an off-by-one:
+    /// slot 1 into gap 3 lands between what were slots 2 and 3.
+    editor.applyModuleDrop(1, {Drop::insert, 3});
+    editor.resyncModuleRack();
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{0, 2, 1, 3, 4});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{0, 2, 1, 3, 4});
+}
+
+TEST_CASE("A drop of nothing leaves the rack alone", "[gui][modules][drag]")
+{
+    /// \note Which is also what a plain click on a strip is: `mouseUp` reaches
+    /// moduleDragEnd() whether or not a drag ever started, and a click is let go
+    /// inside the strip it started in.
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    editor.applyModuleDrop(1, {});
+    editor.resyncModuleRack();
+
+    CHECK(chainOrder(instance) == std::vector<int>{0, 1, 2});
+    CHECK(rackOrder(editor, 3) == std::vector<int>{0, 1, 2});
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What the drag draws
+// -------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   The two drops look different because they *are* different, and the drawing
+/// is the only warning a user gets before letting go. Measured off the picture
+/// rather than off the indicator's bounds, for the reason overlayPanelTests.cpp
+/// gives: what would be wrong is what is on the screen.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A swap fills the strip it would change places with", "[gui][modules][drag]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    auto const idle(rendered(editor));
+
+    editor.showModuleDrop({Drop::swap, 2});
+    auto const marked(rendered(editor));
+
+    // The target strip is filled -- most of it, not an edge of it...
+    CHECK(differenceOver(idle, marked, slotRectangle(2)) > 0.66);
+    // ...and it is the only one that changed, which is what "this one" means.
+    CHECK(differenceOver(idle, marked, slotRectangle(0)) == 0);
+    CHECK(differenceOver(idle, marked, slotRectangle(1)) == 0);
+
+    editor.showModuleDrop({});
+    CHECK(differenceOver(idle, rendered(editor), slotRectangle(2)) == 0);
+}
+
+TEST_CASE("An insert draws a line between two strips", "[gui][modules][drag]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    auto const idle(rendered(editor));
+
+    editor.showModuleDrop({Drop::insert, 2});
+    auto const marked(rendered(editor));
+
+    /// \note A line, so what it changes is a sliver of each of the two strips it
+    /// is between and nothing else. The 0.2 is the other side of the swap case's
+    /// 0.66: four pixels of a 68 px strip is 6 %, and a filled strip would be
+    /// well over either number.
+    CHECK(differenceOver(idle, marked, slotRectangle(1)) > 0);
+    CHECK(differenceOver(idle, marked, slotRectangle(1)) < 0.2);
+    CHECK(differenceOver(idle, marked, slotRectangle(2)) > 0);
+    CHECK(differenceOver(idle, marked, slotRectangle(2)) < 0.2);
+    // The strip that is not beside the gap is untouched.
+    CHECK(differenceOver(idle, marked, slotRectangle(0)) == 0);
+
+    // And the gap at the very front is drawable too, which is the edge case:
+    // half of that line is outside the rack.
+    editor.showModuleDrop({Drop::insert, 0});
+    CHECK(differenceOver(idle, rendered(editor), slotRectangle(0)) > 0);
+
+    editor.showModuleDrop({});
+    CHECK(differenceOver(idle, rendered(editor), slotRectangle(0)) == 0);
+}

--- a/tests/gui/overlayPanelTests.cpp
+++ b/tests/gui/overlayPanelTests.cpp
@@ -107,26 +107,58 @@ juce::Image rendered(Editor &editor)
     return image;
 }
 
-/// \brief What fraction of \p area two renders disagree about.
+////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note The two need not be the same size, only both big enough to hold \p area:
-/// the placement cases compare the left 563 px of a grown editor against the
+/// \brief What fraction of two equally sized rectangles two renders disagree
+/// about.
+///
+/// \note A rectangle each, because the skin is not in the same place in both. An
+/// editor that has grown a column draws the skin mainAreaX to the right of where
+/// an unexpanded one draws it -- the panel is on the left -- so "is the rack the
+/// same" is a question about one rectangle *of the skin* at two positions on
+/// screen. \see withColumn() below.
+///
+/// \note The two images need not be the same size, only each big enough to hold
+/// its own rectangle: the placement cases compare a grown editor against the
 /// editor it grew from, which is the whole question those cases ask.
-double differenceOver(juce::Image const &left, juce::Image const &right,
-                      juce::Rectangle<int> const &area)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+double differenceOver(juce::Image const &left, juce::Rectangle<int> const &leftArea,
+                      juce::Image const &right, juce::Rectangle<int> const &rightArea)
 {
-    REQUIRE(right.getBounds().contains(area));
-    REQUIRE(left.getBounds().contains(area));
+    REQUIRE(leftArea.getWidth() == rightArea.getWidth());
+    REQUIRE(leftArea.getHeight() == rightArea.getHeight());
+    REQUIRE(left.getBounds().contains(leftArea));
+    REQUIRE(right.getBounds().contains(rightArea));
 
     juce::Image::BitmapData const leftPixels(left, juce::Image::BitmapData::readOnly);
     juce::Image::BitmapData const rightPixels(right, juce::Image::BitmapData::readOnly);
 
-    std::size_t different{0};
-    for (int y(area.getY()); y < area.getBottom(); ++y)
-        for (int x(area.getX()); x < area.getRight(); ++x)
-            different += (leftPixels.getPixelColour(x, y) != rightPixels.getPixelColour(x, y));
+    auto const offset(rightArea.getPosition() - leftArea.getPosition());
 
-    return double(different) / double(area.getWidth() * area.getHeight());
+    std::size_t different{0};
+    for (int y(leftArea.getY()); y < leftArea.getBottom(); ++y)
+        for (int x(leftArea.getX()); x < leftArea.getRight(); ++x)
+            different += (leftPixels.getPixelColour(x, y) !=
+                          rightPixels.getPixelColour(x + offset.x, y + offset.y));
+
+    return double(different) / double(leftArea.getWidth() * leftArea.getHeight());
+}
+
+/// The same rectangle in both, which is every case where neither editor moved.
+double differenceOver(juce::Image const &left, juce::Image const &right,
+                      juce::Rectangle<int> const &area)
+{
+    return differenceOver(left, area, right, area);
+}
+
+/// \brief Where an editor with a panel column draws \p skinArea: the panel takes
+/// the left edge and the skin moves right by mainAreaX to make room.
+/// \see SpectrumWorxEditor::MainArea.
+juce::Rectangle<int> withColumn(juce::Rectangle<int> const &skinArea)
+{
+    return skinArea.translated(Editor::mainAreaX, 0);
 }
 
 /// \brief The smallest rectangle holding every pixel two renders disagree about
@@ -276,12 +308,15 @@ TEST_CASE("Clicking the logo opens the About page, not an empty panel", "[gui][o
     REQUIRE(differenceOver(closed, rendered(editor), overlayRectangle()) == 0);
 
     /// \note (37, 321) is the middle of the logo's hit area, which
-    /// `SpectrumWorxEditor::mouseDown` spells as {12, 290, 51, 63}.
+    /// `MainArea::mouseDown` spells as {12, 290, 51, 63} -- and the main area is
+    /// what the click goes to, because the logo is a position in the skin and the
+    /// skin is that component rather than the editor.
     juce::Point<float> const logo(37, 321);
-    static_cast<juce::Component &>(editor).mouseDown(juce::MouseEvent(
-        juce::Desktop::getInstance().getMainMouseSource(), logo,
-        juce::ModifierKeys(juce::ModifierKeys::leftButtonModifier), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-        &editor, &editor, juce::Time(), logo, juce::Time(), 1, false));
+    auto &skin(static_cast<juce::Component &>(editor.mainArea()));
+    skin.mouseDown(juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(), logo,
+                                    juce::ModifierKeys(juce::ModifierKeys::leftButtonModifier),
+                                    1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &skin, &skin, juce::Time(), logo,
+                                    juce::Time(), 1, false));
 
     auto const clicked(rendered(editor));
 
@@ -388,7 +423,8 @@ TEST_CASE("What a plugin opens with is the column, with presets in it", "[gui][o
     CHECK(drawnFractionOver(opened, panelColumnRectangle()) > 0);
 
     SWTest::Instance bare;
-    CHECK(differenceOver(opened, rendered(overlayEditor(bare)), moduleRack()) == 0);
+    CHECK(differenceOver(opened, withColumn(moduleRack()), rendered(overlayEditor(bare)),
+                         moduleRack()) == 0);
 
     /// \note And the same picture as asking for the browser by hand, which is
     /// what says the resting panel is the browser rather than something that
@@ -426,9 +462,9 @@ TEST_CASE("A panel gets a column of its own rather than the module strips", "[gu
 
     // The browser is in the new column...
     CHECK(drawnFractionOver(open, panelColumnRectangle()) > 0);
-    CHECK(differenceOver(closed, open, overlayRectangle()) == 0);
+    CHECK(differenceOver(closed, overlayRectangle(), open, withColumn(overlayRectangle())) == 0);
     // ...and the rack the user was working on is untouched, which is the point.
-    CHECK(differenceOver(closed, open, moduleRack()) == 0);
+    CHECK(differenceOver(closed, moduleRack(), open, withColumn(moduleRack())) == 0);
 
     // Shutting it gives the space back and asks for that too.
     editor.showPresetBrowser(false);

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -203,7 +203,10 @@ class EditorPage final : public juce::Component
         setSize(zoomed_->getWidth(), zoomed_->getHeight());
 
         if (withModuleInFirstSlot)
+        {
             fillFirstSlot();
+            showModuleDrop();
+        }
 
         if (openPresetBrowser)
         {
@@ -360,6 +363,47 @@ class EditorPage final : public juce::Component
         ///
         ////////////////////////////////////////////////////////////////////////
         editor_->resyncModuleRack();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief SW_SHOW_UI_MODULE_DROP -- what dragging a strip over the rack
+    /// looks like. "swap:<slot>" fills the strip a drop would change places
+    /// with; "insert:<gap>" draws the line a drop would open the rack at.
+    ///
+    /// \note Which of the two indications is right is a question for an eye.
+    /// tests/gui/moduleDragTests.cpp can say that a swap fills its target and an
+    /// insert draws a sliver between two, and cannot say whether either reads as
+    /// an invitation to let go of the mouse.
+    ///
+    /// \note Through showModuleDrop() rather than a real drag, for the same
+    /// reason that file gives: a JUCE drag needs a window, and this page renders
+    /// offscreen.
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    void showModuleDrop()
+    {
+        auto const *const requested(std::getenv("SW_SHOW_UI_MODULE_DROP"));
+        if (!requested)
+            return;
+
+        auto const *const pIndex(std::strchr(requested, ':'));
+        LE_ASSERT_MSG(pIndex, "SW_SHOW_UI_MODULE_DROP: swap:<slot> or insert:<gap>.");
+        if (!pIndex)
+            return;
+
+        // Something to drop between: the page fills one slot, this fills two more.
+        for (std::uint8_t effect(1); effect < 3; ++effect)
+            editor_->addUserAddedModule(effect);
+        editor_->resyncModuleRack();
+
+        using Drop = GUI::SpectrumWorxEditor::ModuleDrop;
+        bool const swap(std::strncmp(requested, "swap", 4) == 0);
+        std::fprintf(stderr, "sw-show-ui: %s at %s\n", swap ? "swap" : "insert", pIndex + 1);
+        editor_->showModuleDrop(
+            {swap ? Drop::swap : Drop::insert, static_cast<std::uint8_t>(std::atoi(pIndex + 1))});
     }
 
     HarnessHost host_;


### PR DESCRIPTION
Two changes to the editor.

The panel column was on the right, which cost nothing to lay out -- every offset in the skin is measured from an origin that never moved -- and put the thing a user opens the plugin for at the far edge of the window. It is on the left now and the skin is what moves. What made that cheap is a new MainArea component: the skin and every widget positioned in its pixels are parented to it rather than to the editor, so the 563 x 376 coordinate system every one of them is written in is that component's and no offset in it had to change. The editor slides it right when there is a column and paints what is left of itself, which is the column's chrome and the build-stamp bar.

Dropping a strip somewhere else in the rack had one meaning: it went in the gap nearest where it was let go and everything from there on shifted along. Dropped *on* another strip it now changes places with it instead, and nothing else moves. Which of the two a drop means is the middle half of a strip against its outer quarters, and the drag says which before the mouse is let go: a filled target strip for a swap, a bright blue line in the gap for an insert. The zone runs half a strip past each end of the rack, so putting something at the front or the back does not need the strip to be over the rack at all.

A drop is aimed with the strip and not with the pointer -- the column its eject marker is drawn in -- so where it was picked up cannot move the answer. A swap is two moves of the chain, because a move is the only reordering primitive it has and a swap of two strips that are not neighbours is not one.

Closes #41
Closes #46

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>