### PR TITLE
Remember the interface preferences between sessions

### DIFF
--- a/doc/tech/streaming_format.md
+++ b/doc/tech/streaming_format.md
@@ -268,10 +268,21 @@ calls the reader only when the element is present, so loading a `.swp` into a
 live session is not a silent reset of session state.
 
 **Its payload is deliberately empty for now.** The mechanism is the deliverable;
-the payload accrues. The candidates, both main-thread and neither of them a
-parameter: the preset browser's location and selection; and the interface
-settings the CLAP build persists nowhere at all, so they are back at their
-defaults every time the plugin is loaded.
+the payload accrues. The candidate is the preset browser's location and
+selection, which is main-thread and is not a parameter.
+
+The settings panel's Interface page is *not* a candidate, and it is the case that
+says where the line is. Those three — mouse-over reaction, LFO update behaviour,
+hide-cursor-on-knob-drag — used to persist nowhere at all (issue #61). They are
+answers about how this user likes the editor to behave, not about this session,
+so they are the same in every instance and in every project, and they belong in
+the user's preferences file rather than in a host's state blob:
+`<user folder>/SpectrumWorxUserDefaults.xml`, through
+`sst::plugininfra::defaults::Provider`. \see `src/gui/preferences.hpp`. Its
+format is that library's; what this tree fixes about it is that both
+enumerations are streamed **by name**, so inserting a value cannot silently
+change what an existing file means. `tests/gui/preferencesTests.cpp` pins the
+names.
 
 Note what does *not* need it — the loaded sample. `<Global Sample="…">` has
 carried that since 2011, so putting state on the preset serialisation restores it

--- a/doc/tech/threading_model.md
+++ b/doc/tech/threading_model.md
@@ -419,7 +419,7 @@ The inventory the model is measured by.
 | **`LFOImpl::Timer`'s tempo** | three process-wide statics, `std::atomic` — no longer a race, still shared between instances | issue #11 |
 | `SkinLifetime::liveEditors_` | a process-wide count, main thread only — every editor is built and destroyed there | ✅ |
 | `PresetLoadReport` | a file-scope report the loader counts into and the caller takes; main thread only, and `stateLoad` drops it | ✅ |
-| `Theme::settings()` | process-wide, and arguably correct: these are application preferences | not addressed |
+| `GUI::preferences()` | process-wide, and correct: these are the user's application preferences, shared by every instance and backed by one file. Main thread only — everything that reads them runs under the host's message thread, which is also what makes `setPreferencesFolder()` safe for the tests | ✅ |
 
 **JUCE has one owner.** `SkinLifetime` builds the `Theme` and installs it as the
 default LookAndFeel for as long as at least one editor exists, and touches

--- a/src/gui.cmake
+++ b/src/gui.cmake
@@ -39,6 +39,7 @@ target_compile_definitions(sw-gui-resources PRIVATE LE_ENABLE_ASSERT_HANDLER)
 
 add_library(sw-gui-widgets STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/gui.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/gui/preferences.cpp
 )
 
 # sw-io rather than sw-dsp: the editor opens preset files and lists the factory
@@ -50,7 +51,12 @@ target_link_libraries(sw-gui-widgets PUBLIC sw-gui-resources sw-io)
 # sst-plugininfra handed it, so nothing above needs to know where it came from --
 # and, as of 09.08.2026, nothing has to convert it either. See the note on
 # rootPath() and tests/checkNoJuceFile.cmake.
-target_link_libraries(sw-gui-widgets PRIVATE sst-plugininfra)
+#
+# tinyxml with it, for preferences.cpp: sst-plugininfra's userdefaults.h parses
+# the preferences file with it. Also PRIVATE, and preferences.hpp keeps the
+# provider behind a pimpl, so the header does not arrive above this target
+# either.
+target_link_libraries(sw-gui-widgets PRIVATE sst-plugininfra sst-plugininfra::tinyxml)
 
 # \note gui/gui.mm and "-framework Cocoa" stood here. The .mm held one function,
 # initialiseMac(), which detached a throwaway NSThread to put Cocoa into

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -20,6 +20,7 @@
 #include "core/threading/publish.hpp"
 #include "gui/editor/editorHost.hpp"
 #include "gui/editor/presetLoading.hpp"
+#include "gui/preferences.hpp"
 #include "io/jucePath.hpp"
 
 #include "le/parameters/lfo.hpp"
@@ -3347,13 +3348,12 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
     }
     else if (&comboBox == &settings.interfacePage_.mouseOverComboBox())
     {
-        Theme::singleton().settings().moduleUIMouseOverReaction =
-            static_cast<Theme::ModuleUIMouseOverReaction>(value);
+        preferences().setModuleUIMouseOverReaction(
+            static_cast<Preferences::ModuleUIMouseOverReaction>(value));
     }
     else if (&comboBox == &settings.interfacePage_.lfoUpdateComboBox())
     {
-        Theme::singleton().settings().lfoUpdateBehaviour =
-            static_cast<Theme::LFOUpdateBehaviour>(value);
+        preferences().setLFOUpdateBehaviour(static_cast<Preferences::LFOUpdateBehaviour>(value));
     }
     else
     {
@@ -3486,20 +3486,19 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));
 
-    moduleUIMouseOverReaction_.addItem(Theme::Never, "Never");
-    moduleUIMouseOverReaction_.addItem(Theme::WhenParentModuleSelected, "Module selected");
-    moduleUIMouseOverReaction_.addItem(Theme::WhenParentOrNothingSelected,
+    moduleUIMouseOverReaction_.addItem(Preferences::Never, "Never");
+    moduleUIMouseOverReaction_.addItem(Preferences::WhenParentModuleSelected, "Module selected");
+    moduleUIMouseOverReaction_.addItem(Preferences::WhenParentOrNothingSelected,
                                        "Module/nothing selected");
-    moduleUIMouseOverReaction_.setSelectedIndex(
-        Theme::singleton().settings().moduleUIMouseOverReaction);
+    moduleUIMouseOverReaction_.setSelectedIndex(preferences().moduleUIMouseOverReaction());
 
-    lfoUpdateBehaviour_.addItem(Theme::NoUpdate, "Never");
-    lfoUpdateBehaviour_.addItem(Theme::WhenControlSelected, "Control selected");
-    lfoUpdateBehaviour_.addItem(Theme::WhenControlActive, "Control active");
-    lfoUpdateBehaviour_.addItem(Theme::Always, "Always");
-    lfoUpdateBehaviour_.setSelectedIndex(Theme::singleton().settings().lfoUpdateBehaviour);
+    lfoUpdateBehaviour_.addItem(Preferences::NoUpdate, "Never");
+    lfoUpdateBehaviour_.addItem(Preferences::WhenControlSelected, "Control selected");
+    lfoUpdateBehaviour_.addItem(Preferences::WhenControlActive, "Control active");
+    lfoUpdateBehaviour_.addItem(Preferences::Always, "Always");
+    lfoUpdateBehaviour_.setSelectedIndex(preferences().lfoUpdateBehaviour());
 
-    hideCursorOnKnobDrag_.setToggleState(Theme::singleton().settings().hideCursorOnKnobDrag,
+    hideCursorOnKnobDrag_.setToggleState(preferences().hideCursorOnKnobDrag(),
                                          juce::dontSendNotification);
     hideCursorOnKnobDrag_.addListener(&parent);
 }
@@ -3580,7 +3579,7 @@ void SpectrumWorxEditor::Settings::buttonClicked(juce::Button *const pButton)
     LE_ASSERT(pButton == &interfacePage_.hideCursorOnKnobDrag_);
     (void)pButton;
 
-    Theme::settings().hideCursorOnKnobDrag = interfacePage_.hideCursorOnKnobDrag_.getToggleState();
+    preferences().setHideCursorOnKnobDrag(interfacePage_.hideCursorOnKnobDrag_.getToggleState());
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6,6 +6,7 @@
 #include "core/host_interop/plugin2Host.hpp" //...mrmlj...only for Plugin2HostPassiveInteropController::ParameterLabelGetter...
 #include "gui/editor/editorHost.hpp" // the host's half of a knob's menu
 #include "gui/editor/spectrumWorxEditor.hpp"
+#include "gui/preferences.hpp"
 
 #include "le/spectrumworx/engine/setup.hpp"
 
@@ -939,7 +940,7 @@ void Knob::setupForParameter(char const *const title, unsigned int const diamete
 
 void Knob::startedDragging() noexcept
 {
-    if (!Theme::singleton().settings().hideCursorOnKnobDrag)
+    if (!preferences().hideCursorOnKnobDrag())
         return;
 
     LE_ASSERT(juce::Desktop::getInstance().getNumMouseSources() == 1);
@@ -973,7 +974,7 @@ void Knob::stoppedDragging() noexcept
     LE_ASSERT(juce::Desktop::getInstance().getNumMouseSources() == 1);
     //juce::MouseInputSource & mouseSource( juce::Desktop::getInstance().getMainMouseSource() );
     // http://www.rawmaterialsoftware.com/viewtopic.php?f=2&t=5628&hilit=enableUnboundedMouseMovement
-    //mouseSource.enableUnboundedMouseMovement( false, !Theme::singleton().settings().hideCursorOnKnobDrag );
+    //mouseSource.enableUnboundedMouseMovement( false, !preferences().hideCursorOnKnobDrag() );
 
     //...mrmlj...neither of these works/helps because
     //...mrmlj...enableUnboundedMouseMovement() seems to handle it
@@ -1565,24 +1566,24 @@ void addEnumeratedParameterValueStringsToComboBox(LE::Utility::Span<char const *
 } // namespace Detail
 
 ////////////////////////////////////////////////////////////////////////////////
-// Theme
+// The LFO update policy
 ////////////////////////////////////////////////////////////////////////////////
 
 /// \note Theme itself now lives in theme.hpp/theme.cpp -- it is a
 /// LookAndFeel_V2 there, not a LookAndFeel, and it loads its fonts out of the
 /// binary instead of registering them with the operating system. What stays
 /// here are the two LFO-update policy queries, which were static members of
-/// Theme only because they read Theme::settings(): they ask about a
+/// Theme only because they read what is now GUI::preferences(): they ask about a
 /// ModuleControlBase and a ModuleUI, neither of which a LookAndFeel should
 /// know exist, and their presence is what stopped Theme being separable.
 ///                                       (28.07.2026.) (SW port)
 
 bool shouldUpdateLFOControl(ModuleControlBase const &control)
 {
-    Theme::LFOUpdateBehaviour const lfoUpdateBehaviour(Theme::settings().lfoUpdateBehaviour);
-    return (lfoUpdateBehaviour == Theme::Always) ||
-           (lfoUpdateBehaviour == Theme::WhenControlActive && control.isActive()) ||
-           (lfoUpdateBehaviour == Theme::WhenControlSelected &&
+    Preferences::LFOUpdateBehaviour const lfoUpdateBehaviour(preferences().lfoUpdateBehaviour());
+    return (lfoUpdateBehaviour == Preferences::Always) ||
+           (lfoUpdateBehaviour == Preferences::WhenControlActive && control.isActive()) ||
+           (lfoUpdateBehaviour == Preferences::WhenControlSelected &&
             Detail::hasDirectFocus(control.widget()));
 }
 

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -204,8 +204,8 @@ bool createUserPresetsFolder();
 /// LookAndFeel, which is abstract in JUCE 8, and not a LookAndFeel_V4, which
 /// would paint linear sliders whole and silently drop the skinned thumb).
 ///
-///   These two were static members of Theme purely because they read
-/// Theme::settings(). They ask about a ModuleControlBase and a ModuleUI, which
+///   These two were static members of Theme purely because they read what is now
+/// GUI::preferences(). They ask about a ModuleControlBase and a ModuleUI, which
 /// a LookAndFeel has no business knowing about, and being members is what kept
 /// Theme from being separable at all. aModuleControlNeedsLFOUpdate went with
 /// them: it had no callers.

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -14,6 +14,7 @@
 
 #include "gui/editor/spectrumWorxEditor.hpp"
 #include "gui/modules/moduleUI.hpp"
+#include "gui/preferences.hpp"
 
 #include "le/parameters/lfo.hpp"
 #include "le/parameters/parser.hpp"
@@ -54,8 +55,8 @@ bool ModuleControlBase::tryActivateControl() const
     if (juce::Component::getNumCurrentlyModalComponents() != 0)
         return false;
 
-    Theme::ModuleUIMouseOverReaction const desiredReaction(
-        Theme::settings().moduleUIMouseOverReaction);
+    Preferences::ModuleUIMouseOverReaction const desiredReaction(
+        preferences().moduleUIMouseOverReaction());
     juce::Component const *const pFocusedComponent(juce::Component::getCurrentlyFocusedComponent());
 
     bool const nothingFocused(noModuleOrModuleControlFocused());
@@ -64,8 +65,8 @@ bool ModuleControlBase::tryActivateControl() const
                                       nothingFocused); // Intentional bitwise or as an optimization.
     bool const controlFocused(pFocusedComponent == &widget());
     if ((controlFocused) ||
-        (desiredReaction == Theme::WhenParentOrNothingSelected && parentOrNothingFocused) ||
-        (desiredReaction == Theme::WhenParentModuleSelected && parentFocused))
+        (desiredReaction == Preferences::WhenParentOrNothingSelected && parentOrNothingFocused) ||
+        (desiredReaction == Preferences::WhenParentModuleSelected && parentFocused))
         return true;
     else
         return false;

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -12,6 +12,7 @@
 
 #include "core/modules/moduleDSPAndGUI.hpp"
 #include "gui/editor/spectrumWorxEditor.hpp"
+#include "gui/preferences.hpp"
 
 #include "le/parameters/lfo.hpp"
 #include "le/parameters/printer.hpp"
@@ -733,7 +734,8 @@ void ModuleUI::deactivate()
 
 bool ModuleUI::selectionTracksMouseMovements() const
 {
-    return (Theme::settings().moduleUIMouseOverReaction == Theme::WhenParentOrNothingSelected) &&
+    return (preferences().moduleUIMouseOverReaction() ==
+            Preferences::WhenParentOrNothingSelected) &&
            ModuleControlBase::noModuleOrModuleControlFocused(editor());
 }
 

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -1,0 +1,199 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file preferences.cpp
+/// ---------------------
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "preferences.hpp"
+
+/// `rootPath()`, which is where the file goes.
+#include "gui.hpp"
+
+#include "le/utility/assert.hpp"
+#include "le/utility/platformSpecifics.hpp"
+
+#include <sst/plugininfra/userdefaults.h>
+
+#include <array>
+#include <cstdio>
+#include <optional>
+#include <string>
+
+namespace LE::SW::GUI
+{
+
+namespace
+{
+////////////////////////////////////////////////////////////////////////////////
+// The file
+////////////////////////////////////////////////////////////////////////////////
+
+/// \note What the provider makes the file name out of: it writes
+/// `<productName>UserDefaults.xml`. Named here rather than spelled twice so that
+/// file() cannot drift from what is actually opened.
+char const productName[]{"SpectrumWorx"};
+
+std::string defaultsFileName() { return std::string(productName) + "UserDefaults.xml"; }
+
+enum PreferenceKey
+{
+    moduleUIMouseOverReactionKey,
+    lfoUpdateBehaviourKey,
+    hideCursorOnKnobDragKey,
+    numberOfPreferenceKeys
+};
+
+/// \note The provider calls this for every value in [0, numberOfPreferenceKeys)
+/// when it is constructed, and these strings are the attribute names in the
+/// file, so changing one silently retires whatever a user had chosen.
+std::string preferenceKeyName(PreferenceKey const key)
+{
+    switch (key)
+    {
+    case moduleUIMouseOverReactionKey:
+        return "moduleUIMouseOverReaction";
+    case lfoUpdateBehaviourKey:
+        return "lfoUpdateBehaviour";
+    case hideCursorOnKnobDragKey:
+        return "hideCursorOnKnobDrag";
+    case numberOfPreferenceKeys:
+        break;
+    }
+    LE_UNREACHABLE_CODE();
+}
+
+/// \note stderr, which is where a DAW's log picks it up, rather than
+/// warningMessageBox(). The two things that reach here are a defaults file from
+/// a future version and a folder that cannot be written to; neither is worth
+/// putting a box in front of somebody who has just clicked a combo box, and the
+/// second would put one there on every click.
+void reportPreferencesError(std::string const &message, std::string const &title)
+{
+    std::fputs(title.c_str(), stderr);
+    std::fputs(": ", stderr);
+    std::fputs(message.c_str(), stderr);
+    std::fputs("\n", stderr);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The enumerations, by name
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr std::array<char const *, 3> mouseOverReactionNames{"Never", "WhenParentModuleSelected",
+                                                             "WhenParentOrNothingSelected"};
+
+constexpr std::array<char const *, 4> lfoUpdateBehaviourNames{"NoUpdate", "WhenControlSelected",
+                                                              "WhenControlActive", "Always"};
+
+/// The tables are indexed by the enumerator, so they have to cover it.
+static_assert(mouseOverReactionNames.size() == Preferences::WhenParentOrNothingSelected + 1);
+static_assert(lfoUpdateBehaviourNames.size() == Preferences::Always + 1);
+
+template <typename Enumeration, std::size_t count>
+std::string nameOf(Enumeration const value, std::array<char const *, count> const &names)
+{
+    auto const index(static_cast<std::size_t>(value));
+    LE_ASSERT(index < count);
+    return names[index];
+}
+
+template <typename Enumeration, std::size_t count>
+Enumeration valueNamed(std::string const &name, std::array<char const *, count> const &names,
+                       Enumeration const valueIfUnrecognised)
+{
+    for (std::size_t index(0); index < count; ++index)
+        if (name == names[index])
+            return static_cast<Enumeration>(index);
+    return valueIfUnrecognised;
+}
+
+/// \note An optional rather than a function-local static, because
+/// setPreferencesFolder() has to be able to replace it. `[main-thread]`, which is
+/// what makes that safe: everything that reads these runs under the host's
+/// message thread.
+std::optional<Preferences> instance;
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Preferences::Storage
+//
+////////////////////////////////////////////////////////////////////////////////
+
+class Preferences::Storage
+{
+  public:
+    explicit Storage(fs::path const &folder)
+        : provider(folder, productName, preferenceKeyName, reportPreferencesError),
+          file(folder / defaultsFileName())
+    {
+    }
+
+    sst::plugininfra::defaults::Provider<PreferenceKey, numberOfPreferenceKeys> provider;
+    fs::path const file;
+}; // class Preferences::Storage
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Preferences
+//
+////////////////////////////////////////////////////////////////////////////////
+
+Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Storage>(folder))
+{
+    auto &provider(storage_->provider);
+
+    moduleUIMouseOverReaction_ = valueNamed(
+        provider.getUserDefaultValue(moduleUIMouseOverReactionKey,
+                                     nameOf(moduleUIMouseOverReaction_, mouseOverReactionNames)),
+        mouseOverReactionNames, moduleUIMouseOverReaction_);
+
+    lfoUpdateBehaviour_ =
+        valueNamed(provider.getUserDefaultValue(
+                       lfoUpdateBehaviourKey, nameOf(lfoUpdateBehaviour_, lfoUpdateBehaviourNames)),
+                   lfoUpdateBehaviourNames, lfoUpdateBehaviour_);
+
+    hideCursorOnKnobDrag_ =
+        provider.getUserDefaultValue(hideCursorOnKnobDragKey, hideCursorOnKnobDrag_) != 0;
+}
+
+Preferences::~Preferences() = default;
+
+void Preferences::setModuleUIMouseOverReaction(ModuleUIMouseOverReaction const value)
+{
+    moduleUIMouseOverReaction_ = value;
+    storage_->provider.updateUserDefaultValue(moduleUIMouseOverReactionKey,
+                                              nameOf(value, mouseOverReactionNames));
+}
+
+void Preferences::setLFOUpdateBehaviour(LFOUpdateBehaviour const value)
+{
+    lfoUpdateBehaviour_ = value;
+    storage_->provider.updateUserDefaultValue(lfoUpdateBehaviourKey,
+                                              nameOf(value, lfoUpdateBehaviourNames));
+}
+
+void Preferences::setHideCursorOnKnobDrag(bool const value)
+{
+    hideCursorOnKnobDrag_ = value;
+    storage_->provider.updateUserDefaultValue(hideCursorOnKnobDragKey, value ? 1 : 0);
+}
+
+fs::path const &Preferences::file() const { return storage_->file; }
+
+////////////////////////////////////////////////////////////////////////////////
+
+Preferences &preferences()
+{
+    if (!instance)
+        instance.emplace(rootPath());
+    return *instance;
+}
+
+void setPreferencesFolder(fs::path const &folder) { instance.emplace(folder); }
+
+} // namespace LE::SW::GUI

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file preferences.hpp
+/// ---------------------
+///
+///   The three answers the settings panel's Interface page asks for, and the
+/// file they survive in.
+///
+/// \note These were `Theme::Settings`, three members of a process-wide static
+/// that nothing ever read off disk or wrote back to it: every session started at
+/// the defaults, whatever the user had chosen last time. \see issue #61.
+///
+///   They are not the Theme's. A LookAndFeel answers "what does this widget look
+/// like"; these answer "how does this user like the editor to behave", which is
+/// the question `sst::plugininfra::defaults::Provider` exists for and which
+/// outlives any one plugin instance. The move is what lets the answer live
+/// beside the user's presets -- `rootPath()` is in the widget layer and Theme is
+/// below it, so a Theme that persisted itself would have had to work out where
+/// the user's folder is a second time.
+///                                       (15.08.2026.) (SW port)
+///
+/// Copyright (c) 2009 - 2016. Little Endian Ltd.
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
+#define preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
+//------------------------------------------------------------------------------
+/// `fs`, for the folder the file lives in.
+#include "filesystem/import.h"
+
+#include <memory>
+
+namespace LE::SW::GUI
+{
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \class Preferences
+///
+/// \brief What the user chose on the Interface page, kept in
+/// `<folder>/SpectrumWorxUserDefaults.xml`.
+///
+/// \note Values are cached in members rather than read through the provider on
+/// every call: `moduleUIMouseOverReaction()` is asked on mouse movement over a
+/// module control, and the provider's answer is a map lookup and a string
+/// comparison. Each setter writes its own key through, so the file is one
+/// rewrite per user click rather than three.
+///
+/// \note The enumerations are streamed by *name*, not by ordinal. The struct
+/// this replaces carried a "layout is on disk; do not reorder it" note -- about
+/// a binary blob that no longer exists -- and a name has no such constraint:
+/// inserting a value in the middle cannot silently change what an existing file
+/// means, and the file stays legible to whoever opens it. The names are the enum
+/// identifiers, so a value in the file can be grepped for in the source. An
+/// unrecognised one reads as the default.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class Preferences
+{
+  public:
+    enum ModuleUIMouseOverReaction
+    {
+        Never,
+        WhenParentModuleSelected,
+        WhenParentOrNothingSelected
+    };
+
+    enum LFOUpdateBehaviour
+    {
+        NoUpdate,
+        WhenControlSelected,
+        WhenControlActive,
+        Always
+    };
+
+  public:
+    /// \note Reads the file. A missing one is not an error -- it is what a first
+    /// run looks like -- and leaves every value at its default.
+    explicit Preferences(fs::path const &folder);
+    ~Preferences();
+
+    Preferences(Preferences const &) = delete; // makes non-copyable
+    Preferences &operator=(Preferences const &) = delete;
+
+    ModuleUIMouseOverReaction moduleUIMouseOverReaction() const
+    {
+        return moduleUIMouseOverReaction_;
+    }
+    LFOUpdateBehaviour lfoUpdateBehaviour() const { return lfoUpdateBehaviour_; }
+    bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
+
+    /// Each of these writes the file. `[main-thread]`
+    void setModuleUIMouseOverReaction(ModuleUIMouseOverReaction);
+    void setLFOUpdateBehaviour(LFOUpdateBehaviour);
+    void setHideCursorOnKnobDrag(bool);
+
+    /// Where this instance reads and writes.
+    fs::path const &file() const;
+
+  private:
+    /// \note Out of line so that `sst/plugininfra/userdefaults.h` -- and with it
+    /// tinyxml, `<fstream>` and `<iostream>` -- is preferences.cpp's business
+    /// rather than every editor translation unit's.
+    class Storage;
+    std::unique_ptr<Storage> storage_;
+
+    ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
+    LFOUpdateBehaviour lfoUpdateBehaviour_{Always};
+    bool hideCursorOnKnobDrag_{true};
+}; // class Preferences
+
+/// \brief The process-wide preferences, under `rootPath()` -- beside the user's
+/// presets, which is the folder a user already knows to look in. `[main-thread]`
+///
+/// \note Answered on demand rather than initialised, for the reason rootPath()
+/// is: there is then no "too early" to get wrong. \see gui.cpp.
+Preferences &preferences();
+
+/// \brief Rebuilds the above against \p folder, for the tests.
+///
+///   A test that opens the Interface page reads these, and a test that clicks
+/// its LED writes them; neither may touch the file the developer running it
+/// actually uses. tests/gui/preferencesTests.cpp points the whole binary at its
+/// build tree once, before any case runs.
+void setPreferencesFolder(fs::path const &folder);
+
+} // namespace LE::SW::GUI
+
+//------------------------------------------------------------------------------
+#endif // preferences_hpp

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -46,13 +46,6 @@ void paintSliderThumb(juce::Graphics &graphics, Artwork const &image, float cons
 }
 } // anonymous namespace
 
-Theme::Settings Theme::settings_;
-
-Theme::Settings::Settings()
-    : moduleUIMouseOverReaction(Never), lfoUpdateBehaviour(Always), hideCursorOnKnobDrag(true)
-{
-}
-
 /// \note 2016 named the font family -- "Bitstream Vera Sans" -- after
 /// registering the .ttf files with the operating system. The typefaces come
 /// straight out of the binary now, so they are handed to JUCE by pointer and

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -3,8 +3,12 @@
 /// \file theme.hpp
 /// ---------------
 ///
-///   SpectrumWorx's LookAndFeel, and the handful of user-visible preferences
-/// that travel with it.
+///   SpectrumWorx's LookAndFeel.
+///
+/// \note A `Theme::Settings` used to travel with it -- the three answers the
+/// settings panel's Interface page asks for. They were never the LookAndFeel's
+/// and they are GUI::Preferences now. \see preferences.hpp.
+///                                       (15.08.2026.) (SW port)
 ///
 ///   Split out of gui.hpp so that it can be built and looked at before the
 /// widget set compiles: everything else in src/gui reaches Theme for a font or
@@ -74,35 +78,6 @@ class Theme final : public juce::LookAndFeel_V2
     Theme(Theme const &) = delete; // makes non-copyable
     Theme &operator=(Theme const &) = delete;
 
-    enum ModuleUIMouseOverReaction
-    {
-        Never,
-        WhenParentModuleSelected,
-        WhenParentOrNothingSelected
-    };
-
-    enum LFOUpdateBehaviour
-    {
-        NoUpdate,
-        WhenControlSelected,
-        WhenControlActive,
-        Always
-    };
-
-    /// \note The "layout is on disk; do not reorder it" that stood here was about
-    /// SpectrumWorx.dat, which spectrumWorx.cpp wrote these out to verbatim.
-    /// Neither survives: the CLAP build persists none of this, and the note went
-    /// on outranking that fact.
-    ///                                       (14.08.2026.) (SW port)
-    struct Settings
-    {
-        Settings();
-
-        ModuleUIMouseOverReaction moduleUIMouseOverReaction;
-        LFOUpdateBehaviour lfoUpdateBehaviour;
-        bool hideCursorOnKnobDrag;
-    };
-
   public:
     static void createSingleton();
     static void destroySingleton();
@@ -118,8 +93,6 @@ class Theme final : public juce::LookAndFeel_V2
 
     juce::Font const &blueFont() const { return blueFont_; }
     juce::Font const &whiteFont() const { return whiteFont_; }
-
-    static Settings &settings() { return settings_; }
 
   public: // juce::LookAndFeel_V2 overrides
     void drawLinearSliderBackground(juce::Graphics &, int x, int y, int width, int height,
@@ -149,8 +122,6 @@ class Theme final : public juce::LookAndFeel_V2
     juce::Font const whiteFont_;
 
     std::unique_ptr<juce::Drawable> folderIcon_;
-
-    static Settings settings_;
 }; // class Theme
 
 } // namespace LE::SW::GUI

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -2260,16 +2260,18 @@ catch (...)
 /// is a list that will grow one bullet at a time, and guessing at it now would
 /// be inventing a schema for settings nobody has asked to persist yet.
 ///
-///   The two candidates, both `[main-thread]` and neither of them a parameter:
+///   The candidate, `[main-thread]` and not a parameter: the preset browser's
+/// location and selection -- it does not remember where it was, for the session
+/// case.
 ///
-///   - the preset browser's location and selection -- it does not remember where
-///     it was, for the session case;
-///   - the interface settings (mouse-over reaction, LFO update behaviour,
-///     hide-cursor-on-knob-drag), which the CLAP build persists nowhere at all,
-///     so they are back at their defaults every time the plugin is loaded. Those
-///     are arguably user preferences rather than session state, and
-///     sst-plugininfra's userdefaults.h is the other candidate home; the two are
-///     not exclusive and surge uses both.
+/// \note The settings panel's Interface page was the other candidate and is no
+/// longer one. Mouse-over reaction, LFO update behaviour and
+/// hide-cursor-on-knob-drag persisted nowhere at all (issue #61); they are
+/// answers about how this user likes the editor to behave rather than about this
+/// session, so they went to the user preferences file instead --
+/// `sst::plugininfra::defaults::Provider`, \see gui/preferences.hpp. The two
+/// homes are not exclusive, and surge uses both; these belong in that one.
+///                                       (15.08.2026.) (SW port)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(sw-plugin-tests
         gui/moduleDragTests.cpp
         gui/overlayPanelTests.cpp
         gui/pathsTests.cpp
+        gui/preferencesTests.cpp
         gui/skinTests.cpp
         gui/twoInstanceTests.cpp
         io/jucePathTests.cpp

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -1,0 +1,321 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// preferencesTests.cpp
+/// --------------------
+///
+///   The three interface preferences, and the two halves of issue #61: that they
+/// reach the file at all, and that the Interface page is wired to the file rather
+/// than to a process-wide default that every session started over.
+///
+/// \note The last two cases go through the widgets rather than through
+/// `Preferences` directly, because "it is saved" and "the panel saves it" are
+/// different claims and only the second one was ever wrong. What they cannot go
+/// through is the combo box's popup menu: it is asynchronous and there is no
+/// message loop in a test binary, so a case drives `comboBoxValueChanged()` -- the
+/// function the menu's own callback calls, and the only thing it does with the
+/// menu's answer.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+#include "gui/preferences.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using Editor = GUI::SpectrumWorxEditor;
+using Preferences = GUI::Preferences;
+
+fs::path preferencesRoot() { return fs::path(SW_TEST_OUTPUT_DIR) / "preferences"; }
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Points the whole binary's preferences at an empty folder in the build
+/// tree, before any case runs.
+///
+/// \note Registered here and it covers every file: `GUI::preferences()` is
+/// process-wide and several gui cases in other files open the Interface page.
+/// Without this they would read the preferences of whoever is running the suite,
+/// so what they saw would depend on that person's last click.
+///
+/// \note testRunStarting rather than a fixture, because the earliest thing that
+/// reads these is a case in another file.
+///
+/// \note **Nothing writes here, and this folder is never emptied.** ctest runs one
+/// process per case and eight at a time, so every case that means to *write* a
+/// preference takes a folder of its own below -- see caseFolder(). A shared one
+/// would have cases overwriting each other's file and deleting the folder out
+/// from under each other, which is what one release run of this file did before
+/// they were separated.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class PreferencesInTheBuildTree final : public Catch::EventListenerBase
+{
+  public:
+    using Catch::EventListenerBase::EventListenerBase;
+
+    void testRunStarting(Catch::TestRunInfo const &) override
+    {
+        GUI::setPreferencesFolder(preferencesRoot() / "unwritten");
+    }
+}; // class PreferencesInTheBuildTree
+
+CATCH_REGISTER_LISTENER(PreferencesInTheBuildTree)
+
+/// A folder of this case's own, empty. \p name has to be unique in this file.
+fs::path caseFolder(char const *const name)
+{
+    auto const folder(preferencesRoot() / name);
+    fs::remove_all(folder);
+    return folder;
+}
+
+/// The same, and the process-wide preferences moved onto it -- for the cases that
+/// go through the editor, which reaches `GUI::preferences()` rather than an
+/// instance a case can hand it.
+void useCaseFolder(char const *const name) { GUI::setPreferencesFolder(caseFolder(name)); }
+
+std::string contentsOf(fs::path const &file)
+{
+    std::ifstream stream(file);
+    std::ostringstream text;
+    text << stream.rdbuf();
+    return text.str();
+}
+
+void write(fs::path const &file, std::string const &text)
+{
+    fs::create_directories(file.parent_path());
+    std::ofstream stream(file);
+    stream << text;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Reaching the widgets
+////////////////////////////////////////////////////////////////////////////////
+
+/// Every descendant of \p root that is a \p Widget, in child order.
+template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Component &root)
+{
+    std::vector<Widget *> found;
+    for (auto *const pChild : root.getChildren())
+    {
+        if (auto *const pWidget(dynamic_cast<Widget *>(pChild)); pWidget)
+            found.push_back(pWidget);
+        for (auto *const pDeeper : descendantsOfType<Widget>(*pChild))
+            found.push_back(pDeeper);
+    }
+    return found;
+}
+
+/// \brief The Interface page's two combo boxes, told apart by how many choices
+/// each offers rather than by the order they were added in.
+///
+/// \note A TabbedComponent keeps only the *current* page as a child, so the
+/// engine page's three combo boxes -- which are TitledComboBoxes too -- are not
+/// in the tree while the Interface tab is up. The count is required rather than
+/// assumed, so that a layout change fails here instead of silently sending the
+/// rest of the case at the wrong widget.
+GUI::TitledComboBox &comboBoxOffering(Editor &editor, unsigned int const choices)
+{
+    auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
+    REQUIRE(comboBoxes.size() == 2);
+
+    for (auto *const pComboBox : comboBoxes)
+        if (pComboBox->numberOfItems() == choices)
+            return *pComboBox;
+
+    FAIL("no combo box on the Interface page offers " << choices << " choices");
+    return *comboBoxes.front();
+}
+
+GUI::TitledComboBox &mouseOverComboBox(Editor &editor) { return comboBoxOffering(editor, 3); }
+GUI::TitledComboBox &lfoUpdateComboBox(Editor &editor) { return comboBoxOffering(editor, 4); }
+
+/// The one LED on the Interface page, found through the combo boxes so that the
+/// module strips' own LEDs cannot be picked up instead.
+GUI::LEDTextButton &hideCursorButton(Editor &editor)
+{
+    auto *const pPage(mouseOverComboBox(editor).getParentComponent());
+    REQUIRE(pPage != nullptr);
+
+    auto const buttons(descendantsOfType<GUI::LEDTextButton>(*pPage));
+    REQUIRE(buttons.size() == 1);
+    return *buttons.front();
+}
+
+/// An editor with the Interface page up.
+Editor &editorOnTheInterfacePage(SWTest::Instance &instance)
+{
+    instance.openEditor(Editor::PanelPlacement::overlay);
+    instance.editor().showSettings(Editor::interfacePageIndex);
+    return instance.editor();
+}
+
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+// The file
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("With no preferences file every value is at its default", "[gui][preferences]")
+{
+    Preferences const preferences(caseFolder("absent"));
+
+    CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
+    CHECK(preferences.lfoUpdateBehaviour() == Preferences::Always);
+    CHECK(preferences.hideCursorOnKnobDrag());
+
+    /// \note And reading wrote nothing. A plugin that has only ever been opened
+    /// has no preferences to record, and a file appearing in the user's folder on
+    /// first launch is a claim that it does.
+    CHECK(!fs::exists(preferences.file()));
+}
+
+TEST_CASE("Every preference survives a new instance over the same folder", "[gui][preferences]")
+{
+    auto const folder(caseFolder("roundTrip"));
+
+    {
+        Preferences written(folder);
+        written.setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
+        written.setLFOUpdateBehaviour(Preferences::WhenControlActive);
+        written.setHideCursorOnKnobDrag(false);
+
+        REQUIRE(fs::exists(written.file()));
+    }
+
+    Preferences const read(folder);
+    CHECK(read.moduleUIMouseOverReaction() == Preferences::WhenParentModuleSelected);
+    CHECK(read.lfoUpdateBehaviour() == Preferences::WhenControlActive);
+    CHECK(!read.hideCursorOnKnobDrag());
+}
+
+TEST_CASE("The file names its keys and its enumerated values", "[gui][preferences]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The on-disk contract, pinned the way the preset format's is. What
+    /// makes it worth a case rather than a comment is that the alternative --
+    /// writing the enumerator's ordinal -- reads back wrong rather than not at
+    /// all the first time somebody inserts a value in the middle, and nothing
+    /// else in the suite would notice.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    auto const folder(caseFolder("names"));
+
+    Preferences preferences(folder);
+    preferences.setModuleUIMouseOverReaction(Preferences::WhenParentOrNothingSelected);
+    preferences.setLFOUpdateBehaviour(Preferences::WhenControlSelected);
+    preferences.setHideCursorOnKnobDrag(false);
+
+    auto const file(contentsOf(preferences.file()));
+    CAPTURE(file);
+
+    CHECK(file.find("key=\"moduleUIMouseOverReaction\" value=\"WhenParentOrNothingSelected\"") !=
+          std::string::npos);
+    CHECK(file.find("key=\"lfoUpdateBehaviour\" value=\"WhenControlSelected\"") !=
+          std::string::npos);
+    CHECK(file.find("key=\"hideCursorOnKnobDrag\" value=\"0\"") != std::string::npos);
+}
+
+TEST_CASE("A value this build does not recognise reads as the default", "[gui][preferences]")
+{
+    // The file is the user's to edit, and a downgrade is the same case.
+    auto const folder(caseFolder("unrecognised"));
+
+    write(folder / "SpectrumWorxUserDefaults.xml",
+          "<?xml version = \"1.0\" encoding = \"UTF-8\" ?>\n"
+          "<defaults version=\"1\">\n"
+          "  <default key=\"moduleUIMouseOverReaction\" value=\"Sideways\" type=\"1\"/>\n"
+          "  <default key=\"lfoUpdateBehaviour\" value=\"WhenControlActive\" type=\"1\"/>\n"
+          "</defaults>\n");
+
+    Preferences const preferences(folder);
+
+    CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
+    // ...and the key it could not read did not cost it the one beside it.
+    CHECK(preferences.lfoUpdateBehaviour() == Preferences::WhenControlActive);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The Interface page
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The Interface page opens showing what is in the preferences", "[gui][preferences]")
+{
+    useCaseFolder("pageReads");
+    GUI::preferences().setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
+    GUI::preferences().setLFOUpdateBehaviour(Preferences::NoUpdate);
+    GUI::preferences().setHideCursorOnKnobDrag(false);
+
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(editorOnTheInterfacePage(instance));
+
+    CHECK(mouseOverComboBox(editor).getSelectedID() == Preferences::WhenParentModuleSelected);
+    CHECK(lfoUpdateComboBox(editor).getSelectedID() == Preferences::NoUpdate);
+    CHECK(!hideCursorButton(editor).getToggleState());
+}
+
+TEST_CASE("Choosing a mouse-over reaction on the page writes it to the file", "[gui][preferences]")
+{
+    useCaseFolder("pageWritesTheComboBox");
+    GUI::preferences().setModuleUIMouseOverReaction(Preferences::Never);
+
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(editorOnTheInterfacePage(instance));
+
+    auto &comboBox(mouseOverComboBox(editor));
+    comboBox.setSelectedID(Preferences::WhenParentOrNothingSelected);
+    Editor::Settings::comboBoxValueChanged(comboBox);
+
+    CHECK(GUI::preferences().moduleUIMouseOverReaction() ==
+          Preferences::WhenParentOrNothingSelected);
+
+    // And on disk, which is the half issue #61 was about.
+    Preferences const onDisk(GUI::preferences().file().parent_path());
+    CHECK(onDisk.moduleUIMouseOverReaction() == Preferences::WhenParentOrNothingSelected);
+}
+
+TEST_CASE("Toggling hide-cursor-on-knob-drag on the page writes it to the file",
+          "[gui][preferences]")
+{
+    useCaseFolder("pageWritesTheLED");
+    GUI::preferences().setHideCursorOnKnobDrag(true);
+
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(editorOnTheInterfacePage(instance));
+
+    auto &button(hideCursorButton(editor));
+    REQUIRE(button.getToggleState());
+
+    /// \note sendNotificationSync, which is what makes this reachable headlessly:
+    /// juce::Button calls its listeners from inside the call rather than posting.
+    button.setToggleState(false, juce::sendNotificationSync);
+
+    CHECK(!GUI::preferences().hideCursorOnKnobDrag());
+
+    Preferences const onDisk(GUI::preferences().file().parent_path());
+    CHECK(!onDisk.hideCursorOnKnobDrag());
+}


### PR DESCRIPTION
The settings panel's Interface page -- mouse-over reaction, LFO update behaviour, hide-cursor-on-knob-drag -- was writing to a process-wide static that nothing ever read off disk, so every session started at the defaults whatever the user had chosen last time.

They now live in the user's own preferences file, beside the presets, in sst-plugininfra's user defaults provider. They are not session state: they say how this user likes the editor to behave, so they are the same in every instance and every project, and they do not belong in a host's state blob. Both enumerations are streamed by name rather than by ordinal, so inserting a value cannot change what an existing file means.

Theme keeps only the LookAndFeel. The three were never its, and it sits below the layer that knows where the user's folder is.

Closes #61.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>