### PR TITLE
Let the user choose the editor's zoom

### DIFF
--- a/doc/tech/streaming_format.md
+++ b/doc/tech/streaming_format.md
@@ -272,17 +272,23 @@ the payload accrues. The candidate is the preset browser's location and
 selection, which is main-thread and is not a parameter.
 
 The settings panel's Interface page is *not* a candidate, and it is the case that
-says where the line is. Those three — mouse-over reaction, LFO update behaviour,
-hide-cursor-on-knob-drag — used to persist nowhere at all (issue #61). They are
-answers about how this user likes the editor to behave, not about this session,
-so they are the same in every instance and in every project, and they belong in
-the user's preferences file rather than in a host's state blob:
-`<user folder>/SpectrumWorxUserDefaults.xml`, through
+says where the line is. Its four — zoom, mouse-over reaction, LFO update
+behaviour, hide-cursor-on-knob-drag — used to persist nowhere at all (issues #61
+and #55). They are answers about how this user likes the editor to behave, not
+about this session, so they are the same in every instance and in every project,
+and they belong in the user's preferences file rather than in a host's state
+blob: `<user folder>/SpectrumWorxUserDefaults.xml`, through
 `sst::plugininfra::defaults::Provider`. \see `src/gui/preferences.hpp`. Its
 format is that library's; what this tree fixes about it is that both
 enumerations are streamed **by name**, so inserting a value cannot silently
 change what an existing file means. `tests/gui/preferencesTests.cpp` pins the
 names.
+
+The zoom is a percentage, and **100 is the size the plugin has always opened
+at** rather than a scale factor of one: the skin is a 563 x 376 bitmap laid out
+for a 2010 screen and `ZoomedEditor` has drawn it at 1.5x since the port. A
+percentage the build does not offer — 300, say — reads as 100 rather than being
+clamped, because the combo box could show nothing for it.
 
 Note what does *not* need it — the loaded sample. `<Global Sample="…">` has
 carried that since 2011, so putting state on the preset serialisation restores it

--- a/src/gui/editor/editorHost.hpp
+++ b/src/gui/editor/editorHost.hpp
@@ -222,6 +222,31 @@ class EditorHost
     virtual bool requestEditorSize(int width, int height) = 0;
 
     ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Says the editor *is* now \p width x \p height, and that the window
+    /// around it has to follow. `[main-thread]`
+    ///
+    ///   An announcement, where requestEditorSize() above is a negotiation, and
+    /// the difference is whether there is a fallback. A host that will not widen
+    /// its window for the preset browser gets the browser over the module strips
+    /// instead, so asking first is right there. A user who picks 200 % gets 200
+    /// %; there is nothing else to give them, so the editor changes and this
+    /// carries the consequence outwards.
+    ///
+    /// \note And it must not stop at a refusal, which is what made zoom draw in
+    /// the wrong place. `clap-wrapper`'s macOS standalone resizes its window and
+    /// **returns false** from `request_resize` (AppDelegate.mm), so a refusal
+    /// does not even mean the window stayed put. Treating it as one left the
+    /// shim's own components at the old size while the window had the new one --
+    /// and a JUCE peer inside a foreign NSView is anchored at Cocoa's bottom
+    /// left, so the mismatch showed up as the editor sliding up or down the
+    /// window rather than as a wrong size. \see issue #55.
+    ///                                       (16.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    virtual void editorSizeChanged(int width, int height) = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
     // The side channel's sample: the external audio file that feeds it in place
     // of the host's side chain port.
     //

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -20,6 +20,7 @@
 #include "core/threading/publish.hpp"
 #include "gui/editor/editorHost.hpp"
 #include "gui/editor/presetLoading.hpp"
+#include "gui/editor/zoomedEditor.hpp"
 #include "gui/preferences.hpp"
 #include "io/jucePath.hpp"
 
@@ -40,6 +41,7 @@
 #include "le/utility/ignoreUnused.hpp"
 
 #include <array>
+#include <cstdio>
 #include <span>
 #include <optional>
 #include <string_view>
@@ -447,6 +449,27 @@ bool SpectrumWorxEditor::setPanelColumnVisible(bool const wanted)
     panelHasOwnColumn_ = wanted;
     setSize(width, estimatedHeight);
     return wanted;
+}
+
+void SpectrumWorxEditor::setZoom(unsigned int const zoomPercent)
+{
+    if (!Preferences::isOfferedZoom(zoomPercent))
+        return;
+
+    preferences().setZoomPercent(zoomPercent);
+
+    if (auto *const pWrapper = findParentComponentOfClass<ZoomedEditor>())
+        pWrapper->setZoomPercent(zoomPercent);
+
+    /// \note In skin pixels, like every other caller: the scaling to window
+    /// units happens on the far side, out of the same preference this has just
+    /// written.
+    ///
+    /// \note And an announcement rather than a request -- the editor has already
+    /// changed and there is no fallback to negotiate for. \see
+    /// EditorHost::editorSizeChanged(), which has what treating it as a request
+    /// looked like.
+    editorHost_.editorSizeChanged(getWidth(), getHeight());
 }
 
 void SpectrumWorxEditor::panelPlacement(PanelPlacement const placement)
@@ -3346,6 +3369,10 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
         LE_VERIFY(editor.globalParameterChanged<WindowFunction>(
             static_cast<WindowFunction ::value_type>(value), true));
     }
+    else if (&comboBox == &settings.interfacePage_.zoomComboBox())
+    {
+        editor.setZoom(value);
+    }
     else if (&comboBox == &settings.interfacePage_.mouseOverComboBox())
     {
         preferences().setModuleUIMouseOverReaction(
@@ -3479,12 +3506,24 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : BackgroundImage(resourceArtwork<SettingsIntrfcBg>()),
-      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 0 * yStep, "Mouse over reaction"),
-      lfoUpdateBehaviour_(*this, xMargin, yMargin + 1 * yStep, "LFO update behaviour"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 2 * yStep, "Hide cursor on knob drag")
+      zoom_(*this, xMargin, yMargin + 0 * yStep, "Zoom"),
+      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 1 * yStep, "Mouse over reaction"),
+      lfoUpdateBehaviour_(*this, xMargin, yMargin + 2 * yStep, "LFO update behaviour"),
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep, "Hide cursor on knob drag")
 {
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));
+
+    /// \note The percentage is the item's ID, so what comes back out of
+    /// `getValue()` is the zoom itself rather than a position in this list that
+    /// something else would have to translate.
+    for (auto const percent : Preferences::zoomPercentages)
+    {
+        std::array<char, 8> text;
+        std::snprintf(text.data(), text.size(), "%u%%", percent);
+        zoom_.addItem(percent, text.data());
+    }
+    zoom_.setSelectedID(preferences().zoomPercent());
 
     moduleUIMouseOverReaction_.addItem(Preferences::Never, "Never");
     moduleUIMouseOverReaction_.addItem(Preferences::WhenParentModuleSelected, "Module selected");

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -629,6 +629,35 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// the button is private and its handler recovers the editor from it.
     void showSettings(unsigned int pageIndexToActivate);
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Shows this editor at \p zoomPercent and remembers the choice.
+    ///
+    ///   Three things in one call, and they have to happen in this order:
+    /// the preference is written first, because it is what everything else
+    /// reads; then the wrapper is re-transformed and re-sized; then the host is
+    /// asked for a window that matches.
+    ///
+    /// \note This editor, not every open one. The preference is process-wide and
+    /// a second instance picks it up when its editor is next built -- the same
+    /// as the other three, and for the same reason: an editor reads them once,
+    /// when it is made.
+    ///
+    /// \note A bare editor -- what the tests and `tools/show-ui`'s 1:1 render
+    /// build -- has no ZoomedEditor over it, so there is nothing to transform;
+    /// the preference is still written. \see zoomedEditor.hpp on why the zoom
+    /// lives in the wrapper.
+    ///
+    /// \note A host that refuses the resize leaves its window at the old size
+    /// with the editor drawn at the new scale until the editor is next opened,
+    /// at which point `guiGetSize` reports the zoomed size and it comes right.
+    /// The alternative -- refusing to zoom because the window did not move --
+    /// would leave the user with a control that silently does nothing.
+    ///                                       (16.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void setZoom(unsigned int zoomPercent);
+
   private:
     ////////////////////////////////////////////////////////////////////////////
     ///
@@ -1219,8 +1248,16 @@ class SpectrumWorxEditor final : private SkinLifetime,
           private: // JUCE component overrides.
             void paint(juce::Graphics &) override;
 
+          public:
+            TitledComboBox const &zoomComboBox() const { return zoom_; }
+
           private:
             friend class Settings;
+            /// \note Zoom first: it is the one a user reaches for, and the two
+            /// below it are set once and forgotten. Nothing is baked into the
+            /// page bitmap -- each control draws its own title -- so the order
+            /// is a layout decision rather than an artwork one.
+            TitledComboBox zoom_;
             TitledComboBox moduleUIMouseOverReaction_;
             TitledComboBox lfoUpdateBehaviour_;
             LEDTextButton hideCursorOnKnobDrag_;

--- a/src/gui/editor/zoomedEditor.hpp
+++ b/src/gui/editor/zoomedEditor.hpp
@@ -15,6 +15,8 @@
 //------------------------------------------------------------------------------
 #include "spectrumWorxEditor.hpp"
 
+#include "gui/preferences.hpp"
+
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <memory>
@@ -53,28 +55,82 @@ namespace LE::SW::GUI
 class ZoomedEditor final : public juce::Component
 {
   public:
-    /// What the plugin shows. Not a constant of the editor, because the editor
-    /// does not know it is being scaled.
-    static constexpr float defaultZoom{1.5f};
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The transform a user-facing 100% means.
+    ///
+    ///   The skin is a 563 x 376 bitmap laid out for a 2010 screen and the
+    /// plugin has always drawn it at 1.5x. That 1.5 is what "normal size" has
+    /// meant since, so it is what 100% is defined as here rather than something
+    /// the user is shown -- a zoom combo offering 150% as its resting value
+    /// would be describing the bitmap rather than the window.
+    ///                                       (16.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr float scaleAtOneHundredPercent{1.5f};
 
-    static constexpr int scaled(int const skinPixels, float const zoom = defaultZoom)
+    static constexpr float scaleForZoom(unsigned int const zoomPercent)
     {
-        return static_cast<int>(static_cast<float>(skinPixels) * zoom + 0.5f);
+        return scaleAtOneHundredPercent * static_cast<float>(zoomPercent) / 100.0f;
     }
 
-    ZoomedEditor(std::unique_ptr<SpectrumWorxEditor> editor, float const zoom = defaultZoom)
-        : pEditor_(std::move(editor)), zoom_(zoom)
+    static constexpr int scaled(int const skinPixels, float const scale)
+    {
+        return static_cast<int>(static_cast<float>(skinPixels) * scale + 0.5f);
+    }
+
+    /// \brief \p skinPixels at the zoom the user has asked for.
+    ///
+    /// \note What every size crossing into the host goes through. The editor
+    /// asks in skin pixels -- it does not know it is being scaled -- so the
+    /// preference is read here rather than threaded through the editor, and one
+    /// answer serves the window, the shim and this component.
+    static int scaledForCurrentZoom(int const skinPixels)
+    {
+        return scaled(skinPixels, scaleForZoom(preferences().zoomPercent()));
+    }
+
+    explicit ZoomedEditor(std::unique_ptr<SpectrumWorxEditor> editor)
+        : ZoomedEditor(std::move(editor), preferences().zoomPercent())
+    {
+    }
+
+    ZoomedEditor(std::unique_ptr<SpectrumWorxEditor> editor, unsigned int const zoomPercent)
+        : pEditor_(std::move(editor)), zoomPercent_(zoomPercent)
     {
         LE_ASSERT(pEditor_ != nullptr);
         setOpaque(true);
         addAndMakeVisible(*pEditor_);
         pEditor_->setTopLeftPosition(0, 0);
-        pEditor_->setTransform(juce::AffineTransform::scale(zoom_));
-        matchEditor();
+        applyZoom();
     }
 
     SpectrumWorxEditor &editor() const { return *pEditor_; }
-    float zoom() const { return zoom_; }
+    unsigned int zoomPercent() const { return zoomPercent_; }
+    float scale() const { return scaleForZoom(zoomPercent_); }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Redraws the editor at \p zoomPercent and resizes to match.
+    ///
+    /// \note The transform is replaced rather than composed -- `setTransform`
+    /// takes the whole of it -- so this can be called any number of times
+    /// without the scales multiplying.
+    ///
+    /// \note It does not tell the host. Asking for a window is the plugin's
+    /// half and goes through `EditorHost::requestEditorSize`, which reads the
+    /// same preference; \see SpectrumWorxEditor::setZoom(), which does both in
+    /// the order that keeps them agreeing.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void setZoomPercent(unsigned int const zoomPercent)
+    {
+        if (zoomPercent == zoomPercent_)
+            return;
+
+        zoomPercent_ = zoomPercent;
+        applyZoom();
+    }
 
     /// \note Black, for the half pixel that rounding can leave down the right
     /// and bottom edges when the scaled size is not integral. The same reason
@@ -99,13 +155,19 @@ class ZoomedEditor final : public juce::Component
             matchEditor();
     }
 
+    void applyZoom()
+    {
+        pEditor_->setTransform(juce::AffineTransform::scale(scale()));
+        matchEditor();
+    }
+
     void matchEditor()
     {
-        setSize(scaled(pEditor_->getWidth(), zoom_), scaled(pEditor_->getHeight(), zoom_));
+        setSize(scaled(pEditor_->getWidth(), scale()), scaled(pEditor_->getHeight(), scale()));
     }
 
     std::unique_ptr<SpectrumWorxEditor> pEditor_;
-    float const zoom_;
+    unsigned int zoomPercent_;
 }; // class ZoomedEditor
 
 } // namespace LE::SW::GUI

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -18,6 +18,7 @@
 
 #include <sst/plugininfra/userdefaults.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdio>
 #include <optional>
@@ -44,6 +45,7 @@ enum PreferenceKey
     moduleUIMouseOverReactionKey,
     lfoUpdateBehaviourKey,
     hideCursorOnKnobDragKey,
+    zoomPercentKey,
     numberOfPreferenceKeys
 };
 
@@ -60,6 +62,8 @@ std::string preferenceKeyName(PreferenceKey const key)
         return "lfoUpdateBehaviour";
     case hideCursorOnKnobDragKey:
         return "hideCursorOnKnobDrag";
+    case zoomPercentKey:
+        return "zoomPercent";
     case numberOfPreferenceKeys:
         break;
     }
@@ -159,6 +163,21 @@ Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Sto
 
     hideCursorOnKnobDrag_ =
         provider.getUserDefaultValue(hideCursorOnKnobDragKey, hideCursorOnKnobDrag_) != 0;
+
+    /// \note Checked against the offered list rather than clamped to its ends.
+    /// A file naming a zoom this build does not have is a file from another
+    /// build or from a text editor, and there is no reading of "300" that the
+    /// combo box could then show.
+    auto const zoom(static_cast<unsigned int>(
+        provider.getUserDefaultValue(zoomPercentKey, static_cast<int>(zoomPercent_))));
+    if (Preferences::isOfferedZoom(zoom))
+        zoomPercent_ = zoom;
+}
+
+bool Preferences::isOfferedZoom(unsigned int const percent)
+{
+    return std::find(zoomPercentages.begin(), zoomPercentages.end(), percent) !=
+           zoomPercentages.end();
 }
 
 Preferences::~Preferences() = default;
@@ -181,6 +200,16 @@ void Preferences::setHideCursorOnKnobDrag(bool const value)
 {
     hideCursorOnKnobDrag_ = value;
     storage_->provider.updateUserDefaultValue(hideCursorOnKnobDragKey, value ? 1 : 0);
+}
+
+void Preferences::setZoomPercent(unsigned int const percent)
+{
+    LE_ASSERT_MSG(isOfferedZoom(percent), "a zoom the Interface page cannot show");
+    if (!isOfferedZoom(percent))
+        return;
+
+    zoomPercent_ = percent;
+    storage_->provider.updateUserDefaultValue(zoomPercentKey, static_cast<int>(percent));
 }
 
 fs::path const &Preferences::file() const { return storage_->file; }

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -31,6 +31,7 @@
 /// `fs`, for the folder the file lives in.
 #include "filesystem/import.h"
 
+#include <array>
 #include <memory>
 
 namespace LE::SW::GUI
@@ -77,6 +78,30 @@ class Preferences
         Always
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The zooms the Interface page offers, ascending, as percentages.
+    ///
+    /// \note **100 is the size the skin was drawn for, not a scale factor of
+    /// one.** Every offset in the editor is a pixel position in a 563 x 376
+    /// bitmap from 2010, and that is small on a screen sold since; the plugin
+    /// has always drawn it at 1.5x and called that its normal size. So the
+    /// percentage a user picks is a statement about how big the editor should
+    /// look, and ZoomedEditor is what turns it into a transform. \see issue #55.
+    ///
+    /// \note This list is the whole of what a zoom may be: it is what the combo
+    /// box offers and what a value read out of the preferences file is checked
+    /// against. A typed-in or dragged custom zoom is a separate question and
+    /// waits on the skin being vector.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static constexpr std::array<unsigned int, 7> zoomPercentages{50, 75, 90, 100, 125, 150, 200};
+
+    static constexpr unsigned int defaultZoomPercent{100};
+
+    /// Whether \p percent is one of the above.
+    static bool isOfferedZoom(unsigned int percent);
+
   public:
     /// \note Reads the file. A missing one is not an error -- it is what a first
     /// run looks like -- and leaves every value at its default.
@@ -92,11 +117,17 @@ class Preferences
     }
     LFOUpdateBehaviour lfoUpdateBehaviour() const { return lfoUpdateBehaviour_; }
     bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
+    /// Always one of zoomPercentages.
+    unsigned int zoomPercent() const { return zoomPercent_; }
 
     /// Each of these writes the file. `[main-thread]`
     void setModuleUIMouseOverReaction(ModuleUIMouseOverReaction);
     void setLFOUpdateBehaviour(LFOUpdateBehaviour);
     void setHideCursorOnKnobDrag(bool);
+    /// \note A percentage this build does not offer is ignored, for the same
+    /// reason an unrecognised enumeration name is: the file is the user's to
+    /// edit, and every zoom has to be one the combo box can show.
+    void setZoomPercent(unsigned int);
 
     /// Where this instance reads and writes.
     fs::path const &file() const;
@@ -111,6 +142,7 @@ class Preferences
     ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
     LFOUpdateBehaviour lfoUpdateBehaviour_{Always};
     bool hideCursorOnKnobDrag_{true};
+    unsigned int zoomPercent_{defaultZoomPercent};
 }; // class Preferences
 
 /// \brief The process-wide preferences, under `rootPath()` -- beside the user's

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -2265,13 +2265,13 @@ catch (...)
 /// case.
 ///
 /// \note The settings panel's Interface page was the other candidate and is no
-/// longer one. Mouse-over reaction, LFO update behaviour and
-/// hide-cursor-on-knob-drag persisted nowhere at all (issue #61); they are
-/// answers about how this user likes the editor to behave rather than about this
-/// session, so they went to the user preferences file instead --
+/// longer one. Zoom, mouse-over reaction, LFO update behaviour and
+/// hide-cursor-on-knob-drag persisted nowhere at all (issues #61 and #55); they
+/// are answers about how this user likes the editor to behave rather than about
+/// this session, so they went to the user preferences file instead --
 /// `sst::plugininfra::defaults::Provider`, \see gui/preferences.hpp. The two
 /// homes are not exclusive, and surge uses both; these belong in that one.
-///                                       (15.08.2026.) (SW port)
+///                                       (16.08.2026.) (SW port)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2409,10 +2409,13 @@ bool SpectrumWorxCLAP::requestEditorSize(int const width, int const height)
 
     ///   Scaled, because the editor asks in skin pixels -- it does not know it
     /// is being drawn zoomed -- and every size crossing this boundary is in the
-    /// host's window units. The same factor ZoomedEditor uses, or the window
-    /// and the column it was opened for disagree by exactly the zoom.
-    auto const requestedWidth(static_cast<std::uint32_t>(GUI::ZoomedEditor::scaled(width)));
-    auto const requestedHeight(static_cast<std::uint32_t>(GUI::ZoomedEditor::scaled(height)));
+    /// host's window units. The zoom the *user* has asked for, read from the
+    /// same preference ZoomedEditor reads, or the window and the column it was
+    /// opened for disagree by exactly the zoom.
+    auto const requestedWidth(
+        static_cast<std::uint32_t>(GUI::ZoomedEditor::scaledForCurrentZoom(width)));
+    auto const requestedHeight(
+        static_cast<std::uint32_t>(GUI::ZoomedEditor::scaledForCurrentZoom(height)));
     if (!_host.guiRequestResize(requestedWidth, requestedHeight))
         return false;
 
@@ -2430,6 +2433,48 @@ bool SpectrumWorxCLAP::requestEditorSize(int const width, int const height)
     if (clapJuceShim_ && clapJuceShim_->isEditorAttached())
         clapJuceShim_->guiSetSize(requestedWidth, requestedHeight);
     return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxCLAP::editorSizeChanged()
+// -------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   What the editor calls when it has already changed size and the window has
+/// to catch up -- the zoom, and nothing else so far.
+///
+/// \note **The shim first, the host second.** `guiGetSize()` is answered out of
+/// the shim's holder, so until the holder has the new size the plugin is telling
+/// any host that asks that it is still the old one -- including a host that
+/// answers `request_resize` by turning round and asking. Six Sines drives the
+/// same shim in the same order, for the same reason.
+///
+/// \note And `guiSetSize` unconditionally, where requestEditorSize() reaches it
+/// only past two `return false`s. Neither guard belongs here: a host with no
+/// `clap.gui` still has an editor that has just changed size, and a refusal is
+/// not a statement that the window stayed put. \see EditorHost.
+///                                           (16.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxCLAP::editorSizeChanged(int const width, int const height)
+{
+    LE_ASSERT(Threading::isMainThread() || !Threading::isAudioThread());
+
+    auto const newWidth(static_cast<std::uint32_t>(GUI::ZoomedEditor::scaledForCurrentZoom(width)));
+    auto const newHeight(
+        static_cast<std::uint32_t>(GUI::ZoomedEditor::scaledForCurrentZoom(height)));
+
+    /// \note Not gated on `isEditorAttached()`, which is about a *parent window*
+    /// rather than about there being an editor: the shim's components exist from
+    /// `guiCreate()`, and this is only ever called by an editor that is up.
+    if (clapJuceShim_)
+        clapJuceShim_->guiSetSize(newWidth, newHeight);
+
+    if (_host.canUseGui())
+        _host.guiRequestResize(newWidth, newHeight);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -272,6 +272,7 @@ class SpectrumWorxCLAP final
     void editorClosed(GUI::SpectrumWorxEditor &) override;
 
     bool requestEditorSize(int width, int height) override;
+    void editorSizeChanged(int width, int height) override;
 
     ////////////////////////////////////////////////////////////////////////////
     // The external audio file the side channel can be fed from.

--- a/tests/clap/pluginTests.cpp
+++ b/tests/clap/pluginTests.cpp
@@ -31,6 +31,8 @@
 #include "presets/presetHarness.hpp"
 #include "gui/editor/spectrumWorxEditor.hpp"
 #include "gui/editor/zoomedEditor.hpp"
+#include "gui/preferences.hpp"
+#include "spectrumWorxCLAP.hpp"
 #include "le/spectrumworx/presetStorage.hpp"
 
 #include <clap/clap.h>
@@ -1658,25 +1660,26 @@ TEST_CASE("Opening a panel asks the host for a wider window", "[clap][gui]")
     /// and asks in them -- it does not know it is being drawn zoomed -- and
     /// SpectrumWorxCLAP scales on the way out, because a size crossing into the
     /// host is in window units. So `getWidth()` below is the skin's number and
-    /// what the host was told is that number through ZoomedEditor::scaled().
-    /// The editor this case builds is bare, at 1:1, which is the point: the
-    /// zoom is the wrapper's and the editor is the same either way.
+    /// what the host was told is that number at the zoom in force --
+    /// ZoomedEditor::scaledForCurrentZoom(). The editor this case builds is
+    /// bare, at 1:1, which is the point: the zoom is the wrapper's and the
+    /// editor is the same either way.
     ///
     ////////////////////////////////////////////////////////////////////////////
     using Zoomed = LE::SW::GUI::ZoomedEditor;
 
     editor->showPresetBrowser(true);
     REQUIRE(host.resizeRequests.size() == 1);
-    CHECK(host.resizeRequests.back() ==
-          std::pair<std::uint32_t, std::uint32_t>{Zoomed::scaled(Editor::expandedWidth),
-                                                  Zoomed::scaled(Editor::estimatedHeight)});
+    CHECK(host.resizeRequests.back() == std::pair<std::uint32_t, std::uint32_t>{
+                                            Zoomed::scaledForCurrentZoom(Editor::expandedWidth),
+                                            Zoomed::scaledForCurrentZoom(Editor::estimatedHeight)});
     CHECK(editor->getWidth() == Editor::expandedWidth);
 
     editor->showPresetBrowser(false);
     REQUIRE(host.resizeRequests.size() == 2);
-    CHECK(host.resizeRequests.back() ==
-          std::pair<std::uint32_t, std::uint32_t>{Zoomed::scaled(Editor::estimatedWidth),
-                                                  Zoomed::scaled(Editor::estimatedHeight)});
+    CHECK(host.resizeRequests.back() == std::pair<std::uint32_t, std::uint32_t>{
+                                            Zoomed::scaledForCurrentZoom(Editor::estimatedWidth),
+                                            Zoomed::scaledForCurrentZoom(Editor::estimatedHeight)});
     CHECK(editor->getWidth() == Editor::estimatedWidth);
 
     editor.reset();
@@ -1684,6 +1687,67 @@ TEST_CASE("Opening a panel asks the host for a wider window", "[clap][gui]")
     /// \note `request_resize` is `[main-thread]` and clap-helpers checks it the
     /// moment a host answers the thread check, so this is also what says the
     /// editor asks from where it is allowed to.
+    CHECK(host.misbehaviours().empty());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The bug this was written against, and it is the whole reason
+/// `editorSizeChanged` is not `requestEditorSize`. A zoom change resized the
+/// editor, asked the host, and stopped at the answer -- so on a host that says
+/// no, the shim's own components kept the *old* size while the editor had the
+/// new one. `guiGetSize()` is answered out of the shim's holder, so the plugin
+/// then told every host that asked that it was still the size it used to be.
+///
+///   "A host that says no" is not a corner: `clap-wrapper`'s macOS standalone
+/// resizes its window and returns false (AppDelegate.mm), which is how this was
+/// found -- the editor slid up or down inside a window that had moved without
+/// it. So the refusal is exercised here rather than the acceptance.
+///                                           (16.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A zoom change reaches the window even when the host refuses", "[clap][gui][zoom]")
+{
+    using Editor = LE::SW::GUI::SpectrumWorxEditor;
+    using Zoomed = LE::SW::GUI::ZoomedEditor;
+
+    /// \note A folder of this case's own: the zoom is a process-wide preference,
+    /// ctest runs eight cases at a time, and this one writes it.
+    LE::SW::GUI::setPreferencesFolder(fs::path(SW_TEST_OUTPUT_DIR) / "preferences" /
+                                      "clapZoomRefused");
+    LE::SW::GUI::preferences().setZoomPercent(100);
+
+    Entry const entry;
+    TestHost host{{.threadCheck = true, .log = true, .gui = true}};
+    host.grantResizes = false; // what the macOS standalone answers
+    ActivePlugin plugin(48000, 512, host);
+
+    auto const *const gui(
+        static_cast<clap_plugin_gui const *>(plugin->get_extension(&*plugin, CLAP_EXT_GUI)));
+    REQUIRE(gui != nullptr);
+    REQUIRE(gui->create(&*plugin, CLAP_WINDOW_API_COCOA, false));
+
+    std::uint32_t width{0}, height{0};
+    REQUIRE(gui->get_size(&*plugin, &width, &height));
+    REQUIRE(width == std::uint32_t(Zoomed::scaledForCurrentZoom(Editor::expandedWidth)));
+
+    auto &editor(*static_cast<LE::SW::SpectrumWorxCLAP &>(SWTest::editorHostOf(*plugin)).gui());
+    editor.setZoom(200);
+
+    // The plugin asked, and was told no...
+    REQUIRE(host.resizeRequests.size() == 1);
+    CHECK(host.resizeRequests.back() == std::pair<std::uint32_t, std::uint32_t>{
+                                            Zoomed::scaledForCurrentZoom(Editor::expandedWidth),
+                                            Zoomed::scaledForCurrentZoom(Editor::estimatedHeight)});
+
+    // ...and the shim moved anyway, so what the plugin reports is what it is.
+    CHECK(gui->get_size(&*plugin, &width, &height));
+    CHECK(width == std::uint32_t(Zoomed::scaledForCurrentZoom(Editor::expandedWidth)));
+    CHECK(height == std::uint32_t(Zoomed::scaledForCurrentZoom(Editor::estimatedHeight)));
+    CHECK(width == 2292);
+
+    gui->destroy(&*plugin);
     CHECK(host.misbehaviours().empty());
 }
 

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -179,7 +179,16 @@ class Instance final : public GUI::EditorHost
         return grantResizes;
     }
 
+    /// \note Recorded separately from requestedSizes, because the distinction is
+    /// the point: this one has no answer and cannot be refused. \see
+    /// EditorHost::editorSizeChanged().
+    void editorSizeChanged(int const width, int const height) override
+    {
+        announcedSizes.emplace_back(width, height);
+    }
+
     std::vector<juce::Point<int>> requestedSizes;
+    std::vector<juce::Point<int>> announcedSizes;
     bool grantResizes{true};
 
     fs::path currentSampleFile() const override { return {}; }

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -22,6 +22,7 @@
 //------------------------------------------------------------------------------
 #include "gui/editorHarness.hpp"
 
+#include "gui/editor/zoomedEditor.hpp"
 #include "gui/preferences.hpp"
 
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -126,18 +127,18 @@ template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Compone
     return found;
 }
 
-/// \brief The Interface page's two combo boxes, told apart by how many choices
-/// each offers rather than by the order they were added in.
+/// \brief The Interface page's combo boxes, told apart by how many choices each
+/// offers rather than by the order they were added in.
 ///
 /// \note A TabbedComponent keeps only the *current* page as a child, so the
 /// engine page's three combo boxes -- which are TitledComboBoxes too -- are not
 /// in the tree while the Interface tab is up. The count is required rather than
 /// assumed, so that a layout change fails here instead of silently sending the
 /// rest of the case at the wrong widget.
-GUI::TitledComboBox &comboBoxOffering(Editor &editor, unsigned int const choices)
+GUI::TitledComboBox &comboBoxOffering(Editor &editor, std::size_t const choices)
 {
     auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
-    REQUIRE(comboBoxes.size() == 2);
+    REQUIRE(comboBoxes.size() == 3);
 
     for (auto *const pComboBox : comboBoxes)
         if (pComboBox->numberOfItems() == choices)
@@ -147,6 +148,10 @@ GUI::TitledComboBox &comboBoxOffering(Editor &editor, unsigned int const choices
     return *comboBoxes.front();
 }
 
+GUI::TitledComboBox &zoomComboBox(Editor &editor)
+{
+    return comboBoxOffering(editor, Preferences::zoomPercentages.size());
+}
 GUI::TitledComboBox &mouseOverComboBox(Editor &editor) { return comboBoxOffering(editor, 3); }
 GUI::TitledComboBox &lfoUpdateComboBox(Editor &editor) { return comboBoxOffering(editor, 4); }
 
@@ -183,6 +188,7 @@ TEST_CASE("With no preferences file every value is at its default", "[gui][prefe
     CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
     CHECK(preferences.lfoUpdateBehaviour() == Preferences::Always);
     CHECK(preferences.hideCursorOnKnobDrag());
+    CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
 
     /// \note And reading wrote nothing. A plugin that has only ever been opened
     /// has no preferences to record, and a file appearing in the user's folder on
@@ -199,6 +205,7 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
         written.setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
         written.setLFOUpdateBehaviour(Preferences::WhenControlActive);
         written.setHideCursorOnKnobDrag(false);
+        written.setZoomPercent(75);
 
         REQUIRE(fs::exists(written.file()));
     }
@@ -207,6 +214,7 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
     CHECK(read.moduleUIMouseOverReaction() == Preferences::WhenParentModuleSelected);
     CHECK(read.lfoUpdateBehaviour() == Preferences::WhenControlActive);
     CHECK(!read.hideCursorOnKnobDrag());
+    CHECK(read.zoomPercent() == 75);
 }
 
 TEST_CASE("The file names its keys and its enumerated values", "[gui][preferences]")
@@ -226,6 +234,7 @@ TEST_CASE("The file names its keys and its enumerated values", "[gui][preference
     preferences.setModuleUIMouseOverReaction(Preferences::WhenParentOrNothingSelected);
     preferences.setLFOUpdateBehaviour(Preferences::WhenControlSelected);
     preferences.setHideCursorOnKnobDrag(false);
+    preferences.setZoomPercent(125);
 
     auto const file(contentsOf(preferences.file()));
     CAPTURE(file);
@@ -235,6 +244,7 @@ TEST_CASE("The file names its keys and its enumerated values", "[gui][preference
     CHECK(file.find("key=\"lfoUpdateBehaviour\" value=\"WhenControlSelected\"") !=
           std::string::npos);
     CHECK(file.find("key=\"hideCursorOnKnobDrag\" value=\"0\"") != std::string::npos);
+    CHECK(file.find("key=\"zoomPercent\" value=\"125\"") != std::string::npos);
 }
 
 TEST_CASE("A value this build does not recognise reads as the default", "[gui][preferences]")
@@ -247,13 +257,50 @@ TEST_CASE("A value this build does not recognise reads as the default", "[gui][p
           "<defaults version=\"1\">\n"
           "  <default key=\"moduleUIMouseOverReaction\" value=\"Sideways\" type=\"1\"/>\n"
           "  <default key=\"lfoUpdateBehaviour\" value=\"WhenControlActive\" type=\"1\"/>\n"
+          "  <default key=\"zoomPercent\" value=\"300\" type=\"2\"/>\n"
           "</defaults>\n");
 
     Preferences const preferences(folder);
 
     CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
-    // ...and the key it could not read did not cost it the one beside it.
+
+    /// \note 300 is a zoom, and a reasonable one -- issue #55 asks for it -- but
+    /// it is not one this build offers, and the combo box could show nothing for
+    /// it. A zoom is checked against the offered list rather than clamped to its
+    /// ends for that reason.
+    REQUIRE(!Preferences::isOfferedZoom(300));
+    CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
+
+    // ...and neither unreadable key cost it the one beside it.
     CHECK(preferences.lfoUpdateBehaviour() == Preferences::WhenControlActive);
+}
+
+TEST_CASE("Every offered zoom scales the skin by its own percentage", "[gui][preferences]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note What "100%" means, pinned. The skin is drawn at 1.5x and always has
+    /// been, so a user picking 100 is asking for the size the plugin has always
+    /// opened at rather than for a scale factor of one -- and every size the
+    /// host is told goes through this. \see ZoomedEditor.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    using Zoomed = GUI::ZoomedEditor;
+
+    useCaseFolder("scaling");
+
+    CHECK(Zoomed::scaleForZoom(100) == Zoomed::scaleAtOneHundredPercent);
+    CHECK(Zoomed::scaleForZoom(200) == 2 * Zoomed::scaleAtOneHundredPercent);
+    CHECK(Zoomed::scaleForZoom(50) == Zoomed::scaleAtOneHundredPercent / 2);
+
+    for (auto const percent : Preferences::zoomPercentages)
+    {
+        CAPTURE(percent);
+        GUI::preferences().setZoomPercent(percent);
+
+        CHECK(Zoomed::scaledForCurrentZoom(Editor::estimatedWidth) ==
+              Zoomed::scaled(Editor::estimatedWidth, Zoomed::scaleForZoom(percent)));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -318,4 +365,78 @@ TEST_CASE("Toggling hide-cursor-on-knob-drag on the page writes it to the file",
 
     Preferences const onDisk(GUI::preferences().file().parent_path());
     CHECK(!onDisk.hideCursorOnKnobDrag());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The zoom
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("An editor opens at the zoom the last session chose", "[gui][preferences][zoom]")
+{
+    useCaseFolder("zoomAtOpening");
+    GUI::preferences().setZoomPercent(75);
+
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+
+    // Built the way SpectrumWorxCLAP::createEditor() builds it: nothing tells the
+    // wrapper what zoom to use, so what it opens at is what was remembered.
+    GUI::ZoomedEditor const wrapper(
+        std::make_unique<Editor>(instance, Editor::PanelPlacement::overlay));
+
+    CHECK(wrapper.zoomPercent() == 75);
+
+    /// \note And the skin did not move: the editor is laid out in the 563 x 376
+    /// it always was and the wrapper is its scaled shadow. That split is what
+    /// keeps every offset in the editor a constant.
+    CHECK(wrapper.editor().getWidth() == Editor::estimatedWidth);
+    CHECK(wrapper.getWidth() ==
+          GUI::ZoomedEditor::scaled(Editor::estimatedWidth, GUI::ZoomedEditor::scaleForZoom(75)));
+}
+
+TEST_CASE("Choosing a zoom on the page resizes the editor and remembers it",
+          "[gui][preferences][zoom]")
+{
+    useCaseFolder("pageWritesTheZoom");
+    GUI::preferences().setZoomPercent(100);
+
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+
+    GUI::ZoomedEditor wrapper(std::make_unique<Editor>(instance, Editor::PanelPlacement::overlay));
+    auto &editor(wrapper.editor());
+    editor.showSettings(Editor::interfacePageIndex);
+
+    auto &comboBox(zoomComboBox(editor));
+    REQUIRE(comboBox.getSelectedID() == 100);
+    auto const atOneHundred(wrapper.getWidth());
+
+    comboBox.setSelectedID(200);
+    Editor::Settings::comboBoxValueChanged(comboBox);
+
+    CHECK(wrapper.zoomPercent() == 200);
+    CHECK(wrapper.getWidth() > atOneHundred);
+    CHECK(wrapper.getWidth() ==
+          GUI::ZoomedEditor::scaled(Editor::estimatedWidth, GUI::ZoomedEditor::scaleForZoom(200)));
+
+    // The skin is where it was; only the transform over it moved.
+    CHECK(editor.getWidth() == Editor::estimatedWidth);
+
+    /// \note And the window was told, in skin pixels -- the scaling into window
+    /// units is SpectrumWorxCLAP's and is measured against a real host in
+    /// tests/clap/pluginTests.cpp. Without this the editor would be drawn at the
+    /// new scale inside a window still the old size.
+    ///
+    /// \note `announcedSizes`, not `requestedSizes`: a zoom is not a request and
+    /// nothing may make it conditional on the host's answer. \see
+    /// EditorHost::editorSizeChanged().
+    CHECK(instance.requestedSizes.empty());
+    REQUIRE(!instance.announcedSizes.empty());
+    CHECK(instance.announcedSizes.back() ==
+          juce::Point<int>{Editor::estimatedWidth, Editor::estimatedHeight});
+
+    CHECK(GUI::preferences().zoomPercent() == 200);
+
+    Preferences const onDisk(GUI::preferences().file().parent_path());
+    CHECK(onDisk.zoomPercent() == 200);
 }

--- a/tools/show-ui/main.cpp
+++ b/tools/show-ui/main.cpp
@@ -33,14 +33,18 @@
 //------------------------------------------------------------------------------
 #include "page.hpp"
 
+#include "gui/preferences.hpp"
 #include "gui/theme.hpp"
+#include "io/jucePath.hpp"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <cstddef>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <map>
+#include <system_error>
 //------------------------------------------------------------------------------
 namespace
 {
@@ -305,12 +309,52 @@ int renderPage(juce::String const &pageName, juce::File const &output)
     return drewSomething(ink, page->name) ? 0 : 1;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Points the interface preferences at an empty folder beside the PNG.
+///
+///   A render has to be a function of the build and nothing else. The editor
+/// reads GUI::preferences() -- the settings panel's Interface page shows them,
+/// and the zoom among them decides how big the whole image is -- so without this
+/// `--render` would answer differently on every machine, according to what
+/// whoever ran it last chose in a DAW. `ctest` runs these.
+///
+/// \note Only `--render`. Run interactively, sw-show-ui is looking at the real
+/// editor and should use the real preferences, zoom included.
+///
+/// \note `SW_SHOW_UI_ZOOM` then puts one back, for looking at a page at a size
+/// other than the plugin's normal one. Same shape as SW_SHOW_UI_SETTINGS_PAGE
+/// and SW_SHOW_UI_PRESET_BANK, and an unoffered percentage is ignored -- \see
+/// GUI::Preferences::zoomPercentages.
+///                                           (16.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void usePreferencesOfNobodyInParticular(juce::File const &output)
+{
+    auto const folder(LE::IO::juceFileToPath(output.getParentDirectory()) / "show-ui-preferences");
+    std::error_code ignored;
+    fs::remove_all(folder, ignored);
+    LE::SW::GUI::setPreferencesFolder(folder);
+
+    if (auto const *const requested = std::getenv("SW_SHOW_UI_ZOOM"))
+    {
+        auto const percent(static_cast<unsigned int>(std::atoi(requested)));
+        if (LE::SW::GUI::Preferences::isOfferedZoom(percent))
+            LE::SW::GUI::preferences().setZoomPercent(percent);
+        else
+            std::fprintf(stderr, "sw-show-ui: SW_SHOW_UI_ZOOM=%s is not an offered zoom.\n",
+                         requested);
+    }
+}
+
 int render(juce::String const &pageName, juce::File const &output)
 {
     // No JUCEApplication and no message loop: paintEntireComponent() needs a
     // graphics context and a font engine, which ScopedJuceInitialiser_GUI
     // provides, and nothing else.
     juce::ScopedJuceInitialiser_GUI const juceInitialiser;
+    usePreferencesOfNobodyInParticular(output);
     auto const result(renderPage(pageName, output));
     // Inside the initialiser's lifetime, so the images and typefaces the page
     // cached are gone before JUCE's leak detector looks. Getting this wrong is

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -160,6 +160,12 @@ class HarnessHost final : public GUI::EditorHost
     /// page follows the editor's size; there is no window under either.
     bool requestEditorSize(int, int) override { return true; }
 
+    /// \note Nothing to do: there is no window here, and the page follows the
+    /// wrapper's size through childBoundsChanged. `--render` never changes the
+    /// zoom anyway, and interactively the wrapper has already re-transformed
+    /// itself by the time this is called.
+    void editorSizeChanged(int, int) override {}
+
     /// \note The external audio file, declined: the harness has no engine to
     /// feed one to and renders a still image, so the sample area draws its empty
     /// state. Loading one is what sampleTests.cpp covers.


### PR DESCRIPTION
The Interface page offers 50, 75, 90, 100, 125, 150 and 200 per cent, and the choice is remembered the way the other interface preferences are, so the next editor opens at it.

100 % is the size the plugin has always opened at rather than a scale factor of one. The skin is a 563 x 376 bitmap laid out for a 2010 screen and has been drawn at 1.5x since the port; a combo offering 150 % as its resting value would be describing the bitmap rather than the window. A percentage the build does not offer reads as 100 rather than being clamped, because the combo box could show nothing for it.

Changing the zoom is an announcement to the host, not a request. The editor has already changed and there is no fallback to negotiate for, unlike the preset browser's column, which still asks first and lays itself over the module strips when refused. Nor may a refusal stop the shim being told: clap-wrapper's macOS standalone resizes its window and then returns false, so treating that as "the window stayed put" left the shim a size behind, and a JUCE peer inside a foreign NSView is anchored at Cocoa's bottom left -- which showed up as the editor sliding up or down the window rather than as a wrong size.

Renders are a function of the build again: sw-show-ui --render reads the interface preferences, and the zoom among them decides how big the image is, so it now reads an empty folder beside the PNG rather than whatever the person running it last chose in a DAW. SW_SHOW_UI_ZOOM overrides it.

Closes #55.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>