### PR TITLE
Right-click the rack to replace, insert or add an effect

### DIFF
--- a/src/gui/editor/moduleMenuHolder.cpp
+++ b/src/gui/editor/moduleMenuHolder.cpp
@@ -103,7 +103,8 @@ struct FlatMenuAdder
 
 #pragma warning(pop)
 
-void fillMenu(Menus &menus, std::true_type /*has sub menus*/)
+/// \brief The effects themselves, which is the part that is built once.
+void fillSubMenus(Menus &menus, std::true_type /*has sub menus*/)
 {
     // Implementation note:
     //   Our own implementation of the boost::mpl::detail::execute() helper
@@ -111,15 +112,22 @@ void fillMenu(Menus &menus, std::true_type /*has sub menus*/)
     // vastly improved compilation times (on GCC atleast).
     //                                    (23.09.2010.) (Domagoj Saric)
     addModulesToMenu<0, 0>(menus, std::false_type());
+}
 
+/// \note One of each pair below is chosen by hasSubMenus and the other is not
+/// compiled into anything; which one that is is a configuration choice, not a
+/// dead function.
+[[maybe_unused]] void fillSubMenus(Menus &, std::false_type /*does not have sub menus*/) {}
+
+/// \brief What goes under the heading: one entry per group, or, with too few
+/// effects for that to be worth a level of nesting, one per effect.
+void fillTopMenu(Menus &menus, std::true_type /*has sub menus*/)
+{
     TopMenusAdder topMenusAdder(menus);
     Utility::forEach<Effects::Groups>(topMenusAdder);
 }
 
-/// \note One of the pair is chosen by hasSubMenus and the other is not compiled
-/// into anything; which one that is is a configuration choice, not a dead
-/// function.
-[[maybe_unused]] void fillMenu(Menus &menus, std::false_type /*does not have sub menus*/)
+[[maybe_unused]] void fillTopMenu(Menus &menus, std::false_type /*does not have sub menus*/)
 {
     FlatMenuAdder const adder = {menus};
     Utility::forEach<Effects::ValidIndices>(adder);
@@ -137,7 +145,17 @@ void fillMenu(Menus &menus, std::true_type /*has sub menus*/)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-ModuleMenuHolder::ModuleMenuHolder() { fillMenu(menus_, std::bool_constant<hasSubMenus>()); }
+ModuleMenuHolder::ModuleMenuHolder() { fillSubMenus(menus_, std::bool_constant<hasSubMenus>()); }
+
+ModuleMenuHolder::Menu const &ModuleMenuHolder::menuWithHeader(char const *const title)
+{
+    auto &menu(topMenu());
+    menu.clear();
+    menu.addSectionHeader(title);
+    menu.addSeparator();
+    fillTopMenu(menus_, std::bool_constant<hasSubMenus>());
+    return menu;
+}
 
 bool ModuleMenuHolder::isOwnerOfEntry(unsigned int const menuEntryID) const
 {

--- a/src/gui/editor/moduleMenuHolder.hpp
+++ b/src/gui/editor/moduleMenuHolder.hpp
@@ -63,7 +63,20 @@ class ModuleMenuHolder
     bool isOwnerOfEntry(unsigned int menuEntryID) const;
     std::uint8_t effectIndexForEntry(unsigned int menuEntryID) const;
 
-    Menu const &topMenu() const { return const_cast<ModuleMenuHolder &>(*this).topMenu(); }
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The effect list, under \p title and a separating rule.
+    ///
+    /// \note The same entries every time; only the heading changes, and it is
+    /// what says which of the several things choosing one can now mean -- adding
+    /// an effect, inserting one between two others, replacing one. The top menu
+    /// is therefore refilled per use rather than built once in the constructor:
+    /// it is a handful of strings, and the effects' own sub-menus -- the part
+    /// that is a compile-time traversal -- are still built exactly once.
+    ///                                       (14.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    Menu const &menuWithHeader(char const *title);
 
   private:
     Menu &topMenu() { return menus_.front(); }

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -25,6 +25,7 @@
 #include "le/parameters/lfo.hpp"
 #include "le/parameters/printer.hpp"
 #include "le/parameters/uiElements.hpp"
+#include "le/spectrumworx/effects/configuration/effectNames.hpp"
 #include "le/spectrumworx/presetStorage.hpp"
 #include "le/spectrumworx/presets.hpp"
 #include "le/utility/countof.hpp"
@@ -844,6 +845,236 @@ void SpectrumWorxEditor::swapModuleSlots(std::uint8_t const a, std::uint8_t cons
     host().gestureEnd();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// The right-click effect menu
+// ---------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   The same list of effects the add-module button opens, asked in three places
+/// and meaning something different in each: on a strip it replaces that effect,
+/// between two it goes in there and shifts the rest along, and past the last one
+/// it is simply added. Which of the three is the heading on the menu, so that the
+/// answer is read before anything is chosen rather than discovered afterwards.
+///
+/// \note The zones are the drag's in shape -- a band at each end of a strip means
+/// "between these two" and the middle means "this one" -- but narrower. A drag
+/// draws where it would land and can be walked back before the button is let go;
+/// a right-click is committed to the moment it goes down, and the heading is the
+/// first the user hears of which of the two they asked for. So the seam is
+/// something to be aimed at here and something to be fallen into there.
+///                                           (14.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+/// \see the note above.
+constexpr int menuInsertZone{slotWidth / 6};
+static_assert(menuInsertZone < insertZone, "The menu's seam is the narrower of the two.");
+} // anonymous namespace
+
+SpectrumWorxEditor::EffectMenuTarget
+SpectrumWorxEditor::effectMenuTargetAt(juce::Point<int> const position) const
+{
+    /// \note The whole rack, not the filled part of it: what is past the last
+    /// strip is where a module is added, and that is the emptiest and most
+    /// obvious place to ask for one.
+    juce::Rectangle<int> const rack(ModuleUI::horizontalOffset, ModuleUI::verticalOffset,
+                                    SW::Constants::maxNumberOfModules * slotWidth,
+                                    ModuleUI::height);
+    if (!rack.contains(position))
+        return {};
+
+    auto const filled(nextAvailableModuleSlot_);
+    auto const alongTheRack(position.getX() - ModuleUI::horizontalOffset);
+    auto const slot(static_cast<std::uint8_t>(alongTheRack / slotWidth));
+
+    if (slot >= filled)
+        return {EffectMenuTarget::append, filled};
+
+    /// \note And a full rack has no gaps to insert into, so its strips are
+    /// replaceable edge to edge. Offering an insert that would have to drop
+    /// somebody's last module to make room is the one answer nobody wants.
+    if (filled < SW::Constants::maxNumberOfModules)
+    {
+        auto const acrossTheStrip(alongTheRack % slotWidth);
+        if (acrossTheStrip < menuInsertZone)
+            return {EffectMenuTarget::insert, slot};
+        if (acrossTheStrip >= (slotWidth - menuInsertZone))
+        {
+            /// \note Except off the right of the last strip, which is the end of
+            /// the rack rather than a gap in it -- and inserting there is adding.
+            /// Said as an add so that the heading does not change across a
+            /// boundary the user cannot see and the action does not.
+            auto const gap(static_cast<std::uint8_t>(slot + 1));
+            return (gap < filled) ? EffectMenuTarget{EffectMenuTarget::insert, gap}
+                                  : EffectMenuTarget{EffectMenuTarget::append, filled};
+        }
+    }
+
+    return {EffectMenuTarget::replace, slot};
+}
+
+/// \note A replacement names what it would replace -- "Replace Tonal Effect" --
+/// because that is the one of the three where the user has pointed at something
+/// in particular, and a heading that read "Replace with" left them checking which
+/// strip the menu had opened over. The other two point at a gap, which has no
+/// name.
+juce::String SpectrumWorxEditor::effectMenuHeader(EffectMenuTarget const target) const
+{
+    switch (target.action)
+    {
+    case EffectMenuTarget::replace:
+    {
+        auto const effect(effectInRackSlot(target.slot));
+        /// \note An empty slot cannot be reached from effectMenuTargetAt(), which
+        /// only names a replacement for a slot with a strip in it. Guarded rather
+        /// than asserted because the alternative is indexing the name table with
+        /// `noModule`.
+        if (effect == AutomatedModuleChain::noModule)
+            return "Replace effect";
+        return juce::String("Replace ") + Effects::effectName(static_cast<std::uint8_t>(effect)) +
+               " Effect";
+    }
+    case EffectMenuTarget::insert:
+        return "Insert effect";
+    case EffectMenuTarget::append:
+        return "Add effect";
+    case EffectMenuTarget::none:
+        break;
+    }
+    /// \note `none` never gets this far -- showEffectMenuAt() answers it by not
+    /// opening a menu -- so this is the switch being total, not a fourth heading.
+    return "Add effect";
+}
+
+PopupMenu::OnChosen SpectrumWorxEditor::effectMenuCallback(EffectMenuTarget const target)
+{
+    /// \note The same SafePointer the add-module button has always taken: the
+    /// menu no longer blocks, so the editor can be torn down while it is open.
+    juce::Component::SafePointer<SpectrumWorxEditor> pEditor(this);
+    return [pEditor, target](PopupMenu::OptionalID const chosenMenuEntryID) {
+        if (!pEditor || !chosenMenuEntryID.has_value())
+            return;
+        auto &editor(*pEditor);
+        LE_ASSERT(editor.moduleMenu_.isOwnerOfEntry(*chosenMenuEntryID));
+        editor.applyEffectMenuChoice(target,
+                                     editor.moduleMenu_.effectIndexForEntry(*chosenMenuEntryID));
+    };
+}
+
+void SpectrumWorxEditor::showEffectMenuAt(juce::Point<int> const screenPosition)
+{
+    auto const target(effectMenuTargetAt(mainArea_.getLocalPoint(nullptr, screenPosition)));
+    if (target.action == EffectMenuTarget::none)
+        return;
+
+    auto const header(effectMenuHeader(target));
+    moduleMenu_.menuWithHeader(header.toRawUTF8())
+        .showAtScreenPosition(screenPosition, effectMenuCallback(target));
+}
+
+void SpectrumWorxEditor::applyEffectMenuChoice(EffectMenuTarget const target,
+                                               std::uint8_t const effectIndex)
+{
+    LE_ASSERT(isThisTheGUIThread());
+
+    switch (target.action)
+    {
+    case EffectMenuTarget::replace:
+        replaceModuleInSlot(target.slot, effectIndex);
+        return;
+    case EffectMenuTarget::insert:
+        insertModuleAtGap(target.slot, effectIndex);
+        return;
+    case EffectMenuTarget::append:
+        addUserAddedModule(effectIndex);
+        return;
+    case EffectMenuTarget::none:
+        return;
+    }
+}
+
+void SpectrumWorxEditor::replaceModuleInSlot(std::uint8_t const slot,
+                                             std::uint8_t const effectIndex)
+{
+    /// \note Not an assertion, for removeModule()'s reason: the menu is
+    /// asynchronous, so the strip it was opened on can leave the rack -- a host
+    /// changing a slot, a preset arriving -- while it is down.
+    if (slot >= nextAvailableModuleSlot_)
+        return;
+    if (effectInRackSlot(slot) == static_cast<std::int8_t>(effectIndex))
+        return; // Already that effect; nothing to tell anybody.
+
+    /// \see the note in applyModuleDrop() for why the chain is not walked while
+    /// the host is being told about it.
+    Host2PluginInteropControler::AutomationBlocker const automationBlocker(
+        /*host*/ moduleChainOwner /*mrmlj*/ ());
+
+    if (!setModuleInSlot(slot, static_cast<std::int8_t>(effectIndex)))
+        return; // The effect is not in this build; nothing was asked of the engine.
+
+    /// \note As the add-module menu does: what the user just asked for is what
+    /// they are about to reach for.
+    slotAwaitingFocus_ = slot;
+
+    host().gestureBegin("Replace module");
+    host().moduleChangedByUser(slot, static_cast<std::int8_t>(effectIndex));
+    host().gestureEnd();
+
+    refreshModuleRackAsync();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::insertModuleAtGap()
+// ---------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Added on the end and then moved, because those are the two things the
+/// chain can be asked for and an insert is not one of them. Both edits reach the
+/// engine through the same ring and it drains the whole ring per block, so the
+/// two are one change as far as anything processing is concerned -- the same
+/// reasoning swapModuleSlots() runs on.
+///
+/// \note No strip is moved here, unlike a drag: the module the user asked for has
+/// no strip yet -- it gets one when resyncModuleRack() next runs -- so there is
+/// nothing to move it *around*, and the rack is left as it is until then. Which
+/// is also what makes effectInRackSlot() below the right thing to ask: it still
+/// describes the rack the menu was opened over.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::insertModuleAtGap(std::uint8_t const gap, std::uint8_t const effectIndex)
+{
+    auto const filled(nextAvailableModuleSlot_);
+    if ((gap >= filled) || (filled >= SW::Constants::maxNumberOfModules))
+        return; // The rack changed under the open menu. \see replaceModuleInSlot().
+
+    Host2PluginInteropControler::AutomationBlocker const automationBlocker(
+        /*host*/ moduleChainOwner /*mrmlj*/ ());
+
+    if (!setModuleInSlot(filled, static_cast<std::int8_t>(effectIndex)))
+        return; // The effect is not in this build; nothing was asked of the engine.
+    editorHost().editModuleMove(filled, gap);
+
+    slotAwaitingFocus_ = gap;
+    moduleAdded();
+
+    /// \note The new module, and every one it pushed along -- which is
+    /// removeModule()'s loop with the shift the other way.
+    host().gestureBegin("Insert module");
+    host().moduleChangedByUser(gap, static_cast<std::int8_t>(effectIndex));
+    for (std::uint8_t moved(gap + 1); moved <= filled; ++moved)
+        host().moduleChangedByUser(moved, effectInRackSlot(moved - 1));
+    host().gestureEnd();
+
+    refreshModuleRackAsync();
+}
+
 void SpectrumWorxEditor::setLastModulePosition(std::uint_fast8_t const slotIndex)
 {
     LE_ASSERT(slotIndex <= SW::Constants::maxNumberOfModules);
@@ -958,8 +1189,18 @@ void SpectrumWorxEditor::MainArea::paint(juce::Graphics &graphics)
 /// the rectangle is a position in the skin -- which is what this component's
 /// coordinates are and what the editor's stopped being when the panel column
 /// went to the left.
+///
+/// \note And the right button, which is the rack's empty slots asking for an
+/// effect. The strips have their own handler for it; this is what is left of the
+/// skin underneath them. \see showEffectMenuAt().
 void SpectrumWorxEditor::MainArea::mouseDown(juce::MouseEvent const &event)
 {
+    if (event.mods.isPopupMenu())
+    {
+        editor().showEffectMenuAt(event.getScreenPosition());
+        return;
+    }
+
     juce::Rectangle<int> const logoArea(12, 290, 51, 63);
     if (logoArea.contains(event.x, event.y))
     {
@@ -2111,18 +2352,11 @@ void SpectrumWorxEditor::ModuleMenuButton::clicked()
     /// main area now, not the editor. \see MainArea.
     SpectrumWorxEditor &editor(SpectrumWorxEditor::fromChild(*this));
     LE_ASSERT(editor.nextAvailableModuleSlot_ < SW::Constants::maxNumberOfModules);
-    /// \note The menu no longer blocks, so the editor can be torn down while it
-    /// is open -- a host closing the window under it. A SafePointer to it, and
-    /// the reference is only taken once the callback has proved it is alive.
-    juce::Component::SafePointer<SpectrumWorxEditor> pEditor(&editor);
-    editor.moduleMenu_.topMenu().showCenteredAtRight(
-        *this, [pEditor](PopupMenu::OptionalID const chosenMenuEntryID) {
-            if (!pEditor || !chosenMenuEntryID.has_value())
-                return;
-            auto &editor(*pEditor);
-            LE_ASSERT(editor.moduleMenu_.isOwnerOfEntry(*chosenMenuEntryID));
-            editor.addUserAddedModule(editor.moduleMenu_.effectIndexForEntry(*chosenMenuEntryID));
-        });
+
+    EffectMenuTarget const target{EffectMenuTarget::append, editor.nextAvailableModuleSlot_};
+    auto const header(editor.effectMenuHeader(target));
+    editor.moduleMenu_.menuWithHeader(header.toRawUTF8())
+        .showCenteredAtRight(*this, editor.effectMenuCallback(target));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -872,6 +872,70 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
   public:
     ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What choosing an effect from the right-click menu would do, which
+    /// depends on where the menu was opened. \see effectMenuTargetAt().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    struct EffectMenuTarget
+    {
+        enum Action : std::uint8_t
+        {
+            /// Somewhere the menu is not offered at all.
+            none,
+            /// Take over `slot`, keeping the rack the length it is.
+            replace,
+            /// Go into the gap `slot`, shifting the rest along.
+            insert,
+            /// Go on the end, which is what the add-module button does.
+            append
+        }; // enum Action
+
+        Action action{none};
+
+        /// A slot index for `replace`; a gap index for `insert`; unused for the
+        /// other two.
+        std::uint8_t slot{0};
+    }; // struct EffectMenuTarget
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What a right-click at \p position -- in the skin's coordinates,
+    /// which are mainArea()'s -- offers to do. \see the definition.
+    ///
+    /// \note Public for the same reason moduleDropAt() is: which of three things
+    /// a point in the rack means is geometry, and a headless run can ask it.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    EffectMenuTarget effectMenuTargetAt(juce::Point<int> position) const;
+
+    /// \brief What the menu is headed with, which is how the user is told which
+    /// of the three they are about to do -- and, for a replacement, which strip
+    /// it would be done to. \see the definition.
+    juce::String effectMenuHeader(EffectMenuTarget) const;
+
+    /// \brief Opens the effect menu for whatever is under \p screenPosition, or
+    /// nothing if that is not somewhere it is offered.
+    void showEffectMenuAt(juce::Point<int> screenPosition);
+
+    /// \brief Puts \p effectIndex where \p target says. Public for the same
+    /// reason applyModuleDrop() is: the only other way here is an open menu.
+    void applyEffectMenuChoice(EffectMenuTarget target, std::uint8_t effectIndex);
+
+  private:
+    /// \brief The callback that hands what was chosen to applyEffectMenuChoice(),
+    /// shared by the two places the menu is opened from.
+    PopupMenu::OnChosen effectMenuCallback(EffectMenuTarget target);
+
+    /// \brief Swaps the effect in \p slot for \p effectIndex, in place.
+    void replaceModuleInSlot(std::uint8_t slot, std::uint8_t effectIndex);
+
+    /// \brief Puts \p effectIndex in the gap \p gap. \see the definition.
+    void insertModuleAtGap(std::uint8_t gap, std::uint8_t effectIndex);
+
+  public:
+    ////////////////////////////////////////////////////////////////////////////
     /// \internal
     /// \class SampleArea
     ///
@@ -1196,7 +1260,8 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     EditorKnob in_, out_, mix_;
 
-    ModuleMenuHolder const moduleMenu_;
+    /// \note Not const: its heading is set per use. \see menuWithHeader().
+    ModuleMenuHolder moduleMenu_;
     ModuleMenuButton moduleMenuButton_;
     DropIndicator dropIndicator_;
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -537,7 +537,7 @@ void PopupMenu::addItem(ItemID const newItemId, char const *const newItemText,
 {
     juce::String text(newItemText);
     updateDimensionsForNewItem(text);
-    items_.push_back({newItemId, std::move(text), icon, enabled, false, nullptr});
+    items_.push_back({newItemId, std::move(text), icon, enabled, false, false, nullptr});
 }
 
 void PopupMenu::addSubMenu(PopupMenu &subMenu, char const *const name)
@@ -545,7 +545,7 @@ void PopupMenu::addSubMenu(PopupMenu &subMenu, char const *const name)
     LE_ASSERT(name);
     juce::String text(name);
     updateDimensionsForNewItem(text);
-    items_.push_back({0, std::move(text), nullptr, true, false, &subMenu});
+    items_.push_back({0, std::move(text), nullptr, true, false, false, &subMenu});
 }
 
 void PopupMenu::addSectionHeader(char const *const title)
@@ -553,8 +553,12 @@ void PopupMenu::addSectionHeader(char const *const title)
     LE_ASSERT(title);
     juce::String text(title);
     updateDimensionsForNewItem(text);
-    items_.push_back({0, std::move(text), nullptr, false, true, nullptr});
+    items_.push_back({0, std::move(text), nullptr, false, true, false, nullptr});
 }
+
+/// \note Nothing added to the measured height: a rule is a few pixels and the
+/// height is only used to centre showCenteredAtRight().
+void PopupMenu::addSeparator() { items_.push_back({0, {}, nullptr, false, false, true, nullptr}); }
 
 void PopupMenu::updateDimensionsForNewItem(juce::String const &itemText)
 {
@@ -583,7 +587,9 @@ juce::PopupMenu PopupMenu::build(int const tickedIndex) const
     for (int index(0); index < static_cast<int>(items_.size()); ++index)
     {
         auto const &item(items_[static_cast<std::size_t>(index)]);
-        if (item.isSectionHeader)
+        if (item.isSeparator)
+            menu.addSeparator();
+        else if (item.isSectionHeader)
             menu.addSectionHeader(item.text);
         else if (item.pSubMenu)
             menu.addSubMenu(item.text, item.pSubMenu->build(item.pSubMenu->tickedIndex_), true);
@@ -625,6 +631,12 @@ void PopupMenu::showCenteredBelow(juce::Component const &owner, OnChosen onChose
     showAt(point.getX(), point.getY(), width, owner.getHeight(), std::move(onChosen));
 }
 
+void PopupMenu::showAtScreenPosition(juce::Point<int> const screenPosition, OnChosen onChosen) const
+{
+    showAt(static_cast<unsigned int>(screenPosition.getX()),
+           static_cast<unsigned int>(screenPosition.getY()), 1, 1, std::move(onChosen));
+}
+
 void PopupMenu::showAt(unsigned int const x, unsigned int const y, unsigned int const width,
                        unsigned int const height, OnChosen onChosen) const
 {
@@ -654,6 +666,11 @@ void PopupMenu::clear()
 }
 
 unsigned int PopupMenu::numberOfItems() const { return static_cast<unsigned int>(items_.size()); }
+
+juce::String const &PopupMenu::getItemText(unsigned int const itemIndex) const
+{
+    return items_[itemIndex].text;
+}
 
 PopupMenuWithSelection::PopupMenuWithSelection() : currentSelection_(0), currentSelectionID_(0) {}
 
@@ -747,11 +764,6 @@ void PopupMenuWithSelection::showCenteredBelow(juce::Component const &owner,
         owner, [this, onSelection = std::move(onSelection)](OptionalID const &chosen) {
             onSelection(handleNewSelection(chosen));
         });
-}
-
-juce::String const &PopupMenuWithSelection::getItemText(unsigned int const itemIndex) const
-{
-    return items()[itemIndex].text;
 }
 
 ComboBox::ComboBox(juce::Component &parent, Artwork const &normalBackground,

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -574,15 +574,20 @@ class PopupMenu
                  bool enabled = true);
     void addSubMenu(PopupMenu &, char const *name);
     void addSectionHeader(char const *title);
+    void addSeparator();
 
     void clear();
 
     unsigned int numberOfItems() const;
+    juce::String const &getItemText(unsigned int itemIndex) const;
 
     /// \note Asynchronous. JUCE 8 defaults JUCE_MODAL_LOOPS_PERMITTED to 0, and
     /// showMenu() -- which blocked until the user chose -- is gone with it.
     void showCenteredAtRight(juce::Component const &, OnChosen) const;
     void showCenteredBelow(juce::Component const &, OnChosen) const;
+    /// \brief With its corner at \p screenPosition, which is what a right-click
+    /// menu wants: it belongs to the point that was clicked, not to a widget.
+    void showAtScreenPosition(juce::Point<int> screenPosition, OnChosen) const;
 
     ////////////////////////////////////////////////////////////////////////////
     ///
@@ -608,6 +613,7 @@ class PopupMenu
         Artwork const *icon;
         bool enabled;
         bool isSectionHeader;
+        bool isSeparator;
         /// Non-owning, as it was when this held a juce::PopupMenu: sub-menus are
         /// members of the owning widget and outlive the menu.
         PopupMenu const *pSubMenu;
@@ -668,8 +674,6 @@ class PopupMenuWithSelection : public PopupMenu
     void clear();
 
     bool hasValidSelection() const;
-
-    juce::String const &getItemText(unsigned int itemIndex) const;
 
   private:
     bool handleNewSelection(OptionalID const &chosenMenuEntryID);

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -483,6 +483,14 @@ void ModuleUI::updateCursorFor(juce::Point<int> const position)
                                           : juce::MouseCursor::NormalCursor);
 }
 
+/// \note Wherever in the strip it lands, handles included: the drag is the left
+/// button's and this is the right one's, so the two never compete for a pixel.
+void ModuleUI::mouseDown(juce::MouseEvent const &event)
+{
+    if (event.mods.isPopupMenu())
+        editor().showEffectMenuAt(event.getScreenPosition());
+}
+
 void ModuleUI::mouseDrag(juce::MouseEvent const &event)
 {
     /// \note Where the mouse went *down*, not where it is: a drag that began on a

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -397,6 +397,9 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
   private: // JUCE Component overrides.
     void paint(juce::Graphics &) override;
 
+    /// \note Only the right button, which opens the effect menu; the left one is
+    /// the drag, and that starts in mouseDrag().
+    void mouseDown(juce::MouseEvent const &) override;
     void mouseDrag(juce::MouseEvent const &) override;
     void mouseEnter(juce::MouseEvent const &) override;
     void mouseExit(juce::MouseEvent const &) noexcept override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(sw-plugin-tests
         gui/buildStampTests.cpp
         gui/lfoDisplayTests.cpp
         gui/moduleControlFocusTests.cpp
+        gui/effectMenuTests.cpp
         gui/moduleDragTests.cpp
         gui/overlayPanelTests.cpp
         gui/pathsTests.cpp

--- a/tests/gui/effectMenuTests.cpp
+++ b/tests/gui/effectMenuTests.cpp
@@ -1,0 +1,433 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// effectMenuTests.cpp
+/// -------------------
+///
+///   The right-click effect menu, which is one list of effects meaning three
+/// different things. On a strip, choosing one replaces that effect; between two
+/// strips it goes in there and the rest shift along; past the last strip it is
+/// added. Which of the three is decided by where the click landed and announced
+/// by the menu's heading, so the two halves are asked separately here: where a
+/// point puts the menu, and what choosing from it then does to the chain.
+///
+/// \note The menu is not opened. `showMenuAsync` wants a desktop and a modal
+/// manager that a headless run has neither of; what it would decide and what it
+/// would do are both reachable without one, and they are the parts that can be
+/// wrong. \see moduleDragTests.cpp, which is the same split for the same rack.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module: the module chain downcasts a
+/// node to it, and this is the header with the complete type.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "gui/editor/moduleMenuHolder.hpp"
+#include "gui/modules/moduleUI.hpp"
+
+#include "le/spectrumworx/effects/configuration/effectNames.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using Editor = GUI::SpectrumWorxEditor;
+using Target = Editor::EffectMenuTarget;
+using Strip = GUI::ModuleUI;
+
+constexpr int slotWidth{Strip::width + Strip::distance};
+constexpr std::uint8_t rackSlots{SW::Constants::maxNumberOfModules};
+
+/// The middle of the strip drawn in \p slot, which is where a replacement is asked.
+juce::Point<int> overSlot(std::uint8_t const slot)
+{
+    return {Strip::horizontalOffset + (slot * slotWidth) + (slotWidth / 2),
+            Strip::verticalOffset + (Strip::height / 2)};
+}
+
+/// The boundary between two strips, which is where an insert is asked.
+juce::Point<int> overGap(std::uint8_t const gap)
+{
+    return {Strip::horizontalOffset + (gap * slotWidth),
+            Strip::verticalOffset + (Strip::height / 2)};
+}
+
+/// \brief An editor with \p effects, one strip each, in the order given.
+///
+/// \note Overlay placement, so that the skin's coordinates are the editor's --
+/// every point above is a position in the skin. \see moduleDragTests.cpp.
+Editor &rackOf(SWTest::Instance &instance, std::vector<std::uint8_t> const &effects)
+{
+    instance.openEditor(Editor::PanelPlacement::overlay);
+    auto &editor(instance.editor());
+    for (auto const effect : effects)
+        editor.addUserAddedModule(effect);
+    /// \note By hand: adding a module ends in a posted resync and a test has no
+    /// message loop to deliver it.
+    editor.resyncModuleRack();
+    return editor;
+}
+
+/// What the chain is playing, as effect indices, which is the answer that matters.
+std::vector<int> chainOrder(SWTest::Instance const &instance)
+{
+    auto &chain(const_cast<SWTest::Instance &>(instance).core().program().moduleChain());
+    std::vector<int> order;
+    for (std::uint8_t slot(0); slot < chain.size(); ++slot)
+        order.push_back(chain.moduleAs<SW::Module>(slot)->effectTypeIndex());
+    return order;
+}
+
+/// The same question of the rack, which is what the user is looking at.
+std::vector<int> rackOrder(Editor &editor, std::size_t const strips)
+{
+    std::vector<int> order;
+    for (std::uint8_t slot(0); slot < strips; ++slot)
+        order.push_back(editor.regionInRackSlot(slot)->module().effectTypeIndex());
+    return order;
+}
+
+std::string describe(std::vector<int> const &order)
+{
+    std::string text;
+    for (auto const effect : order)
+        text += std::to_string(effect) + " ";
+    return text;
+}
+
+/// \brief Carries \p target out and brings the rack up to date with it, which is
+/// what the message loop would do a turn later.
+void choose(Editor &editor, Target const target, std::uint8_t const effectIndex)
+{
+    editor.applyEffectMenuChoice(target, effectIndex);
+    editor.resyncModuleRack();
+}
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Which of the three a point means
+// --------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A strip offers a replacement and the gaps between offer an insert",
+          "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    // The middle of a strip: take this one's place.
+    for (std::uint8_t slot(0); slot < 3; ++slot)
+    {
+        CAPTURE(slot);
+        auto const target(editor.effectMenuTargetAt(overSlot(slot)));
+        CHECK(target.action == Target::replace);
+        CHECK(int(target.slot) == slot);
+    }
+
+    /// \note And the boundaries between them: a gap has to have width or it is a
+    /// target nobody hits, so a band at each end of a strip belongs to the gap
+    /// beside it. These points are 8 px either side of the boundary and mean the
+    /// same insert.
+    for (auto const offset : {-8, 0, +8})
+    {
+        CAPTURE(offset);
+        auto const target(editor.effectMenuTargetAt(overGap(2).translated(offset, 0)));
+        CHECK(target.action == Target::insert);
+        CHECK(int(target.slot) == 2);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And it is a *narrow* band -- narrower than the drag's, where these
+    /// same two points are an insert. A drag draws where it would land and can be
+    /// walked back before the button is let go; a right-click is committed to the
+    /// moment it goes down. So most of a strip is the strip, and the seam is
+    /// something to be aimed at.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    for (auto const offset : {-16, +16})
+    {
+        CAPTURE(offset);
+        CHECK(editor.effectMenuTargetAt(overGap(2).translated(offset, 0)).action ==
+              Target::replace);
+    }
+
+    // The gap before the first strip is one too, which is how an effect is put
+    // at the head of the chain.
+    auto const front(editor.effectMenuTargetAt(overGap(0).translated(+4, 0)));
+    CHECK(front.action == Target::insert);
+    CHECK(int(front.slot) == 0);
+}
+
+TEST_CASE("The empty part of the rack is where an effect is added", "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1}));
+
+    // Every slot past the last strip.
+    for (std::uint8_t slot(2); slot < rackSlots; ++slot)
+    {
+        CAPTURE(slot);
+        auto const target(editor.effectMenuTargetAt(overSlot(slot)));
+        CHECK(target.action == Target::append);
+        CHECK(int(target.slot) == 2);
+    }
+
+    /// \note Including the strip edge that abuts it. That edge is an insert zone
+    /// by geometry, but the gap it names is the end of the rack -- where an
+    /// insert and an add are the same thing -- so it is called what it does,
+    /// rather than changing the heading across a boundary nothing else marks.
+    auto const lastEdge(editor.effectMenuTargetAt(overSlot(1).translated(+24, 0)));
+    CHECK(lastEdge.action == Target::append);
+
+    /// \note And an editor with no modules at all, which is the state every one
+    /// of them opens in: the whole rack is the empty part.
+    SWTest::Instance empty;
+    auto &bare(rackOf(empty, {}));
+    CHECK(bare.effectMenuTargetAt(overSlot(0)).action == Target::append);
+    CHECK(int(bare.effectMenuTargetAt(overSlot(0)).slot) == 0);
+}
+
+TEST_CASE("The menu is not offered away from the rack", "[gui][modules][menu]")
+{
+    /// \note The skin is mostly not the rack -- the spectrum display, the shared
+    /// controls, the logo -- and a right-click there is somebody missing, not
+    /// somebody asking for an effect.
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1}));
+
+    // To the left of the first strip...
+    CHECK(editor.effectMenuTargetAt({Strip::horizontalOffset - 1, overSlot(0).getY()}).action ==
+          Target::none);
+    // ...past the last slot the rack has...
+    CHECK(editor.effectMenuTargetAt(overSlot(rackSlots)).action == Target::none);
+    // ...and above and below it.
+    CHECK(editor.effectMenuTargetAt({overSlot(0).getX(), Strip::verticalOffset - 1}).action ==
+          Target::none);
+    CHECK(editor.effectMenuTargetAt({overSlot(0).getX(), Strip::verticalOffset + Strip::height + 1})
+              .action == Target::none);
+}
+
+TEST_CASE("A full rack offers replacement everywhere", "[gui][modules][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note With every slot taken there is nowhere to insert, and the only way
+    /// to make room would be to drop somebody's last module -- which is not what
+    /// anybody means by "insert". So the gaps close and the strips are
+    /// replaceable edge to edge, which is the one thing that still works.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2, 3, 4}));
+
+    REQUIRE(chainOrder(instance).size() == rackSlots);
+
+    for (std::uint8_t slot(0); slot < rackSlots; ++slot)
+    {
+        CAPTURE(slot);
+        CHECK(editor.effectMenuTargetAt(overSlot(slot)).action == Target::replace);
+        // The boundary that would be a gap in a rack with room in it.
+        auto const edge(editor.effectMenuTargetAt(overGap(slot).translated(+2, 0)));
+        CHECK(edge.action == Target::replace);
+        CHECK(int(edge.slot) == slot);
+    }
+}
+
+TEST_CASE("The heading says which of the three it is", "[gui][modules][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The heading is the whole of what tells a user that this menu is
+    /// about to replace what they right-clicked rather than add to it, so it is
+    /// held to the words rather than to "something non-empty".
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+
+    /// \note Found by name rather than assumed to be an index, so that the case
+    /// keeps meaning "the strip's own effect" if the effect list is reordered.
+    auto const tonal(Effects::effectIndex("Tonal"));
+    auto const frecho(Effects::effectIndex("Frecho"));
+    REQUIRE(tonal >= 0);
+    REQUIRE(frecho >= 0);
+
+    auto &editor(rackOf(instance, {std::uint8_t(tonal), std::uint8_t(frecho)}));
+
+    // A replacement names what it would replace, which is the strip pointed at...
+    CHECK(editor.effectMenuHeader({Target::replace, 0}) == juce::String("Replace Tonal Effect"));
+    // ...and it is *that* strip rather than the first one or a fixed word.
+    CHECK(editor.effectMenuHeader({Target::replace, 1}) == juce::String("Replace Frecho Effect"));
+
+    // The other two point at a gap, which has no name to give.
+    CHECK(editor.effectMenuHeader({Target::insert, 1}) == juce::String("Insert effect"));
+    CHECK(editor.effectMenuHeader({Target::append, 2}) == juce::String("Add effect"));
+}
+
+TEST_CASE("The effect list is the same list under any heading", "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1}));
+
+    GUI::ModuleMenuHolder holder;
+
+    /// \note Read at once, because all three are the same menu object refilled:
+    /// the effects are built once and only the heading is per use.
+    struct Shape
+    {
+        juce::String header;
+        bool ruledOff;
+        unsigned int items;
+    };
+    auto const headed([&holder, &editor](Target const target) {
+        auto const &menu(holder.menuWithHeader(editor.effectMenuHeader(target).toRawUTF8()));
+        return Shape{menu.getItemText(0), menu.getItemText(1).isEmpty(), menu.numberOfItems()};
+    });
+
+    auto const replace(headed({Target::replace, 0}));
+    CHECK(replace.header.startsWith("Replace "));
+    // The separator under it, which carries no text of its own.
+    CHECK(replace.ruledOff);
+    // ...and the effects themselves, which is what the menu is for.
+    CHECK(replace.items > 2);
+
+    auto const insert(headed({Target::insert, 1}));
+    CHECK(insert.header == juce::String("Insert effect"));
+    CHECK(insert.items == replace.items);
+
+    auto const append(headed({Target::append, 2}));
+    CHECK(append.header == juce::String("Add effect"));
+    CHECK(append.items == replace.items);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What choosing an effect does
+// ----------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   The rack and the chain, both. The rack is what the user is looking at and
+/// the chain is what is playing; an edit that reaches one and not the other is a
+/// window that looks right and plays something else.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Replacing an effect leaves the rest of the rack where it was", "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    REQUIRE(chainOrder(instance) == std::vector<int>{0, 1, 2});
+
+    choose(editor, {Target::replace, 1}, 3);
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{0, 3, 2});
+    CHECK(rackOrder(editor, 3) == std::vector<int>{0, 3, 2});
+
+    // The ends too, which is where an off-by-one would land.
+    choose(editor, {Target::replace, 0}, 4);
+    choose(editor, {Target::replace, 2}, 1);
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{4, 3, 1});
+    CHECK(rackOrder(editor, 3) == std::vector<int>{4, 3, 1});
+}
+
+TEST_CASE("Inserting an effect shifts the rest along", "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1, 2}));
+
+    REQUIRE(chainOrder(instance) == std::vector<int>{0, 1, 2});
+
+    /// \note Into the middle, which is the case that tells a real insert from an
+    /// append that happened to be drawn in the right place: the chain grows by
+    /// one and everything from the gap onwards moves down a slot.
+    choose(editor, {Target::insert, 1}, 3);
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{0, 3, 1, 2});
+    CHECK(rackOrder(editor, 4) == std::vector<int>{0, 3, 1, 2});
+
+    // And at the head of the chain, which is the gap with nothing to its left.
+    choose(editor, {Target::insert, 0}, 4);
+
+    INFO("chain " << describe(chainOrder(instance)));
+    CHECK(chainOrder(instance) == std::vector<int>{4, 0, 3, 1, 2});
+    CHECK(rackOrder(editor, 5) == std::vector<int>{4, 0, 3, 1, 2});
+}
+
+TEST_CASE("Adding an effect puts it on the end", "[gui][modules][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    auto &editor(rackOf(instance, {0, 1}));
+
+    choose(editor, {Target::append, 2}, 3);
+
+    CHECK(chainOrder(instance) == std::vector<int>{0, 1, 3});
+    CHECK(rackOrder(editor, 3) == std::vector<int>{0, 1, 3});
+}
+
+TEST_CASE("A choice that would change nothing changes nothing", "[gui][modules][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Two of them, and the second is the one that matters: the menu is
+    /// asynchronous, so a rack that filled up while it was open would otherwise
+    /// have an insert applied to it with nowhere to put the module.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+
+    {
+        SWTest::Instance instance;
+        auto &editor(rackOf(instance, {0, 1, 2}));
+        auto const asked(editor.rackResyncRequests());
+
+        // The effect that is already there.
+        choose(editor, {Target::replace, 1}, 1);
+
+        CHECK(chainOrder(instance) == std::vector<int>{0, 1, 2});
+        CHECK(editor.rackResyncRequests() == asked);
+    }
+
+    {
+        SWTest::Instance instance;
+        auto &editor(rackOf(instance, {0, 1, 2, 3, 4}));
+        auto const asked(editor.rackResyncRequests());
+
+        // An insert into a rack with no room for one.
+        choose(editor, {Target::insert, 2}, 1);
+
+        CHECK(chainOrder(instance) == std::vector<int>{0, 1, 2, 3, 4});
+        CHECK(editor.rackResyncRequests() == asked);
+    }
+}


### PR DESCRIPTION
The list of effects the add-module button opens is now reachable from anywhere in the module rack, and what choosing one does depends on where the menu was opened. On a strip it replaces that effect and the rack stays the length it is; between two strips it goes in there and the rest shift along; past the last strip it is added, which is what the button has always done. The heading says which -- "Replace Tonal Effect" names the strip pointed at, so what is about to happen is read before anything is chosen rather than discovered afterwards.

The zones are shaped like the drag's, a band at each end of a strip meaning "between these two", but narrower. A drag draws where it would land and can be walked back before the button is let go; a right-click is committed to the moment it goes down. With every slot taken there is nowhere to insert, so a full rack offers replacement edge to edge instead.

An insert is an append followed by a move, because those are the two things the module chain can be asked for and an insert is not one of them. Both reach the engine through the ring it drains whole per block, so the two are one change to anything processing.

Closes #45.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>