### PR TITLE
Give knobs a parameter menu on the right button

### DIFF
--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -142,6 +142,14 @@ ModuleControlBase &SharedModuleControls::controlForParameter(std::uint8_t const 
 ///                                           (08.08.2026.) (SW port)
 void SharedModuleControls::focusLost(FocusChangeType)
 {
+    /// \note Not while a menu is up. These two knobs each have a right button
+    /// menu with a type-in field in it, the field takes the keyboard, and
+    /// deactivating the module from here destroys *these controls* -- so the
+    /// knob the open menu belongs to would be freed under it.
+    /// \see the note on ModuleControlImpl::focusLost().
+    if (isCurrentlyBlockedByAnotherModalComponent())
+        return;
+
     auto *const pModuleUI(editor().selectedModule());
     if (pModuleUI && !pModuleUI->hasFocus())
         pModuleUI->deactivate();

--- a/src/gui/editor/editorHost.hpp
+++ b/src/gui/editor/editorHost.hpp
@@ -38,6 +38,11 @@
 /// `fs`, for the side channel's sample file. \see io/jucePath.hpp.
 #include "filesystem/import.h"
 
+namespace juce
+{
+class PopupMenu;
+} // namespace juce
+
 namespace LE::SW
 {
 
@@ -151,6 +156,23 @@ class EditorHost
     /// The other direction: telling the host that the user moved something.
     /// Gestures, automation notifications and module chain changes.
     virtual Plugin2HostInteropControler &automation() = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Appends the host's own entries for \p parameter to \p menu -- its
+    /// automation lanes, its MIDI learn, whatever it has -- when a knob's right
+    /// button menu is being built. `[main-thread]`
+    ///
+    /// \note `clap_host_context_menu`, which is the only route a plugin has to
+    /// them, and it is optional: a host that does not implement it adds nothing
+    /// and the menu ends where the plugin's own entries do.
+    ///
+    /// \note Here rather than in the widget layer because a `clap_host *` is the
+    /// one thing on the far side of this interface that the editor cannot reach
+    /// through `core()` -- which is the test this file's header sets.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    virtual void addHostParameterEntries(ParameterID parameter, juce::PopupMenu &menu) const = 0;
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2786,6 +2786,54 @@ void SpectrumWorxEditor::LFODisplay::paint(juce::Graphics &graphics)
         paintImage(graphics, *icon, 79, 96);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::setLFOEnabled()
+// -----------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The parameter goes out through `editParameter()` and the host is told
+/// separately, which is what `LFODisplay::updateParameterAndNotifyHost<>` does
+/// for the five LFO parameters that have a ParameterID -- spelled out here
+/// because this is reachable with no LFO strip on screen at all.
+///
+/// \note `lfoStateChanged()` is not cosmetic: it is what re-keys the knob's
+/// scroll wheel and its double-click default on the answer that just changed.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::setLFOEnabled(ModuleControlBase &control, bool const enable)
+{
+    auto const moduleParameterIndex(control.moduleParameterIndex());
+    if (moduleParameterIndex >= (SW::Constants::maxNumberOfParametersPerModule - 1))
+        return; //...mrmlj...a parameter no LFO can drive...
+
+    ParameterID::LFO const lfoParameterID{
+        LE::Parameters::IndexOf<LFO::Parameters, LFO::Enabled>::value, moduleParameterIndex,
+        moduleChain().getIndexForModule(control.module())};
+
+    ParameterID parameterID;
+    parameterID.value.type = ParameterID::LFOParameter;
+    parameterID.value._.lfo = lfoParameterID;
+
+    float const value(enable ? 1.0f : 0.0f);
+    editorHost().editParameter(parameterID, value);
+    host().automatedParameterChanged(lfoParameterID, value);
+
+    control.lfoStateChanged();
+    if (lfoDisplay_ && lfoDisplay_->isFor(control))
+        lfoDisplay_->resyncEnabledSwitch();
+    updateActiveControlValue();
+    control.widget().repaint();
+}
+
+void SpectrumWorxEditor::LFODisplay::resyncEnabledSwitch()
+{
+    switch_.setToggleState(lfo().enabled(), juce::dontSendNotification);
+    repaint();
+}
+
 void SpectrumWorxEditor::LFODisplay::buttonClicked(juce::Button *const pButton)
 {
     auto &lfo(this->lfo());
@@ -2794,9 +2842,10 @@ void SpectrumWorxEditor::LFODisplay::buttonClicked(juce::Button *const pButton)
     {
         bool const enable(switch_.getToggleState());
         LE_ASSERT(enable != lfo.enabled());
-        updateParameterAndNotifyHost<LFO::Enabled>(enable);
-        control().lfoStateChanged();
-        editor().updateActiveControlValue();
+        /// \note Through the editor, which is where the knob's own menu goes as
+        /// well -- see setLFOEnabled(). The button has already toggled itself,
+        /// so the resync that comes back is a no-op here.
+        editor().setLFOEnabled(control(), enable);
     }
     else if (pButton == &typeArrow_)
     {

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -350,6 +350,22 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     ParameterID moduleControlID(ModuleControlBase const &) const;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Turns \p control's LFO on or off. `[main-thread]`
+    ///
+    /// \note One implementation with two ways in: the LFO strip's own switch,
+    /// and the knob's right button menu. `LFO::Enabled` is an exported
+    /// parameter, so this is an edit like any other -- both copies and the host
+    /// -- and not a flag the interface may set for itself.
+    ///
+    /// \note Takes the control rather than working off `activeControl()`: a
+    /// menu's callback runs whenever the user chose, and what was current when
+    /// it opened need not still be.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void setLFOEnabled(ModuleControlBase &control, bool enable);
+
     bool sharedModuleControlsActive() const { return sharedModuleControls_.has_value(); }
     bool sharedModuleControlsActiveAndFocused() const
     {
@@ -1025,6 +1041,13 @@ class SpectrumWorxEditor final : private SkinLifetime,
         ~LFODisplay();
 
         void setupForControl(ModuleControlBase &, double minimum, double maximum, double interval);
+
+        /// \brief Whether this strip is showing \p control.
+        bool isFor(ModuleControlBase const &control) const { return pModuleControl_ == &control; }
+
+        /// \brief Puts the switch back in step with the LFO, for a change made
+        /// somewhere other than by pressing it. \see setLFOEnabled().
+        void resyncEnabledSwitch();
 
         void updateForNewTimingInfo();
         void updateForChangedParameters(ModuleUI const &, std::uint8_t parameterIndex,

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -4,9 +4,15 @@
 #include "gui.hpp"
 
 #include "core/host_interop/plugin2Host.hpp" //...mrmlj...only for Plugin2HostPassiveInteropController::ParameterLabelGetter...
+#include "gui/editor/editorHost.hpp" // the host's half of a knob's menu
 #include "gui/editor/spectrumWorxEditor.hpp"
 
 #include "le/spectrumworx/engine/setup.hpp"
+
+/// print() and its inverse: what an editor knob draws inside its face, and what
+/// its menu's type-in field reads back. \see EditorKnob::setParameterFromText().
+#include "le/parameters/parser.hpp"
+
 #include "le/utility/cstdint.hpp"
 #include "le/utility/lexicalCast.hpp"
 #include "le/utility/platformSpecifics.hpp"
@@ -910,7 +916,8 @@ Knob::Knob(juce::Component &parent, unsigned int const x, unsigned int const y,
     setSliderStyle(RotaryVerticalDrag);
     setTextBoxStyle(NoTextBox, true, 0, 0);
     //setPopupDisplayEnabled ( true, 0               ); //...mrmlj...for testing...
-    setPopupMenuEnabled(true);
+    /// \note `setPopupMenuEnabled( true )` stood here. See the note over the
+    /// menu interface in the header: the right button raises ours now.
     setMouseDragSensitivity(800);
     addToParentAndShow(parent, *this);
 }
@@ -973,6 +980,192 @@ void Knob::stoppedDragging() noexcept
     //...mrmlj...automatically (but imprecisely)...
     //juce::Desktop::setMousePosition( juce::Desktop::getLastMouseDownPosition() );
     //juce::Desktop::setMousePosition( this->localPointToGlobal( this->getBounds().getCentre() ) );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Knob::ValueTypein
+// -----------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The "type a value here" line of a knob's menu: a juce::TextEditor
+/// living inside a menu item.
+///
+/// \note `CustomComponent( false )` -- not triggered automatically -- because a
+/// click inside the field must land in the field. The item is dismissed by
+/// triggerMenuItem() when the user commits or gives up, which is also what
+/// carries the "an item was chosen" result back out of the menu.
+///
+/// \note The knob is held through a SafePointer and every use is guarded. A menu
+/// is asynchronous, and while ~SpectrumWorxEditor dismisses whatever is open,
+/// the deferred grab below can still find itself running against a knob that has
+/// gone.
+///                                           (15.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class Knob::ValueTypein final : public juce::PopupMenu::CustomComponent,
+                                private juce::TextEditor::Listener
+{
+  public:
+    explicit ValueTypein(Knob &knob)
+        : juce::PopupMenu::CustomComponent(/*isTriggeredAutomatically*/ false), knob_(&knob)
+    {
+        editor_.setWantsKeyboardFocus(true);
+        editor_.setIndents(4, 0);
+        editor_.setJustification(juce::Justification::centredLeft);
+        editor_.setFont(Theme::singleton().Theme::getPopupMenuFont());
+        editor_.addListener(this);
+        addAndMakeVisible(editor_);
+    }
+
+  private: // juce::PopupMenu::CustomComponent overrides
+    void getIdealSize(int &idealWidth, int &idealHeight) override
+    {
+        idealWidth = fieldWidth;
+        idealHeight = fieldHeight;
+    }
+
+    void resized() override { editor_.setBounds(getLocalBounds().reduced(4, 2)); }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note Deferred by a message rather than done here. The item is made
+    /// visible while the menu is still laying itself out and before its window
+    /// is on screen, and a component that grabs the keyboard then does not keep
+    /// it.
+    ////////////////////////////////////////////////////////////////////////////
+    void visibilityChanged() override
+    {
+        if (!isVisible())
+            return;
+
+        juce::Component::SafePointer<ValueTypein> pThis(this);
+        juce::MessageManager::callAsync([pThis] {
+            if (!pThis || !pThis->isVisible())
+                return;
+            pThis->editor_.setText(pThis->knob_ ? pThis->knob_->parameterValueText()
+                                                : juce::String(),
+                                   juce::dontSendNotification);
+            pThis->editor_.grabKeyboardFocus();
+            pThis->editor_.selectAll();
+        });
+    }
+
+  private: // juce::TextEditor::Listener overrides
+    /// \note The typo is not committed and not clamped: setParameterFromText()
+    /// answers false for text no value of this parameter displays as, and the
+    /// menu simply closes with the parameter where it was.
+    void textEditorReturnKeyPressed(juce::TextEditor &typedInto) override
+    {
+        if (knob_)
+            knob_->setParameterFromText(typedInto.getText());
+        triggerMenuItem();
+    }
+    void textEditorEscapeKeyPressed(juce::TextEditor &) override { triggerMenuItem(); }
+
+  private:
+    static int constexpr fieldWidth{140};
+    static int constexpr fieldHeight{22};
+
+  private:
+    juce::Component::SafePointer<Knob> knob_;
+    juce::TextEditor editor_;
+}; // class Knob::ValueTypein
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Knob::showParameterMenu()
+// -------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+void Knob::showParameterMenu(juce::MouseEvent const &event)
+{
+    bool const editable(parameterEditable());
+
+    juce::PopupMenu menu;
+    menu.addSectionHeader(parameterName());
+    menu.addSeparator();
+    if (editable)
+    {
+        /// \note The result ID is unused -- the field dismisses the menu itself
+        /// -- but it may not be zero, which juce::PopupMenu reserves for "the
+        /// user dismissed it".
+        menu.addCustomItem(1, std::make_unique<ValueTypein>(*this));
+    }
+    menu.addItem("Set to Default", editable, /*isTicked*/ false,
+                 [pThis = juce::Component::SafePointer<Knob>(this)] {
+                     if (pThis)
+                         pThis->setParameterToDefault();
+                 });
+
+    addParameterMenuEntries(menu);
+
+    auto &editor(SpectrumWorxEditor::fromChild(*this));
+    editor.editorHost().addHostParameterEntries(parameterID(), menu);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **Inside the editor, not on the desktop**, which the skin's own
+    /// menus are not -- and the reason is the type-in field. A menu with no
+    /// parent component gets a window of its own carrying
+    /// `ComponentPeer::windowIgnoresKeyPresses` (juce_PopupMenu.cpp:387), so
+    /// that window can never become the key one and a juce::TextEditor inside it
+    /// can never take the keyboard. A parented menu is an ordinary child of the
+    /// editor's own peer and the field simply works. It is what six-sines,
+    /// two-filters and ShortCircuit all do with theirs.
+    ///
+    ///   It settles the zoom for free as well: a child inherits the editor's
+    /// transform, where a menu with a window of its own has to be told to
+    /// follow the component that opened it. \see PopupMenu::showAt() for that
+    /// half, and the note there on why a menu that names nothing is drawn at
+    /// 1:1 beside an editor drawn at 1.5.
+    ///
+    /// \note withTargetComponent() all the same, and before
+    /// withTargetScreenArea() because it overwrites the area: it is what the
+    /// menu forwards key presses to and what it measures "the mouse went back
+    /// to whatever opened me" against.
+    ///
+    /// \note And the keyboard goes back to the knob when the menu closes,
+    /// because the type-in field borrowed it and JUCE does not return it: the
+    /// menu enters its modal state with `takeKeyboardFocus` false, so it never
+    /// recorded what had the focus to give it back. Without this the knob is
+    /// left selected with nothing focused, which the editor recovers from on the
+    /// next mouse move rather than immediately.
+    /// \see ModuleControlImpl::focusLost().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    menu.showMenuAsync(
+        juce::PopupMenu::Options()
+            .withParentComponent(&editor)
+            .withTargetComponent(this)
+            .withTargetScreenArea(localAreaToGlobal(juce::Rectangle<int>(event.x, event.y, 1, 1))),
+        [pThis = juce::Component::SafePointer<Knob>(this)](int) {
+            if (pThis && pThis->getWantsKeyboardFocus() && pThis->isShowing())
+                pThis->grabKeyboardFocus();
+        });
+}
+
+void Knob::mouseDown(juce::MouseEvent const &event)
+{
+    if (event.mods.isPopupMenu())
+        return showParameterMenu(event);
+    juce::Slider::mouseDown(event);
+}
+
+void Knob::mouseDrag(juce::MouseEvent const &event)
+{
+    if (event.mods.isPopupMenu())
+        return;
+    juce::Slider::mouseDrag(event);
+}
+
+void Knob::mouseUp(juce::MouseEvent const &event)
+{
+    if (event.mods.isPopupMenu())
+        return;
+    juce::Slider::mouseUp(event);
 }
 
 void LE_NOINLINE Knob::setValue(param_type const newValue)
@@ -1151,22 +1344,12 @@ struct ParameterPrinter
 #pragma warning(pop)
 } // namespace
 
-void EditorKnob::paint(juce::Graphics &graphics)
+/// \note Was inline in paint(). The menu's type-in field starts out holding
+/// exactly what the knob is showing, so there is one place that says what that
+/// is rather than two that could drift.
+///                                           (15.08.2026.)
+juce::String EditorKnob::parameterValueText() const
 {
-    /// \note valueToProportionOfLength() rather than getNormalisedValue(): it is
-    /// what the film strip picked its frame with, so a skewed range -- which the
-    /// two gains have -- keeps pointing where it used to.
-    paintEditorKnob(graphics, juce::Rectangle<float>(0, 0, diameter, diameter),
-                    static_cast<float>(juce::Slider::valueToProportionOfLength(Knob::getValue())));
-
-    // For main knobs we display the value within the knob itself.
-    graphics.setColour(juce::Colours::white);
-    {
-        juce::Font font(Theme::singleton().whiteFont());
-        font.setHeight(11);
-        graphics.setFont(font);
-    }
-
     //...mrmlj...ugh...
     std::array<char, 20> valueString;
     ParameterPrinter const printer = {editor().engineSetup(), static_cast<float>(getValue()),
@@ -1188,13 +1371,113 @@ void EditorKnob::paint(juce::Graphics &graphics)
         LE_DEFAULT_CASE_UNREACHABLE();
     }
     //...mrmlj...assumes global parameters are static...
-    ParameterID::Global parameterID;
-    parameterID.index = parameterIndex_;
-    char const *const pUnit(
-        Plugin2HostPassiveInteropController::ParameterLabelGetter()(parameterID, nullptr));
+    char const *const pUnit(Plugin2HostPassiveInteropController::ParameterLabelGetter()(
+        parameterID().value._.global, nullptr));
 
-    graphics.drawFittedText(juce::String(&valueString[0]) + pUnit, 14, 16, 28, 24,
-                            juce::Justification::centred, 1, 0.1f);
+    return juce::String(&valueString[0]) + pUnit;
+}
+
+void EditorKnob::paint(juce::Graphics &graphics)
+{
+    /// \note valueToProportionOfLength() rather than getNormalisedValue(): it is
+    /// what the film strip picked its frame with, so a skewed range -- which the
+    /// two gains have -- keeps pointing where it used to.
+    paintEditorKnob(graphics, juce::Rectangle<float>(0, 0, diameter, diameter),
+                    static_cast<float>(juce::Slider::valueToProportionOfLength(Knob::getValue())));
+
+    // For main knobs we display the value within the knob itself.
+    graphics.setColour(juce::Colours::white);
+    {
+        juce::Font font(Theme::singleton().whiteFont());
+        font.setHeight(11);
+        graphics.setFont(font);
+    }
+
+    graphics.drawFittedText(parameterValueText(), 14, 16, 28, 24, juce::Justification::centred, 1,
+                            0.1f);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// EditorKnob -- the right button's menu
+// -------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+ParameterID EditorKnob::parameterID() const
+{
+    ParameterID parameterID;
+    parameterID.value.type = ParameterID::GlobalParameter;
+    parameterID.value._.global.index = parameterIndex_;
+    return parameterID;
+}
+
+/// \note Asked of the same place the host asks, rather than off the widget:
+/// Knob::setupForParameter() is handed a null title for these three, because a
+/// main knob prints its value inside its own face and has never had a caption.
+juce::String EditorKnob::parameterName() const
+{
+    std::array<char, 64> name{};
+    Plugin2HostPassiveInteropController::getParameterName(
+        parameterID(), LE::Utility::makeSpan(&name[0], name.size()), nullptr);
+    return juce::String(&name[0]);
+}
+
+bool EditorKnob::setParameterFromText(juce::String const &text)
+{
+    using LE::Parameters::IndexOf;
+    using namespace GlobalParameters;
+    typedef GlobalParameters::Parameters GlobalParams;
+
+    auto const &engineSetup(editor().engineSetup());
+    char const *const string(text.toRawUTF8());
+
+    LE::Parameters::ParsedValue value;
+    switch (parameterIndex_)
+    {
+    case IndexOf<GlobalParams, InputGain>::value:
+        value = LE::Parameters::parse<InputGain>(string, engineSetup);
+        break;
+    case IndexOf<GlobalParams, OutputGain>::value:
+        value = LE::Parameters::parse<OutputGain>(string, engineSetup);
+        break;
+    case IndexOf<GlobalParams, MixPercentage>::value:
+        value = LE::Parameters::parse<MixPercentage>(string, engineSetup);
+        break;
+        LE_DEFAULT_CASE_UNREACHABLE();
+    }
+
+    if (!value)
+        return false;
+
+    setParameterValue(*value);
+    return true;
+}
+
+/// \note getDoubleClickReturnValue() is the default Knob::setupForParameter()
+/// was given, so the menu entry and the double click cannot disagree about what
+/// "default" means.
+void EditorKnob::setParameterToDefault() { setParameterValue(getDoubleClickReturnValue()); }
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Bracketed in a gesture of its own, which a drag gets from
+/// started/stoppedDragging(). Without it the host sees a parameter jump with no
+/// gesture around it -- which some record as automation and some ignore -- where
+/// what happened is one deliberate edit.
+///
+/// \note sendNotificationSync, so that valueChanged() -- and through it the
+/// queue and the host -- runs before this returns, exactly as it does mid-drag.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void EditorKnob::setParameterValue(double const newValue)
+{
+    auto &editor(this->editor());
+    editor.mainKnobDragStarted(parameterIndex_);
+    juce::Slider::setValue(newValue, juce::sendNotificationSync);
+    editor.mainKnobDragStopped(parameterIndex_);
+    repaint();
 }
 
 /// \note EditorKnob::valueChanged() lives in spectrumWorxEditor.cpp. It is the
@@ -1219,7 +1502,7 @@ void EditorKnob::stoppedDragging() noexcept
 
 /// \note fromChild() rather than a downcast of the parent, which is the main
 /// area rather than the editor. \see SpectrumWorxEditor::MainArea.
-SpectrumWorxEditor &EditorKnob::editor() { return SpectrumWorxEditor::fromChild(*this); }
+SpectrumWorxEditor &EditorKnob::editor() const { return SpectrumWorxEditor::fromChild(*this); }
 
 TitledComboBox::TitledComboBox(juce::Component &parent, unsigned int const x, unsigned int const y,
                                char const *const title)

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -27,6 +27,10 @@
 
 #include "le/utility/intrusivePtr.hpp"
 
+/// A knob's right button menu names the parameter it belongs to, and the host's
+/// half of that menu is addressed by ID. \see Knob::parameterID().
+#include "core/parameterID.hpp"
+
 #include "resources.hpp"
 #include "theme.hpp"
 
@@ -887,7 +891,73 @@ class Knob : public WidgetBase<juce::Slider>
     /// second paint() to keep out of the way of the virtual one.
     ///                                       (15.08.2026.) (SW port)
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \name The right button's menu
+    ///
+    ///   The parameter's name, somewhere to type a value, the way back to the
+    /// default, whatever the knob itself adds, and then whatever the host has to
+    /// add -- which is the menu the rest of the Surge Synth Team's plugins put
+    /// on a parameter.
+    ///
+    /// \note What was here until 15.08.2026: `setPopupMenuEnabled( true )`, so
+    /// the right button raised *juce::Slider*'s own menu -- velocity-sensitive
+    /// mode and the drag direction. Two settings about the mouse, offered on the
+    /// one control a user opens a menu on to reach its parameter.
+    ///
+    /// \note Protected and virtual rather than a constructor argument because
+    /// every one of them is a question only the concrete knob can answer, and
+    /// two of them (the value and whether it may be edited) change under the
+    /// user while the knob lives.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///@{
+  protected:
+    /// The section header: what this parameter is called.
+    virtual juce::String parameterName() const = 0;
+    /// What the type-in field starts out holding, unit and all.
+    virtual juce::String parameterValueText() const = 0;
+    /// Which parameter this is, for the host's own entries.
+    virtual ParameterID parameterID() const = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \brief Whether the knob's own value is worth editing at all.
+    ///
+    /// \note False while an LFO drives the parameter: what is heard then is the
+    /// LFO's output and the widget's value is overwritten from under any edit.
+    /// The two gestures that could already move a knob -- the drag and the
+    /// double click -- are blocked on the same question, so the type-in and the
+    /// default follow them rather than becoming a third answer.
+    ////////////////////////////////////////////////////////////////////////////
+    virtual bool parameterEditable() const { return true; }
+
+    /// \return false when \p text is not a value this parameter can hold, which
+    /// leaves the parameter where it was. \see LE::Parameters::parse().
+    virtual bool setParameterFromText(juce::String const &text) = 0;
+    virtual void setParameterToDefault() = 0;
+
+    /// Entries of the knob's own, under "Set to Default": the module knob's LFO
+    /// switch.
+    virtual void addParameterMenuEntries(juce::PopupMenu &) {}
+    ///@}
+
+  private:
+    /// The type-in field, as a menu item. \see gui.cpp.
+    class ValueTypein;
+
+    void showParameterMenu(juce::MouseEvent const &);
+
   protected: // juce::Component overrides
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note All three, and not only the press. juce::Slider::mouseDown is what
+    /// clears `useDragEvents`, so returning from it early -- which is what
+    /// showing our own menu instead does -- would leave the flag set from the
+    /// last real drag and let a right-drag move the value.
+    ////////////////////////////////////////////////////////////////////////////
+    void mouseDown(juce::MouseEvent const &) override;
+    void mouseDrag(juce::MouseEvent const &) override;
+    void mouseUp(juce::MouseEvent const &) override;
+
     void startedDragging() noexcept override;
     /// \note Was declared and defined only under !NDEBUG, but
     /// EditorKnob::stoppedDragging calls it unconditionally -- an undefined
@@ -998,8 +1068,22 @@ class EditorKnob final : public Knob
     void startedDragging() noexcept override;
     void stoppedDragging() noexcept override;
 
+  private: // Knob's menu interface
+    juce::String parameterName() const override;
+    juce::String parameterValueText() const override;
+    ParameterID parameterID() const override;
+    bool setParameterFromText(juce::String const &) override;
+    void setParameterToDefault() override;
+
+    /// \brief A value from somewhere other than a drag, bracketed in a gesture
+    /// of its own so that a host records it as one edit rather than as a jump.
+    void setParameterValue(double newValue);
+
   private:
-    SpectrumWorxEditor &editor();
+    /// \note const, and still handing back a non-const editor: fromChild() takes
+    /// a `Component const &` and answers the editor it belongs to, and the const
+    /// half of the menu interface above has to be able to ask.
+    SpectrumWorxEditor &editor() const;
 
   private:
     std::uint8_t parameterIndex_;

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -16,6 +16,7 @@
 #include "gui/modules/moduleUI.hpp"
 
 #include "le/parameters/lfo.hpp"
+#include "le/parameters/parser.hpp"
 #include "le/parameters/printer.hpp"
 
 #include "core/modules/moduleDSPAndGUI.hpp"
@@ -108,6 +109,28 @@ void ModuleControlBase::moduleParameterChanged()
     LE_ASSERT(isActive());
     LE_ASSERT(!isLFOEnabled());
 
+    publishValue();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// ModuleControlBase::publishValue()
+// ---------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Split out of moduleParameterChanged() above, which is this and the four
+/// assertions that say the user is turning the control at this moment. A value
+/// typed into the knob's right button menu is the same edit made from outside
+/// that: the type-in field takes the keyboard, so the knob loses it, so the
+/// control deactivates -- and `isActive()` is false by the time the user presses
+/// return on a value they are quite deliberately setting.
+///                                           (15.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void ModuleControlBase::publishValue()
+{
     /// \note Checkout revision 7493 or earlier for (more templated) code
     /// that directly accessed the effect's parameters.
     ///                                       (12.03.2013.) (Domagoj Saric)
@@ -194,6 +217,18 @@ juce::String ModuleControlBase::getValueString(float const *LE_RESTRICT const pV
     juce::String result(pValueString);
     result.appendCharPointer(juce::CharPointer_ASCII(pUnit));
     return result;
+}
+
+/// \note The same parser `clap_plugin_params::text_to_value` runs, over the same
+/// module: a value typed into a knob's menu and a value typed into the host's
+/// generic panel are one question, and there is one answer to it.
+///                                           (15.08.2026.)
+std::optional<float> ModuleControlBase::parseValueString(juce::String const &text) const
+{
+    LE::Parameters::ParameterValueParser const parser{text.toRawUTF8(),
+                                                      moduleUI().editor().engineSetup()};
+    std::uint8_t const parameterIndex(moduleParameterIndex() + 1 /*Bypass*/);
+    return Automation::parseParameterValue(parameterIndex, parser, module());
 }
 
 namespace

--- a/src/gui/modules/moduleControl.hpp
+++ b/src/gui/modules/moduleControl.hpp
@@ -14,6 +14,8 @@
 #include "le/math/conversion.hpp"
 #include "le/utility/cstdint.hpp"
 
+#include <optional>
+
 /// \note This header names juce::Component and juce::Slider throughout but used
 /// to rely on whoever included it having pulled JUCE in first. That worked while
 /// there was exactly one includer.
@@ -62,6 +64,9 @@ template <class ImplWidget> class ModuleControl
 
     ModuleControlBase &control()
     { /*LE_ASSERT( &ModuleControlBase::controlForWidget( impl() ) == &impl() );*/ return impl(); }
+    /// \note The const half, for the widget's own const questions -- what this
+    /// parameter is called and what it currently reads as.
+    ModuleControlBase const &control() const { return impl(); }
 
   protected: // Default implementations for the module control interface
     static bool const mouseClickCanGrabFocus = false;
@@ -133,6 +138,19 @@ class ModuleControlBase
 
     juce::String getValueString(float const *LE_RESTRICT pValue) const;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief getValueString() backwards: the value this parameter would have to
+    /// hold for it to read as \p text, in the widget's own units -- or nothing at
+    /// all, when no value of it does.
+    ///
+    /// \note Nothing rather than a clamp, which is the whole reason it is an
+    /// optional: a knob handed a clamped value has told the user their typo was
+    /// understood. \see LE::Parameters::parse().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    std::optional<float> parseValueString(juce::String const &text) const;
+
     Parameters::RuntimeInformation const &info() const;
     char const *name() const;
 
@@ -144,6 +162,11 @@ class ModuleControlBase
     bool isLFOEnabled() const;
 
     void moduleParameterChanged();
+
+    /// \brief The widget's value, into the Program and out to the host --
+    /// moduleParameterChanged() without the assertions that say the user has
+    /// this control under the mouse right now. \see the definition.
+    void publishValue();
 
     using Module = SW::Module;
 
@@ -282,6 +305,8 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
         reportActiveControl();
         ImplWidget::focusChanged();
     }
+    ////////////////////////////////////////////////////////////////////////////
+    ///
     /// \note `|| !isEnabled()`. JUCE spells getWantsKeyboardFocus() as
     /// `wantsKeyboardFocusFlag && !isDisabledFlag`, and
     /// `Component::setEnabled( false )` sets that flag *before* handing the
@@ -290,9 +315,36 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
     /// it. `ModuleKnob::mouseDown` does exactly that to a knob whose LFO is on,
     /// which is why clicking one fired this.
     ///                                       (03.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **The focus a menu borrows is not a focus loss.** A knob's own
+    /// right button menu contains a type-in field, the field takes the keyboard
+    /// when it opens, and the editor reads every focus loss as "this control is
+    /// no longer the one the user is on" -- which retires the LFO strip out from
+    /// under the menu that is offering to switch it, and, one level up, deselects
+    /// the module and destroys the shared controls the knob may itself be one of.
+    /// So the widget under the open menu could be freed while its menu was still
+    /// on screen, and choosing an item then did nothing at all.
+    ///
+    ///   `isCurrentlyBlockedByAnotherModalComponent()` is the question, and it is
+    /// exactly the right one: a menu is a modal component, so this is true for
+    /// every widget in the editor for as long as one is up, and false the moment
+    /// it closes. Nothing is lost by waiting -- a mouseExit or the next focus
+    /// change re-asks -- and the other two tear-downs guard on the same thing.
+    /// \see ModuleUI::focusLost(), SharedModuleControls::focusLost().
+    ///
+    /// \note The skin's own menus never reach here: they are desktop windows
+    /// carrying `ComponentPeer::windowIgnoresKeyPresses` and take no keyboard, so
+    /// no focus is lost when one opens. \see Knob::showParameterMenu().
+    ///                                       (15.08.2026.)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
     virtual void focusLost(juce::Component::FocusChangeType) noexcept override
     {
         LE_ASSERT(this->getWantsKeyboardFocus() || !this->isEnabled());
+        if (this->isCurrentlyBlockedByAnotherModalComponent())
+            return;
         reportInactiveControl();
         ImplWidget::focusChanged();
     }

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -337,6 +337,77 @@ void ModuleKnob::updateForEngineSetupChanges(Engine::Setup const &engineSetup)
     setRange(adjustedMinimum, adjustedMaximum, quantization);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// ModuleKnob -- the right button's menu
+// -------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// \note getName(), which setupForParameter() took from the same
+/// RuntimeInformation, and *not* the host's name for it: that reads "M3.Wet",
+/// and the strip the knob is standing in already says which module this is.
+juce::String ModuleKnob::parameterName() const { return getName(); }
+
+juce::String ModuleKnob::parameterValueText() const { return control().getValueText(); }
+
+ParameterID ModuleKnob::parameterID() const
+{
+    return control().editor().moduleControlID(control());
+}
+
+bool ModuleKnob::parameterEditable() const { return !isLFOEnabled(); }
+
+bool ModuleKnob::setParameterFromText(juce::String const &text)
+{
+    auto const value(control().parseValueString(text));
+    if (!value)
+        return false;
+
+    /// \note Knob::setValue() rather than juce::Slider's notifying form, and
+    /// publishValue() rather than moduleParameterChanged(): valueChanged()
+    /// asserts the mouse is on the knob or dragging it, and it is on the menu.
+    /// \see ModuleControlBase::publishValue().
+    setValue(static_cast<param_type>(*value));
+    control().publishValue();
+    repaint();
+    return true;
+}
+
+void ModuleKnob::setParameterToDefault()
+{
+    setValue(static_cast<param_type>(control().info().default_));
+    control().publishValue();
+    repaint();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The LFO strip's own switch is the other way in, and both end up in
+/// SpectrumWorxEditor::setLFOEnabled(): turning an LFO on is an edit of an
+/// exported parameter, so it has to reach the engine and the host and not just
+/// the copy this thread draws from.
+///
+/// \note Offered whether or not the strip is up. A knob is reachable with no LFO
+/// display on screen -- the shared gain and wet pair above the rack are the
+/// obvious case -- and there is nothing about the switch that needs one.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void ModuleKnob::addParameterMenuEntries(juce::PopupMenu &menu)
+{
+    /// \note The tick is read here, when the menu is built; the toggle re-reads
+    /// when it is chosen. The two can only disagree if the host moved the LFO
+    /// while the menu was open, and then the fresh answer is the right one.
+    menu.addItem("LFO On", /*isEnabled*/ true, /*isTicked*/ isLFOEnabled(),
+                 [pThis = juce::Component::SafePointer<ModuleKnob>(this)] {
+                     if (!pThis)
+                         return;
+                     auto &control(pThis->control());
+                     control.editor().setLFOEnabled(control, !control.isLFOEnabled());
+                 });
+}
+
 void ModuleKnob::moduleControlActivated() { syncMouseWheelAndLFOState(); }
 void ModuleKnob::moduleControlDeactivated() { setScrollWheelEnabled(false); }
 void ModuleKnob::syncMouseWheelAndLFOState() { setScrollWheelEnabled(!isLFOEnabled()); }
@@ -608,6 +679,13 @@ void ModuleUI::focusLost(FocusChangeType)
     // not deactivate.
     //                                        (14.11.2011.) (Domagoj Saric)
     if (hasFocus() || editor().sharedModuleControlsActiveAndFocused())
+        return;
+
+    /// \note ...nor to a menu one of those subcontrols opened, which is a third
+    /// case of the same thing: deselecting the strip under an open menu destroys
+    /// the shared controls, and the menu may belong to one of them.
+    /// \see the note on ModuleControlImpl::focusLost().
+    if (isCurrentlyBlockedByAnotherModalComponent())
         return;
 
     //...mrmlj...rethink this focus changing logic and assumptions

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -194,6 +194,15 @@ class ModuleKnob : public Knob, public ModuleControl<ModuleKnob>
 
     void paint(juce::Graphics &) override;
 
+  private: // Knob's menu interface
+    juce::String parameterName() const override;
+    juce::String parameterValueText() const override;
+    ParameterID parameterID() const override;
+    bool parameterEditable() const override;
+    bool setParameterFromText(juce::String const &) override;
+    void setParameterToDefault() override;
+    void addParameterMenuEntries(juce::PopupMenu &) override;
+
   protected: // ModuleControl interface.
     void lfoStateChanged();
 

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -44,6 +44,7 @@
 
 #include "le/math/vector.hpp" // Math::copy(), for the sample's wrap
 
+#include <sst/clap_juce_shim/menu_helper.h> // the host's own parameter menu
 #include <sst/plugininfra/cpufeatures.h>
 #include <sst/plugininfra/version_information.h>
 
@@ -2329,6 +2330,27 @@ void SpectrumWorxCLAP::resyncSpectralParametersToEngine()
     requestRescan(CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
     if (pEditor_)
         pEditor_->updateForGlobalParameterChange();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxCLAP::addHostParameterEntries()
+// -------------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note `clap_id` and `ParameterID::binaryValue` are the same number -- see
+/// paramsInfo(), which writes one straight into the other. The helper asks the
+/// host for its extension and adds nothing when there is none, which is why
+/// there is no test for one here.
+///                                           (15.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxCLAP::addHostParameterEntries(ParameterID const parameterID,
+                                               juce::PopupMenu &menu) const
+{
+    sst::clap_juce_shim::populateMenuForClapParam(menu, parameterID.binaryValue, _host.host());
 }
 
 void SpectrumWorxCLAP::editorOpened(GUI::SpectrumWorxEditor &editor) { pEditor_ = &editor; }

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -263,6 +263,11 @@ class SpectrumWorxCLAP final
     void publishUnexportedLFOParameter(std::uint8_t moduleIndex, std::uint8_t moduleParameterIndex,
                                        std::uint8_t lfoParameterIndex, float value) override;
 
+    /// \note The one thing on this interface that only a plugin can answer:
+    /// `clap_host_context_menu` needs the `clap_host *`, and the editor has
+    /// none. \see sst::clap_juce_shim::populateMenuForClapParam().
+    void addHostParameterEntries(ParameterID, juce::PopupMenu &) const override;
+
     void editorOpened(GUI::SpectrumWorxEditor &) override;
     void editorClosed(GUI::SpectrumWorxEditor &) override;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(sw-plugin-tests
         presets/presetHarness.cpp
         gui/aboutPageTests.cpp
         gui/buildStampTests.cpp
+        gui/knobMenuTests.cpp
         gui/knobPaintingTests.cpp
         gui/lfoDisplayTests.cpp
         gui/moduleControlFocusTests.cpp

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -150,6 +150,10 @@ class Instance final : public GUI::EditorHost
     Threading::ToEngineQueue &toEngine() const override { return toEngine_; }
     Threading::ValueMailbox const &modulatedValues() const override { return values_; }
 
+    /// \note Nothing, which is also what a host with no `clap_host_context_menu`
+    /// contributes: the knob's menu ends where the plugin's own entries do.
+    void addHostParameterEntries(ParameterID, juce::PopupMenu &) const override {}
+
     void editorOpened(GUI::SpectrumWorxEditor &) override {}
     void editorClosed(GUI::SpectrumWorxEditor &) override {}
 

--- a/tests/gui/knobMenuTests.cpp
+++ b/tests/gui/knobMenuTests.cpp
@@ -1,0 +1,246 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// knobMenuTests.cpp
+/// -----------------
+///
+///   The two things a knob's right button menu does that are not JUCE's: reading
+/// a typed value back into the parameter, and turning the LFO on.
+///
+/// \note The menu itself is deliberately not driven here, for the reason
+/// lfoDisplayTests.cpp gives about the LFO waveform popup: a menu is a modal
+/// desktop window and a test binary has no message loop to answer one with. What
+/// is covered is everything underneath it -- the two routes the items call --
+/// which is where all of the logic is. `Knob::showParameterMenu()` itself only
+/// assembles them.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module, as elsewhere: the module chain
+/// downcasts a node to it and this is the header with the complete type.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "core/parameterID.hpp"
+#include "core/threading/messages.hpp"
+#include "gui/modules/moduleControl.hpp"
+#include "gui/modules/moduleUI.hpp"
+
+#include "le/parameters/lfoImpl.hpp"
+#include "le/parameters/parametersUtilities.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+//------------------------------------------------------------------------------
+
+using LE::SW::ParameterID;
+using LE::SW::GUI::ModuleControlBase;
+using LE::SW::Threading::ToEngine;
+
+constexpr std::uint8_t
+    enabledIndex(LE::Parameters::IndexOf<LE::Parameters::LFOImpl::Parameters,
+                                         LE::Parameters::LFOImpl::Enabled>::value);
+
+/// \brief The first effect-specific control of \p moduleUI that is a knob.
+///
+/// \note By parameter index rather than by walking the children, as
+/// moduleControlFocusTests.cpp does and for the same reason: the widget storage
+/// is a compile-time chain of one base class per parameter, so there is no
+/// runtime list to iterate.
+ModuleControlBase *firstKnob(LE::SW::GUI::ModuleUI &moduleUI)
+{
+    auto const parameters(moduleUI.module().numberOfEffectSpecificParameters());
+    for (std::uint8_t index(0); index < parameters; ++index)
+    {
+        auto &control(moduleUI.effectSpecificParameterControl(index));
+        if (dynamic_cast<LE::SW::GUI::ModuleKnob *>(&control.widget()) != nullptr)
+            return &control;
+    }
+    return nullptr;
+}
+
+/// Everything the interface has queued for the engine, drained.
+std::vector<ToEngine> drain(LE::SW::Threading::ToEngineQueue &queue)
+{
+    std::vector<ToEngine> messages;
+    ToEngine message;
+    while (queue.pop(message))
+        messages.push_back(message);
+    return messages;
+}
+
+/// The last `SetBaseParameter` in \p messages naming \p parameterID.
+std::optional<ToEngine> lastEditOf(std::vector<ToEngine> const &messages,
+                                   ParameterID const parameterID)
+{
+    std::optional<ToEngine> found;
+    for (auto const &message : messages)
+        if ((message.kind == ToEngine::Kind::SetBaseParameter) &&
+            (message.setBaseParameter.parameterID == parameterID.binaryValue))
+            found = message;
+    return found;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief An editor with a module in slot 0 and its first knob's control to
+/// hand, selected so that the LFO strip is up.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class KnobUnderTest
+{
+  public:
+    explicit KnobUnderTest(SWTest::Instance &instance)
+    {
+        instance.openEditor();
+        auto &editor(instance.editor());
+        editor.addUserAddedModule(0);
+        editor.resyncModuleRack();
+
+        auto *const pModuleUI(editor.regionInSlot(0));
+        REQUIRE(pModuleUI != nullptr);
+        pControl_ = firstKnob(*pModuleUI);
+        REQUIRE(pControl_ != nullptr);
+
+        /// \note The range the LFO strip's two-value bound slider is laid out
+        /// over; an LFO's bounds are normalised, so the knob's own units do not
+        /// come into it. \see lfoDisplayTests.cpp, which sets it up the same way.
+        editor.moduleControlActivated(*pControl_, 0.0, 1.0, 0.0);
+
+        // Whatever building the strip and the panel queued is not a case's.
+        drain(instance.toEngine());
+    }
+
+    ModuleControlBase &control() const { return *pControl_; }
+    juce::Slider &knob() const { return dynamic_cast<juce::Slider &>(pControl_->widget()); }
+
+    /// The ID the host knows this knob's LFO switch by.
+    ParameterID lfoEnabledID() const
+    {
+        ParameterID parameterID;
+        parameterID.value.type = ParameterID::LFOParameter;
+        parameterID.value._.lfo = {enabledIndex, pControl_->moduleParameterIndex(),
+                                   /*moduleIndex*/ 0};
+        return parameterID;
+    }
+
+  private:
+    ModuleControlBase *pControl_{nullptr};
+}; // class KnobUnderTest
+
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+TEST_CASE("A knob reads back the value string it prints", "[gui][modules][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Which is the whole contract of the type-in field: whatever the knob
+    /// is currently showing is what the field starts out holding, so the user who
+    /// opens the menu and presses return has to land back on the value they were
+    /// already on. The two halves are `getValueString()` and `parseValueString()`,
+    /// and until 15.08.2026 only the first had a caller in the interface.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    KnobUnderTest const knob(instance);
+    auto &control(knob.control());
+
+    auto const value(control.getValue());
+    auto const parsed(control.parseValueString(control.getValueText()));
+
+    REQUIRE(parsed.has_value());
+    /// \note Against the knob's own step and not against an epsilon: a value is
+    /// *printed* rounded, so what comes back is the nearest value of this
+    /// parameter that displays as that text -- which is the right answer and need
+    /// not be bit-identical. \see LE::Parameters::displayRounding().
+    auto const quantum(std::max(knob.knob().getInterval(),
+                                (knob.knob().getMaximum() - knob.knob().getMinimum()) / 1000));
+    CHECK(std::abs(*parsed - value) <= quantum);
+}
+
+TEST_CASE("A knob refuses text no value of it displays as", "[gui][modules][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Refused rather than clamped, which is why parseValueString() answers
+    /// an optional at all: a knob handed a clamped value has told the user their
+    /// typo was understood and has committed a parameter change they did not ask
+    /// for. Nothing is what puts the field back where it was.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    KnobUnderTest const knob(instance);
+    auto &control(knob.control());
+
+    CHECK_FALSE(control.parseValueString("").has_value());
+    CHECK_FALSE(control.parseValueString("not a number").has_value());
+    /// \note Far outside every module parameter's range and, unlike the two
+    /// above, a perfectly good number -- so this is the range check rather than
+    /// the parse.
+    CHECK_FALSE(control.parseValueString("1e9").has_value());
+}
+
+TEST_CASE("The menu's LFO switch moves both copies and the host", "[gui][modules][lfo][menu]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note `LFO::Enabled` is an exported parameter, so turning it on is an edit
+    /// like any other and has to reach the engine as well as the copy this thread
+    /// draws from -- which is the trap lfoDisplayTests.cpp was written around.
+    /// The menu entry and the LFO strip's own switch are one implementation for
+    /// exactly that reason.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    KnobUnderTest const knob(instance);
+    auto &control(knob.control());
+    auto &editor(instance.editor());
+
+    REQUIRE_FALSE(control.isLFOEnabled());
+
+    editor.setLFOEnabled(control, true);
+
+    CHECK(control.isLFOEnabled()); // the main thread's copy
+    {
+        auto const queued(lastEditOf(drain(instance.toEngine()), knob.lfoEnabledID()));
+        REQUIRE(queued.has_value()); // ...and the engine's
+        CHECK(queued->setBaseParameter.value == 1.0f);
+    }
+
+    /// \note Not a side issue: `lfoStateChanged()` is what re-keys the two
+    /// gestures that would otherwise move a value the LFO owns, and the menu
+    /// route has to do it as well as the strip's switch does.
+    CHECK_FALSE(knob.knob().isScrollWheelEnabled());
+    CHECK_FALSE(knob.knob().isDoubleClickReturnEnabled());
+
+    editor.setLFOEnabled(control, false);
+
+    CHECK_FALSE(control.isLFOEnabled());
+    {
+        auto const queued(lastEditOf(drain(instance.toEngine()), knob.lfoEnabledID()));
+        REQUIRE(queued.has_value());
+        CHECK(queued->setBaseParameter.value == 0.0f);
+    }
+    CHECK(knob.knob().isScrollWheelEnabled());
+    CHECK(knob.knob().isDoubleClickReturnEnabled());
+}

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -148,6 +148,10 @@ class HarnessHost final : public GUI::EditorHost
     Threading::ToEngineQueue &toEngine() const override { return toEngine_; }
     Threading::ValueMailbox const &modulatedValues() const override { return values_; }
 
+    /// \note Nothing: there is no CLAP host behind this harness, which is the
+    /// same situation as a host without `clap_host_context_menu`.
+    void addHostParameterEntries(ParameterID, juce::PopupMenu &) const override {}
+
     void editorOpened(GUI::SpectrumWorxEditor &) override {}
     void editorClosed(GUI::SpectrumWorxEditor &) override {}
 


### PR DESCRIPTION
The right button raised juce::Slider's own menu -- velocity-sensitive mode and the drag direction -- two settings about the mouse, offered on the one control a user opens a menu on to reach its parameter.

Both knobs now offer the parameter's name, a field to type a value into, the way back to the default, an LFO switch on a module knob, and then whatever the host itself contributes over clap_host_context_menu. A typed value is refused rather than clamped when no value of the parameter reads as it, which is the same answer the host's own generic panel already gets.

The menu is a child of the editor rather than a window of its own, which is what lets the type-in field hold the keyboard, and the editor no longer treats the focus that field borrows as a reason to retire the LFO strip, deselect the module, or destroy the knob the open menu belongs to.

Closes #3.
Closes #49.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>