### PR TITLE
Say the sample rate and channel layout in the build-stamp bar

### DIFF
--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -203,6 +203,11 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
     /// \note Whatever the mailbox has been accumulating with no editor open is
     /// not this editor's news: it starts from what the widgets were built with.
     editorHost_.modulatedValues().discardChanges();
+
+    /// \note Likewise: the bar is about to be painted from the engine, so record
+    /// what it will say rather than letting the first tick call it a change.
+    engineState_ = currentEngineState();
+
     startTimerHz(modulationRefreshHz);
 
     // Last: nothing may reach a half-built editor.
@@ -1287,20 +1292,55 @@ juce::String SpectrumWorxEditor::buildStampText()
     return juce::String(BuildStamp::date) + "  " + BuildStamp::time + "  " + BuildStamp::commit;
 }
 
+SpectrumWorxEditor::EngineState SpectrumWorxEditor::currentEngineState() const
+{
+    auto const &core(editorHost().core());
+    return {core.getSampleRate(), core.numberOfInputChannels(), core.numberOfSideChannels(),
+            core.numberOfOutputChannels()};
+}
+
+/// \see the note on the declaration.
+juce::String SpectrumWorxEditor::engineStateText() const
+{
+    auto const state(currentEngineState());
+
+    /// \note "no rate" rather than "0 Hz": before a host has activated the
+    /// plugin there is no answer, and a zero would read as one.
+    juce::String rate("no rate");
+    if (state.sampleRate > 0)
+        rate = juce::String(state.sampleRate,
+                            (state.sampleRate == std::floor(state.sampleRate)) ? 0 : 1) +
+               " Hz";
+
+    return rate + "  " + juce::String(int{state.mainChannels}) + "main," +
+           juce::String(int{state.sideChannels}) + "side in, " +
+           juce::String(int{state.outputChannels}) + "main out";
+}
+
+juce::Rectangle<int> SpectrumWorxEditor::buildStampBar() const
+{
+    return {0, artworkHeight, getWidth(), buildStampHeight};
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// \note Painted rather than a juce::Label, and painted from the editor rather
-/// than by a child component, because it has no behaviour at all: it never
-/// changes for the life of the process, takes no mouse, and must not be able to
-/// take focus away from a knob. Everything a child would add here is a thing
-/// that can go wrong.
+/// than by a child component, because it has no behaviour at all: it takes no
+/// mouse and must not be able to take focus away from a knob. Everything a child
+/// would add here is a thing that can go wrong.
 ///                                           (06.08.2026.) (SW port)
+///
+/// \note Two readouts, and they answer different questions. The build stamp on
+/// the left is fixed for the life of the process; the engine state on the right
+/// is whatever the plugin currently believes it is running at, and a host can
+/// move it under an open editor. `timerCallback()` is what notices.
+///                                           (17.08.2026.)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
 void SpectrumWorxEditor::paintBuildStamp(juce::Graphics &graphics) const
 {
-    juce::Rectangle<int> const bar(0, artworkHeight, getWidth(), buildStampHeight);
+    auto const bar(buildStampBar());
 
     graphics.setColour(juce::Colours::black);
     graphics.fillRect(bar);
@@ -1310,7 +1350,10 @@ void SpectrumWorxEditor::paintBuildStamp(juce::Graphics &graphics) const
     /// readable when looked for and quiet when not.
     graphics.setColour(Theme::blueColour());
     graphics.setFont(juce::Font(juce::FontOptions(regularTypeface()).withHeight(11.0f)));
-    graphics.drawText(buildStampText(), bar.reduced(8, 0), juce::Justification::centredLeft);
+
+    auto const text(bar.reduced(8, 0));
+    graphics.drawText(buildStampText(), text, juce::Justification::centredLeft);
+    graphics.drawText(engineStateText(), text, juce::Justification::centredRight);
 }
 
 void SpectrumWorxEditor::buttonClicked(juce::Button *const pButton)
@@ -2296,7 +2339,19 @@ void SpectrumWorxEditor::parameterChangedElsewhere(ParameterID const parameterID
     }
 }
 
-void SpectrumWorxEditor::timerCallback() { pumpModulatedValues(); }
+void SpectrumWorxEditor::timerCallback()
+{
+    pumpModulatedValues();
+
+    /// \note Compared as numbers rather than as the formatted line, so the common
+    /// case -- nothing moved -- costs three loads and no allocation. Only the bar
+    /// is repainted; the skin above it has not changed.
+    if (auto const state(currentEngineState()); state != engineState_)
+    {
+        engineState_ = state;
+        repaint(buildStampBar());
+    }
+}
 
 void SpectrumWorxEditor::pumpModulatedValues()
 {

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -567,10 +567,63 @@ class SpectrumWorxEditor final : private SkinLifetime,
     ////////////////////////////////////////////////////////////////////////////
     static juce::String buildStampText();
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The other end of the same bar: what the engine currently believes
+    /// it is running at -- sample rate, and how many channels in and out.
+    ///
+    ///   Reads `2main,0side in, 2main out`. The side count is spelt out rather
+    /// than folded into a total, because it is the interesting one and a sum
+    /// hides it: `4 in` could be four main channels or two and a side chain, and
+    /// those are different plugins.
+    ///
+    ///   Whether the host actually *patched* anything into that port is a
+    /// different question and a per-block one -- `SpectrumWorxCLAP::runEngine()`
+    /// decides it from `clap_audio_buffer::constant_mask` every callback and
+    /// falls back to the main input -- so it is deliberately not claimed here.
+    /// What this says is what the engine is *configured* for.
+    ///
+    /// \note Live, where buildStampText() is fixed for the life of the process:
+    /// a host can change the sample rate or the layout under an open editor, so
+    /// `timerCallback()` watches for it. \see currentEngineState().
+    ///                                       (17.08.2026.)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    juce::String engineStateText() const;
+
   private:
-    /// \brief Fills the buildStampHeight strip under the artwork and writes
-    /// buildStampText() into it. \see artworkHeight.
+    /// \brief Fills the buildStampHeight strip under the artwork with
+    /// buildStampText() to the left and engineStateText() to the right.
+    /// \see artworkHeight.
     void paintBuildStamp(juce::Graphics &) const;
+
+    /// \brief The strip itself, so that a repaint can name it rather than the
+    /// whole editor. \see artworkHeight.
+    juce::Rectangle<int> buildStampBar() const;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What engineStateText() is drawn from, as numbers -- so the timer
+    /// can ask "has this moved" without formatting a string thirty times a
+    /// second.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    struct EngineState
+    {
+        float sampleRate{0};
+        std::uint8_t mainChannels{0};
+        std::uint8_t sideChannels{0};
+        std::uint8_t outputChannels{0};
+
+        bool operator==(EngineState const &) const = default;
+    }; // struct EngineState
+
+    EngineState currentEngineState() const;
+
+    /// What the bar was last repainted for. Only ever compared, never drawn --
+    /// paintBuildStamp() reads the engine, so a repaint from any other cause
+    /// still shows the truth rather than this.
+    EngineState engineState_;
 
   private: // JUCE Component overrides.
     /// \note Only what is outside the skin: the panel column's chrome and the

--- a/tests/gui/buildStampTests.cpp
+++ b/tests/gui/buildStampTests.cpp
@@ -37,6 +37,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <set>
+#include <string>
 //------------------------------------------------------------------------------
 namespace
 {
@@ -136,4 +137,45 @@ TEST_CASE("The stamp names a date, a time and a commit", "[gui][buildstamp]")
     CHECK(line.contains(date));
     CHECK(line.contains(time));
     CHECK(line.contains(commit));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The other end of the bar: what the plugin believes it is running at.
+///
+/// \note The channel count is the reason this is worth drawing, and the side
+/// count is spelt out rather than summed into the input total: `4 in` could be
+/// four main channels or two and a side chain, and those are different plugins.
+///
+/// \note What the readout deliberately does not claim is whether the host
+/// patched anything into that port. `runEngine()` decides that per block from
+/// `clap_audio_buffer::constant_mask` and falls back to the main input, so it is
+/// not a property of the configuration at all -- which is also why this case
+/// asserts against the engine rather than against a literal.
+///                                           (17.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The bar says the rate and the channel layout", "[gui][buildstamp]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    instance.openEditor(Editor::PanelPlacement::overlay);
+
+    auto const line(instance.editor().engineStateText());
+    INFO("engine state line: " << line);
+
+    /// The harness configures 48 kHz, and a whole rate is drawn without a
+    /// decimal point -- "48000 Hz" rather than "48000.0 Hz".
+    CHECK(line.contains("48000 Hz"));
+
+    /// \note Built from the engine rather than written out, so this says "the
+    /// bar reports the configuration" rather than "the harness is stereo" --
+    /// which is the claim worth making and the one that survives the harness
+    /// being reconfigured.
+    auto const &core(instance.core());
+    auto const layout(std::to_string(core.numberOfInputChannels()) + "main," +
+                      std::to_string(core.numberOfSideChannels()) + "side in, " +
+                      std::to_string(core.numberOfOutputChannels()) + "main out");
+    CHECK(line.contains(layout.c_str()));
 }


### PR DESCRIPTION
The bar said when the binary was built and from what commit. It now also says what the plugin currently believes it is running at, right aligned in the same strip:

    48000 Hz  2main,0side in, 2main out

The side channel count is spelt out rather than summed into the input total, because it is the interesting one and a sum hides it: "4 in" could be four main channels or two and a side chain, and those are different plugins.

What it reports is what the engine is configured for, not whether the host has patched anything into the side chain port. runEngine() decides that per block from clap_audio_buffer::constant_mask and falls back to the main input, so a patched but silent send and an unpatched port look the same to it and neither changes the configuration.

A host can move either of these under an open editor, so the bar is no longer fixed for the life of the process: the editor's existing 30 Hz timer compares the numbers and repaints the strip when they change.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>