### PR TITLE
Drop the load-on-startup and panel opacity settings

### DIFF
--- a/doc/tech/streaming_format.md
+++ b/doc/tech/streaming_format.md
@@ -268,10 +268,10 @@ calls the reader only when the element is present, so loading a `.swp` into a
 live session is not a silent reset of session state.
 
 **Its payload is deliberately empty for now.** The mechanism is the deliverable;
-the payload accrues. The first candidates, all main-thread and none of them
-parameters: `loadLastSession_`, whose own note says session state is its proper
-home; the preset browser's location and selection; and the interface settings the
-CLAP build persists nowhere at all.
+the payload accrues. The candidates, both main-thread and neither of them a
+parameter: the preset browser's location and selection; and the interface
+settings the CLAP build persists nowhere at all, so they are back at their
+defaults every time the plugin is loaded.
 
 Note what does *not* need it — the loaded sample. `<Global Sample="…">` has
 carried that since 2011, so putting state on the preset serialisation restores it

--- a/src/gui/editor/editorHost.hpp
+++ b/src/gui/editor/editorHost.hpp
@@ -252,8 +252,11 @@ class EditorHost
     /// the host, so the plugin must not offer the user a way to change it.
     virtual bool completelyDisableIOChanges() const = 0;
 
-    virtual bool shouldLoadLastSessionOnStartup() const = 0;
-    virtual void shouldLoadLastSessionOnStartup(bool) = 0;
+    /// \note `shouldLoadLastSessionOnStartup()` was a pair here, reaching a flag
+    /// nothing ever read: the checkbox on the interface page stored it and no
+    /// session was ever reloaded from it. Restoring what was open is the host's
+    /// job and every one of them does it.
+    ///                                       (14.08.2026.) (SW port)
 
   protected:
     /// Not deleted through this.

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -3007,7 +3007,6 @@ SpectrumWorxEditor::Settings::Settings() /// \throws std::bad_alloc Out of memor
                       resourceArtwork<SettingsEngineBg>().getHeight());
 
     updateEnginePage();
-    updateLoadLastSessionOnStartup();
 
     aboutPage_.showUsersGuide_.addListener(this);
 
@@ -3033,29 +3032,6 @@ SpectrumWorxEditor::Settings::~Settings()
     //getCurrentContentComponent()->fadeOutComponent( 200, 0, 0, 0.2f );
     //this->fadeOutComponent( 200, 0, 0, 0.2f );
     clearTabs();
-}
-
-void SpectrumWorxEditor::Settings::sliderValueChanged(juce::Slider *const pSlider) noexcept
-{
-    LE_ASSERT(pSlider == &interfacePage_.opacitySlider());
-    Theme::singleton().settings().globalOpacity = pSlider->getValue();
-
-    juce::Colour const tabBackground(juce::Colours::black.withAlpha(
-        static_cast<float>(std::pow(Theme::singleton().settings().globalOpacity, 14))));
-    LE_ASSERT(getTabbedButtonBar().getNumTabs() == 3);
-    for (unsigned int i(0); i < 3; ++i)
-        getTabbedButtonBar().setTabBackgroundColour(i, tabBackground);
-
-    // Force repaint
-    for (unsigned int i(0); i < static_cast<unsigned int>(juce::ComponentPeer::getNumPeers()); ++i)
-    {
-        juce::ComponentPeer &peer(*juce::ComponentPeer::getPeer(i));
-        juce::Rectangle<int> bounds(peer.getBounds());
-        bounds.setPosition(0, 0);
-        peer.repaint(bounds);
-    }
-
-    LE::Utility::ignoreUnused(pSlider);
 }
 
 #pragma warning(push)
@@ -3220,34 +3196,12 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : BackgroundImage(resourceArtwork<SettingsIntrfcBg>()),
-      /// \note "Side window & menu opacity" until 6.4, when the side windows
-      /// stopped being windows. It still drives exactly the same thing --
-      /// BackgroundImage::paint, whose only subclasses are this panel's three
-      /// pages and the preset browser -- and over the editor rather than over
-      /// the desktop it is more use than it was, not less.
-      ///                                   (01.08.2026.) (SW port)
-      opacityTitle_("Panel & menu opacity", xMargin + 7, yMargin + 3 * yStep + 15,
-                    opacityWidth + 40, 16, juce::Justification::left),
-      globalOpacity_(juce::String()),
       moduleUIMouseOverReaction_(*this, xMargin, yMargin + 0 * yStep, "Mouse over reaction"),
       lfoUpdateBehaviour_(*this, xMargin, yMargin + 1 * yStep, "LFO update behaviour"),
-      loadLastSessionOnStartup_(*this, xMargin - 4, yMargin + 2 * yStep,
-                                "Load last session on startup"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep - 15,
-                            "Hide cursor on knob drag")
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 2 * yStep, "Hide cursor on knob drag")
 {
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));
-
-    globalOpacity_.setBounds(xMargin + 7, yMargin + 3 * yStep + 12 + 20, opacityWidth, 16);
-    globalOpacity_.setSliderStyle(juce::Slider::LinearHorizontal);
-    globalOpacity_.setTextBoxStyle(juce::Slider::NoTextBox, true, 10, 12);
-    globalOpacity_.setRange(0.8, 1);
-    globalOpacity_.setValue(Theme::singleton().settings().globalOpacity,
-                            juce::dontSendNotification);
-    globalOpacity_.setDoubleClickReturnValue(true, 0.9);
-    //globalOpacity_.setTooltip               ( globalOpacity_.getName() );
-    globalOpacity_.addListener(&parent);
 
     moduleUIMouseOverReaction_.addItem(Theme::Never, "Never");
     moduleUIMouseOverReaction_.addItem(Theme::WhenParentModuleSelected, "Module selected");
@@ -3262,20 +3216,15 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     lfoUpdateBehaviour_.addItem(Theme::Always, "Always");
     lfoUpdateBehaviour_.setSelectedIndex(Theme::singleton().settings().lfoUpdateBehaviour);
 
-    loadLastSessionOnStartup_.addListener(&parent);
-
     hideCursorOnKnobDrag_.setToggleState(Theme::singleton().settings().hideCursorOnKnobDrag,
                                          juce::dontSendNotification);
     hideCursorOnKnobDrag_.addListener(&parent);
-
-    addToParentAndShow(*this, globalOpacity_);
 }
 
 void SpectrumWorxEditor::Settings::InterfacePage::paint(juce::Graphics &graphics)
 {
     graphics.setColour(juce::Colours::white);
     BackgroundImage::paint(graphics);
-    opacityTitle_.draw(graphics);
 }
 
 #pragma warning(pop)
@@ -3355,12 +3304,7 @@ SpectrumWorxEditor &SpectrumWorxEditor::Settings::editor()
 
 void SpectrumWorxEditor::Settings::buttonClicked(juce::Button *const pButton)
 {
-    if (pButton == &interfacePage_.loadLastSessionOnStartup_)
-    {
-        editor().editorHost().shouldLoadLastSessionOnStartup(
-            interfacePage_.loadLastSessionOnStartup_.getToggleState());
-    }
-    else if (pButton == &interfacePage_.hideCursorOnKnobDrag_)
+    if (pButton == &interfacePage_.hideCursorOnKnobDrag_)
     {
         Theme::settings().hideCursorOnKnobDrag =
             interfacePage_.hideCursorOnKnobDrag_.getToggleState();
@@ -3373,12 +3317,6 @@ void SpectrumWorxEditor::Settings::buttonClicked(juce::Button *const pButton)
             LE::IO::pathToJuceString(rootPath() / "Documents" / "User's Guide.PDF"),
             juce::String()));
     }
-}
-
-void SpectrumWorxEditor::Settings::updateLoadLastSessionOnStartup()
-{
-    interfacePage_.loadLastSessionOnStartup_.setToggleState(
-        editor().editorHost().shouldLoadLastSessionOnStartup(), juce::dontSendNotification);
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1063,9 +1063,7 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// \class Settings
     ////////////////////////////////////////////////////////////////////////////
 
-    class Settings : public juce::TabbedComponent,
-                     private juce::Slider::Listener,
-                     private juce::Button::Listener
+    class Settings : public juce::TabbedComponent, private juce::Button::Listener
     {
       public:
         Settings();
@@ -1079,7 +1077,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
       private:
         void refillFrameSize(Engine::Setup const &);
-        void updateLoadLastSessionOnStartup();
 
       private: // JUCE component overrides.
         void paint(juce::Graphics &) override {}
@@ -1087,9 +1084,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
       private: // JUCE ButtonListener overrides.
         void buttonClicked(juce::Button *) override;
-
-      private: // JUCE SliderListener overrides.
-        void sliderValueChanged(juce::Slider *) noexcept override;
 
       private:
         class EnginePage : public BackgroundImage
@@ -1111,7 +1105,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
           public:
             InterfacePage();
 
-            juce::Slider const &opacitySlider() const { return globalOpacity_; }
             TitledComboBox const &mouseOverComboBox() const { return moduleUIMouseOverReaction_; }
             TitledComboBox const &lfoUpdateComboBox() const { return lfoUpdateBehaviour_; }
 
@@ -1120,14 +1113,8 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
           private:
             friend class Settings;
-            static unsigned int const opacityWidth = 136;
-
-            DrawableText opacityTitle_;
-
-            juce::Slider globalOpacity_;
             TitledComboBox moduleUIMouseOverReaction_;
             TitledComboBox lfoUpdateBehaviour_;
-            LEDTextButton loadLastSessionOnStartup_;
             LEDTextButton hideCursorOnKnobDrag_;
         }; // class InterfacePage
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -437,11 +437,7 @@ juce::Font DrawableText::defaultFont()
     return font;
 }
 
-void BackgroundImage::paint(juce::Graphics &graphics)
-{
-    graphics.setOpacity(Theme::singleton().settings().globalOpacity);
-    paintImage(graphics, image());
-}
+void BackgroundImage::paint(juce::Graphics &graphics) { paintImage(graphics, image()); }
 
 Artwork const &BackgroundImage::image() const
 {

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -49,8 +49,7 @@ void paintSliderThumb(juce::Graphics &graphics, Artwork const &image, float cons
 Theme::Settings Theme::settings_;
 
 Theme::Settings::Settings()
-    : globalOpacity(0.9f), moduleUIMouseOverReaction(Never), lfoUpdateBehaviour(Always),
-      hideCursorOnKnobDrag(true)
+    : moduleUIMouseOverReaction(Never), lfoUpdateBehaviour(Always), hideCursorOnKnobDrag(true)
 {
 }
 
@@ -69,8 +68,7 @@ Theme::Theme()
     setColour(juce::PopupMenu::headerTextColourId, juce::Colours::white);
     setColour(juce::PopupMenu::highlightedBackgroundColourId, juce::Colours::transparentWhite);
     setColour(juce::PopupMenu::highlightedTextColourId, juce::Colours::white);
-    setColour(juce::PopupMenu::backgroundColourId,
-              juce::Colours::black.withAlpha(settings().globalOpacity));
+    setColour(juce::PopupMenu::backgroundColourId, juce::Colours::black);
 
     setColour(juce::TextButton::buttonColourId, juce::Colours::black);
     setColour(juce::TextButton::buttonOnColourId, blueColour());
@@ -120,7 +118,9 @@ Theme::~Theme() = default;
 
 void Theme::drawPopupMenuBackground(juce::Graphics &graphics, int const width, int const height)
 {
-    graphics.setOpacity(std::pow(settings().globalOpacity, 3));
+    /// \note The colour rather than an opacity over whatever the caller left in
+    /// the context, which is what a settings slider used to write into.
+    graphics.setColour(juce::Colours::black);
     graphics.fillRoundedRectangle(0, 0, static_cast<float>(width), static_cast<float>(height), 12);
 }
 

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -89,13 +89,15 @@ class Theme final : public juce::LookAndFeel_V2
         Always
     };
 
-    /// \note Serialised verbatim into SpectrumWorx.dat by spectrumWorx.cpp.
-    /// The layout is on disk; do not reorder it.
+    /// \note The "layout is on disk; do not reorder it" that stood here was about
+    /// SpectrumWorx.dat, which spectrumWorx.cpp wrote these out to verbatim.
+    /// Neither survives: the CLAP build persists none of this, and the note went
+    /// on outranking that fact.
+    ///                                       (14.08.2026.) (SW port)
     struct Settings
     {
         Settings();
 
-        float globalOpacity;
         ModuleUIMouseOverReaction moduleUIMouseOverReaction;
         LFOUpdateBehaviour lfoUpdateBehaviour;
         bool hideCursorOnKnobDrag;

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -2259,19 +2259,16 @@ catch (...)
 /// is a list that will grow one bullet at a time, and guessing at it now would
 /// be inventing a schema for settings nobody has asked to persist yet.
 ///
-///   The first three candidates, all `[main-thread]` and none of them
-/// parameters:
+///   The two candidates, both `[main-thread]` and neither of them a parameter:
 ///
-///   - `loadLastSession_`, whose own note on the declaration says the session
-///     state a host hands back is a better home for it than the settings file
-///     this plugin does not have;
 ///   - the preset browser's location and selection -- it does not remember where
 ///     it was, for the session case;
-///   - the interface settings (opacity, mouse-over reaction, LFO update
-///     behaviour, hide-cursor-on-knob-drag), which the CLAP build persists
-///     nowhere at all. Those are arguably user preferences rather than session
-///     state, and sst-plugininfra's userdefaults.h is the other candidate home;
-///     the two are not exclusive and surge uses both.
+///   - the interface settings (mouse-over reaction, LFO update behaviour,
+///     hide-cursor-on-knob-drag), which the CLAP build persists nowhere at all,
+///     so they are back at their defaults every time the plugin is loaded. Those
+///     are arguably user preferences rather than session state, and
+///     sst-plugininfra's userdefaults.h is the other candidate home; the two are
+///     not exclusive and surge uses both.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -294,13 +294,6 @@ class SpectrumWorxCLAP final
     /// mode parameter.
     bool completelyDisableIOChanges() const override { return false; }
 
-    /// \note There is no settings file to persist this to yet: the 2016 one
-    /// went with the plugin class that owned it, and the session state a host
-    /// hands back through clap_plugin_state is a better home for it anyway.
-    /// Held in memory so the checkbox at least tracks itself.
-    bool shouldLoadLastSessionOnStartup() const override { return loadLastSession_; }
-    void shouldLoadLastSessionOnStartup(bool const load) override { loadLastSession_ = load; }
-
   protected:
     bool init() noexcept override;
     bool activate(double sampleRate, std::uint32_t minFrames,
@@ -625,7 +618,6 @@ class SpectrumWorxCLAP final
     double sampleRate_{0};
     std::uint32_t latencyInSamples_{0};
     bool engineRunning_{false};
-    bool loadLastSession_{false};
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -181,8 +181,6 @@ class Instance final : public GUI::EditorHost
     void deregisterSampleLoadedListener(GUI::SpectrumWorxEditor const &) override {}
 
     bool completelyDisableIOChanges() const override { return false; }
-    bool shouldLoadLastSessionOnStartup() const override { return false; }
-    void shouldLoadLastSessionOnStartup(bool) override {}
 
   private:
     Engine engine_;

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -166,8 +166,6 @@ class HarnessHost final : public GUI::EditorHost
     void deregisterSampleLoadedListener(GUI::SpectrumWorxEditor const &) override {}
 
     bool completelyDisableIOChanges() const override { return false; }
-    bool shouldLoadLastSessionOnStartup() const override { return false; }
-    void shouldLoadLastSessionOnStartup(bool) override {}
 
   private:
     HarnessEngine engine_;


### PR DESCRIPTION
Two controls come off the interface page, and neither had anything left to control.

"Load last session on startup" stored a flag nobody read: no session was ever reloaded from it, in this build or in the port it came from. Restoring what was open belongs to the host and every host does it. The pair of EditorHost virtuals behind the checkbox goes with it, so the three things that implement that interface each lose a stub.

"Panel & menu opacity" was the window alpha of the panels back when they were desktop windows, which they have not been since 6.4. Panels and menus are drawn solid now. Half of that setting was already dead -- the panel backgrounds went through Artwork::draw, which sets its own opacity and ignored it -- so what changes on screen is that a popup menu no longer has the editor showing faintly through it.

Neither setting was persisted anywhere, so nothing on disk has to be migrated: the note in sessionState() saying the interface settings survive nothing is what makes removing a field from Theme::Settings free, and it now says so where it used to point at a file this plugin has not written since 2016.

Closes #50.
Closes #51.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>