### PR TITLE
Let the patch choose what feeds the side chain

### DIFF
--- a/doc/tech/README.md
+++ b/doc/tech/README.md
@@ -1,6 +1,6 @@
 # SpectrumWorx — the tech documents
 
-Five documents, and every one of them describes the tree **as it is now** — how
+Six documents, and every one of them describes the tree **as it is now** — how
 something works, not what is left to do about it. Nothing here is a plan being
 executed or a record of how the port got where it is; that is in [`old/`](old/).
 
@@ -14,6 +14,7 @@ executed or a record of how the port got where it is; that is in [`old/`](old/).
 | [`streaming_format.md`](streaming_format.md) | What goes into a preset and into session state: the on-disk names, the snapshot tests that pin them, and the rules for changing any of it. |
 | [`latency.md`](latency.md) | Why the delay is one FFT window, why it cannot be less, the two FIFO primings that hold it constant, and the block-splitting bug that happened without the second one. |
 | [`how-lfo-rates-work.md`](how-lfo-rates-work.md) | What an LFO's period holds, which bar it is a fraction of, and what tempo sync does and does not move. |
+| [`sidechain-approach.md`](sidechain-approach.md) | The three things that can feed the side channel, why the choice is a *source* and not a bus topology, and what an old preset's `Input_mode` turns into. |
 
 ## What is left — the issue tracker
 
@@ -25,7 +26,7 @@ carried. All three are now
 where somebody looking for something to do will actually look, and which can be
 assigned, closed and argued with.
 
-So: **if it is a claim about how the tree behaves, it belongs in one of the five
+So: **if it is a claim about how the tree behaves, it belongs in one of the six
 documents above. If it is something somebody should do about it, it is an
 issue.** The rule that made the old files worth reading still applies to both —
 a claim carries its date and its evidence — and the one that made them work

--- a/doc/tech/effect_contract.md
+++ b/doc/tech/effect_contract.md
@@ -485,14 +485,21 @@ restates it: **all processing is in place, side-channel data is read only.**
 plugged in. Silence is what you get when it is not, so an effect that multiplies
 by the side chain goes silent rather than misbehaving.
 
-**What the engine is handed when the host's side-chain port is unpatched is the
+**Which of three sources fills it is the patch's, and an effect cannot tell them
+apart** — `data.side()` is the same span whichever one it came from. The user
+picks a file, the main input, or the host's second port;
+[`sidechain-approach.md`](sidechain-approach.md) is the whole of it, including
+what an old preset's `Input_mode` migrates to. Nothing about it reaches an effect,
+which is the point: side-chain routing is not a DSP concern.
+
+**What the engine is handed when the selected source has nothing behind it is the
 main input, not silence** — so a Blender with nothing patched blends the signal
-with itself. Three arrangements take that fallback, and the third is the only one
-a real DAW produces: no second port at all, a second port with no `data32`, and a
-second port whose channels the host declares constant and zero through
-`clap_audio_buffer::constant_mask`. The mask is a hint and a host that sets none
-is indistinguishable from one carrying real silence, which is what issue #13
-is still open about.
+with itself, and one in `Main` does so always. For the host's port that is three
+arrangements, of which the third is the only one a real DAW produces: no second
+port at all, a second port with no `data32`, and a second port whose channels the
+host declares constant and zero through `clap_audio_buffer::constant_mask`. The
+mask is a hint and a host that sets none is indistinguishable from one carrying
+real silence, which is what issue #13 is still open about.
 
 > **Nothing declares that an effect reads the side chain, and nothing should.**
 > The `process()` overload is the declaration: take a `MainSideChannelData` and

--- a/doc/tech/sidechain-approach.md
+++ b/doc/tech/sidechain-approach.md
@@ -1,0 +1,195 @@
+# SpectrumWorx — The side chain
+
+What feeds the engine's second input, who decides it, and what an old patch means.
+
+Written 18.08.2026. Everything here is in the tree and has tests naming it.
+
+---
+
+## 1. The insight this rests on
+
+**Bus topology is not a user setting.** How many ports a plugin has, and how many
+channels each carries, is a handshake between the plugin, the host and the track.
+A control that claimed to decide it would be claiming something it does not get
+to decide — and a control that *described* it would be describing something the
+user cannot act on.
+
+What the user actually decides is **what goes into the side channel**. There are
+three answers and there is no fourth:
+
+| | `SideChainSource` | fed from |
+|---|---|---|
+| a file | `File` | a decoded audio file, read forwards, wrapping at its end |
+| yourself | `Main` | the main input, so an effect side-chains against itself |
+| the host | `Host` | the host's second input port |
+
+That is the whole model. `src/le/spectrumworx/sideChainSource.hpp` is where it
+lives, and it is deliberately *not* a parameter — see §5.
+
+## 2. The rule at render time
+
+`SpectrumWorxCLAP::runEngine()`, three lines:
+
+```
+File, and a sample is loaded?     -> the sample's chunks
+Host, and the port carries signal -> process->audio_inputs[ 1 ]
+otherwise                         -> the main input
+```
+
+**Every fallback is the main input, never silence.** A Blender with nothing
+patched blends the signal with itself; that is the documented behaviour and
+`effect_contract.md` §1.8 is where an effect author meets it. An effect cannot
+tell the three apart — `data.side()` is the same span whichever filled it — which
+is what makes the selection a routing decision rather than a DSP one.
+
+`Host` has three ways to carry no signal, and the third is the only one a real
+DAW produces: no second port in the count, a second port with no `data32`, and a
+second port whose channels the host declares constant and zero through
+`clap_audio_buffer::constant_mask`. The mask is a *hint* and a host that sets none
+is indistinguishable from one carrying real silence — issue #13 is still open on
+whether any host sets one at all. **That unreliability is now confined to one
+arm.** It decides between the port and the main input, and it can no longer
+decide against a file the user loaded, which is what it did until 18.08.2026.
+
+### Two states that cannot occur
+
+- **`File` with no sample loaded.** Refused at both doors:
+  `SpectrumWorxCLAP::setSideChainSource()` leaves `Main` selected instead, and
+  `resolveSideChainSource()` does the same for a patch being loaded. So the
+  selector never shows a file that is not there. `runEngine()` still tests
+  `pSample_` rather than trusting it, because a source the engine cannot honour
+  should fall back rather than dereference null.
+- **A source and a sample the audio thread disagrees about.** They travel in one
+  `ToEngine::SwapSample` message, so no block can be rendered with a new source
+  and the sample the previous one named. Its `replacesSample` flag separates
+  "here is a new sample, or none" from "only the source has changed" — the second
+  is what restores a patch that names a file, where the sample has just been
+  published and must not be cleared by the source arriving behind it.
+- **A file loaded and unheard.** Selecting `Main` or `Host` *discards* it.
+  Keeping it was tried and reverted on 18.08.2026: it left the box's three
+  answers hiding a fourth piece of state, so a patch could carry audio nothing
+  would ever play and `stateSave` would write a `Sample=` its own source
+  contradicted. The cost is a second decode when a user switches back, and it is
+  the right one — the alternative is a plugin that quietly remembers.
+
+## 3. Selecting it
+
+The box under the LFO panel, which used to be labelled `External audio`. It is
+**always populated**: "nothing" is not one of the three answers.
+
+```
+Main as sidechain
+Host sidechain
+── Audio file ──
+Load audio file...
+<the seventeen factory samples>
+```
+
+`No external audio` is gone. It named the *absence* of one source rather than the
+presence of another, which is why a user who cleared a file had no way to say
+what they wanted instead — and it was disabled in exactly the state a user most
+wanted to read it. The right mouse button, which used to clear the file, selects
+`Main`.
+
+Loading a file *is* selecting it as the source, and selecting either of the other
+two discards it. There is no arrangement in which a file is loaded and silently
+unheard, in either direction.
+
+## 4. What an old patch means
+
+No 2.x file records a source. All 288 shipped presets record an `Input_mode`,
+written by a 2016 parameter that was compiled out behind
+`LE_SW_ENGINE_INPUT_MODE`, never present in any build this port produced, and
+deleted on 04.08.2026 — so for a fortnight the plugin was discarding the only
+thing the format had ever said about a patch's side chain.
+
+`Input_mode` was a **bus** setting: `(Stereo)(StereoSideChain)(Mono)(MonoSideChain)`,
+driving `ioChannels()` and nothing else. Crossed with "is a file loaded" it
+produced this, which is what the 2016 plugin did:
+
+```
+audio file loaded
+   2x2 -> the file
+   4x2 -> the file
+no audio file loaded
+   2x2 -> the main input
+   4x2 -> the host's side chain
+```
+
+Read as a bus setting that table has a corner nobody can explain. Read as
+*sources* it has none: the file wins because the file **is** the source, and the
+2x2/no-file corner is `Main` under another name. So the migration is exact —
+`resolveSideChainSource()`:
+
+```
+the patch records a source?  -> that, unless it is File with no sample
+a sample was applied?        -> File
+Input_mode odd (1 or 3)      -> Host
+otherwise (0, 2, or absent)  -> Main
+```
+
+Three things worth knowing about it:
+
+- **"A sample was applied", not "the patch names one".** A patch loaded with the
+  preset browser's `Ignore external audio` on names a file and gets none, so it
+  migrates to `Input_mode`'s answer instead — which is what a user who asked not
+  to be given somebody else's audio meant. A named file that will not decode is
+  reported and cleared, and lands in the same place.
+- **Mono is not a source.** `Input_mode` 2 and 3 are the mono arrangements, and
+  they say how many channels each source carries rather than which one is
+  selected — hence the odd/even test. Mono itself is issue #114.
+- **`Input_mode` is read and never written.** It is migration input, not a
+  parameter, and a file that omits it is not missing anything.
+
+`presetCorpusTests.cpp`'s `[side-chain]` case walks all 288 shipped presets and
+holds the outcome: the `Sidechainables` bank is exactly the set that comes back
+`Host`, and it is the whole bank.
+
+## 5. Why it is not a parameter
+
+It streams beside `<p n="Sample">` in the `<Global>` block, as
+`<p n="Side chain source" v="host"/>`, and is handled by the same special-cased
+path rather than by the parameter machinery. Three reasons, in order of weight:
+
+1. **It is the file selector's value.** "Load this file" and "take the host's
+   port" are one act and one control. A parameter and a file path that had to be
+   kept consistent would be two answers to one question.
+2. **Atomicity.** Publishing it with the decoded sample is one message; two
+   independent publications would leave a window in which the audio thread had a
+   new source and the previous sample.
+3. It does not need automating, and a host automating "which file" is not a thing
+   it can do anyway.
+
+**Streamed by name — `file`, `main`, `host` — not by ordinal.** A fourth value
+appended later then cannot change what an existing file means. Every *parameter*
+in this tree streams as a number, so this is the exception and it is a deliberate
+one; the preferences file already follows the same rule for its two enumerations
+(`streaming_format.md` §4.4).
+
+## 6. What is not decided here
+
+**The port layout.** The plugin declares two stereo input ports and one stereo
+output port unconditionally, in every source, and `activate()` asks the engine for
+`setNumberOfChannels(4, 2)` regardless. A host therefore shows four inputs
+whatever the patch selected. That is the handshake, not a setting, and issue #114
+is where it changes — for mono, which is the case where it genuinely has to.
+
+One consequence worth stating, since it is a cost rather than a nicety: the
+engine analyses the side channel every hop even when it is a byte-for-byte copy of
+the main input. `ProcessParameters::haveSideChannel()` is "the pointer is
+non-null" and the fallback pointer never is, so `Main` pays for a redundant
+transform. Only a build whose engine channel count follows the layout could skip
+it — issue #114 again, and it is not free: with no side channel at all the side
+spectrum is never filled, so a Blender would go *silent* rather than blend with
+itself.
+
+## 7. What guards it
+
+| | holds |
+|---|---|
+| `tests/external_audio/sampleFeedTests.cpp` | each of the three reaches the DSP, and **only** the selected one does — three `==` pairs with a file loaded and a port patched at once. Plus the two fallbacks, and that `File` with no file is refused rather than stored |
+| `tests/clap/pluginTests.cpp` | a patched, signal-carrying port is bit-identical to no port at all under `Main`; an untouched patch reads it, which is the default's audible consequence |
+| `tests/presets/presetCorpusTests.cpp` | the migration, over all 288 shipped presets |
+| `tests/presets/presetRoundTripTests.cpp` | the 3.0 fixture, built so that only one reading passes: it records `main` (not the default) *and* `Input mode="1"` (which migrates to `host`), so `main` is reachable only by reading the recorded source and letting it win |
+| `tests/gui/sideChainSelectorTests.cpp` | the box draws the selection and the editor asks its host for it |
+| `tests/presets/data/presetFixtures.txt` | the source is inside the hashed dump, so a shipped preset whose `Input_mode` stopped being read moves its row |

--- a/doc/tech/streaming_format.md
+++ b/doc/tech/streaming_format.md
@@ -181,6 +181,7 @@ version; both went with the parameter on 07.08.2026.
 		<p n="In" v="1" />
 		<p n="FFT size" v="4096" />
 		<p n="Sample" v="Carrier.mp3" />
+		<p n="Side chain source" v="file" />
 	</Global>
 	<Modules>
 		<Module effect="Ah-ah">
@@ -197,6 +198,23 @@ The external sample is a `<p>` like everything else rather than an attribute on
 It is not a parameter, but it is a global scalar keyed by name, and giving it the
 same shape means the reader needs no special case for it: `getSampleFileName()`
 goes through the same lookup as `In` and `FFT size`.
+
+`Side chain source` (18.08.2026) is the second of those, and it is the sample's
+companion: what feeds the side channel is the audio-file selector's answer, so it
+is a selection rather than an automatable value. Two things about it are
+deliberate and neither is the norm here —
+
+- **It streams by name**, `file` / `main` / `host`, where every *parameter*
+  streams as a number. A fourth value appended later then cannot change what an
+  existing file means. The preferences file already streams its two enumerations
+  this way (§4.4).
+- **It is written always**, where the sample name is written only when there is
+  one. A patch that omitted it would be indistinguishable from a 2.x file and
+  would be *migrated* rather than read.
+
+A patch with no `Side chain source` is migrated from 2016's `Input_mode`, which
+all 288 shipped presets carry and which is no longer a parameter — read at load,
+never written. See [`sidechain-approach.md`](sidechain-approach.md) §4.
 
 Against 2.x:
 

--- a/src/core/threading/messages.hpp
+++ b/src/core/threading/messages.hpp
@@ -57,7 +57,11 @@ struct ToEngine
         /// ToUI::Retire, now holding what used to be live -- so nothing is ever
         /// destroyed under the callback.
         SwapChain,
-        /// Likewise a decoded Sample.
+        /// Likewise a decoded Sample -- and, in the same message, what the side
+        /// channel is to be fed from. The two travel together because they are
+        /// one user act ("play this file", "take the host's port") and because a
+        /// block that saw one without the other would be a block fed from the
+        /// wrong place. \see SideChainSource.
         SwapSample,
         /// An LFO sub-parameter that has no `ParameterID` -- Waveform and
         /// SyncTypes, both past `ParameterCounts::lfoExportedParameters`.
@@ -101,9 +105,26 @@ struct ToEngine
             void *pChain;
         } swapChain;
 
+        ////////////////////////////////////////////////////////////////////////
+        ///
+        /// \note `replacesSample` distinguishes "here is a new sample, or none"
+        /// from "keep the one you have, only the source has changed". Selecting
+        /// `Main` or `Host` sends the first, with a null pointer, because those
+        /// discard a loaded file; restoring a patch that names one sends the
+        /// second, because the sample it refers to has just been published and
+        /// must not be cleared by the source arriving behind it.
+        ///
+        /// \note `source` is `std::uint8_t` rather than the enum for the reason
+        /// the note above `swapChain` gives: this header is the protocol and has
+        /// no business including anything. The two sites that put a value in and
+        /// take it out are one file apart.
+        ///
+        ////////////////////////////////////////////////////////////////////////
         struct
         {
             void *pSample;
+            bool replacesSample;
+            std::uint8_t source;
         } swapSample;
 
         /// \note The value in the parameter's own units, as a float, which is
@@ -246,11 +267,12 @@ inline ToEngine swapChain(void *const pChain)
 }
 
 /// \param pSample an `LE::Sample *`, owned by the message.
-inline ToEngine swapSample(void *const pSample)
+inline ToEngine swapSample(void *const pSample, bool const replacesSample,
+                           std::uint8_t const source)
 {
     ToEngine message{};
     message.kind = ToEngine::Kind::SwapSample;
-    message.swapSample = {pSample};
+    message.swapSample = {pSample, replacesSample, source};
     return message;
 }
 

--- a/src/gui/editor/editorHost.hpp
+++ b/src/gui/editor/editorHost.hpp
@@ -29,6 +29,7 @@
 #define editorHost_hpp__0C5A1E7B_9D34_4F82_A6E1_37B0C4D8F925
 //------------------------------------------------------------------------------
 #include "core/threading/messages.hpp"
+#include "le/spectrumworx/sideChainSource.hpp"
 #include "core/threading/valueMailbox.hpp"
 
 #include "le/utility/platformSpecifics.hpp"
@@ -281,6 +282,21 @@ class EditorHost
     ///
     ////////////////////////////////////////////////////////////////////////////
     virtual char const *setNewSample(fs::path const &) = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What feeds the side channel, which is the audio-file selector's
+    /// answer and travels with the patch. \see sideChainSource.hpp.
+    ///
+    /// \note A pair of plain accessors rather than a parameter, because "load
+    /// this file" and "take the host's port" are one act and one selection. The
+    /// setter publishes to the audio thread; `SpectrumWorxCLAP` sends it in the
+    /// same command as a sample swap so that the two can never be seen apart.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    virtual SideChainSource sideChainSource() const = 0;
+    virtual void setSideChainSource(SideChainSource) = 0;
+
     virtual bool isSampleLoadInProgress() const = 0;
     virtual void registerSampleLoadedListener(SpectrumWorxEditor &) = 0;
     virtual void deregisterSampleLoadedListener(SpectrumWorxEditor const &) = 0;

--- a/src/gui/editor/presetLoading.cpp
+++ b/src/gui/editor/presetLoading.cpp
@@ -163,6 +163,12 @@ struct Loader
 
     bool wantsSampleFile() const { return !ignoreSampleFile && !onlySetParameters(); }
 
+    /// \note Wider than wantsSampleFile(): a patch loaded with "Ignore external
+    /// audio" on still says where its side channel comes from, and the answer is
+    /// then one of the two that is not a file. Only a load into a Program copy,
+    /// which has no host to set anything on, wants none of this.
+    bool wantsSideChain() const { return !onlySetParameters(); }
+
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \note The sample is the one thing a preset can name that a preset failing
@@ -231,6 +237,49 @@ struct Loader
 
         if (pEditor)
             pEditor->updateSampleNameAsync();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The audio file and the side-chain source together, because the
+    /// second is not decidable without the first.
+    ///
+    /// \note **The sample is applied exactly as it always was**, independently of
+    /// the source: a patch that names a file loads it and a patch that names none
+    /// clears whatever the last one left, because a preset is a statement about
+    /// everything it can name. What is new is only the source, which is then
+    /// allowed to be `Main` or `Host` with a file still loaded and ready to be
+    /// switched back to.
+    ///
+    /// \note **The migration.** A patch that records no source is a 2.x file, or
+    /// a 3.0 file this build's predecessor wrote, and 2016's rule is recoverable
+    /// exactly: the file wins if there is one, and otherwise `Input_mode`'s odd
+    /// values are the ones that asked the host. That reproduces the old truth
+    /// table row for row, including for the 84 shipped presets that name a
+    /// carrier and the ten in `Sidechainables` that ask for a send.
+    ///
+    ///   `Ignore external audio` falls out of it rather than being a case: with
+    /// the toggle on no sample is applied, so a patch that named one migrates to
+    /// `Input_mode`'s answer instead of to `File`, which is what a user who asked
+    /// not to be given somebody else's audio meant.
+    ///
+    /// \note A source of `File` with nothing loaded is not a state this leaves
+    /// behind. A named file that will not decode is reported and cleared, and the
+    /// source falls to `Main` -- so the selector never shows a file that is not
+    /// there, and the engine never has a source it cannot honour.
+    ///                                       (18.08.2026.)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    void setSideChain(std::string_view const recordedSource,
+                      std::optional<unsigned int> const legacyInputMode,
+                      std::string_view const sampleFileName) const
+    {
+        if (wantsSampleFile())
+            setSample(sampleFileName);
+
+        host.setSideChainSource(resolveSideChainSource(recordedSource, legacyInputMode,
+                                                       !host.currentSampleFile().empty()));
     }
 
     bool setNewGlobalParameters(GlobalParameters::Parameters const &newParameters) const

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1294,9 +1294,7 @@ juce::String SpectrumWorxEditor::buildStampText()
 
 SpectrumWorxEditor::EngineState SpectrumWorxEditor::currentEngineState() const
 {
-    auto const &core(editorHost().core());
-    return {core.getSampleRate(), core.numberOfInputChannels(), core.numberOfSideChannels(),
-            core.numberOfOutputChannels()};
+    return {editorHost().core().getSampleRate()};
 }
 
 /// \see the note on the declaration.
@@ -1312,9 +1310,7 @@ juce::String SpectrumWorxEditor::engineStateText() const
                             (state.sampleRate == std::floor(state.sampleRate)) ? 0 : 1) +
                " Hz";
 
-    return rate + "  " + juce::String(int{state.mainChannels}) + "main," +
-           juce::String(int{state.sideChannels}) + "side in, " +
-           juce::String(int{state.outputChannels}) + "main out";
+    return rate;
 }
 
 juce::Rectangle<int> SpectrumWorxEditor::buildStampBar() const
@@ -1433,9 +1429,26 @@ void SpectrumWorxEditor::updateSampleName(juce::String const &newSampleName)
     updateString(currentSampleName, sampleNameVerticalOffset, textBoxHeight, newSampleName);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The box shows the **source**, which is a file's name only when a file is
+/// what was selected. It is never empty: "nothing" is not one of the three
+/// answers, and an empty box was 2016's way of saying `Main` without a word for
+/// it. \see doc/tech/sidechain-approach.md.
+///
+////////////////////////////////////////////////////////////////////////////////
+
 void SpectrumWorxEditor::updateSampleName()
 {
-    updateSampleName(LE::IO::pathToJuceString(editorHost_.currentSampleFile().stem()));
+    switch (editorHost_.sideChainSource())
+    {
+    case SideChainSource::File:
+        return updateSampleName(LE::IO::pathToJuceString(editorHost_.currentSampleFile().stem()));
+    case SideChainSource::Main:
+        return updateSampleName("Main as sidechain");
+    case SideChainSource::Host:
+        return updateSampleName("Host sidechain");
+    }
 }
 
 /// \note "Async" is 2016's, and the branch it names is currently unreachable:
@@ -1470,6 +1483,20 @@ void SpectrumWorxEditor::setSampleLoadingStatus()
 /// `setNewSample` is a preset or a session being loaded, where there is nobody to
 /// answer a modal box and possibly no window to put one in.
 ///                                           (08.08.2026.) (SW port)
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Picking one of these **discards** a loaded file. The box has three
+/// answers and it should not be hiding a fourth piece of state behind one of
+/// them; \see the note on `SpectrumWorxCLAP::setSideChainSource()`.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::sideChainSourceSelected(SideChainSource const source)
+{
+    editorHost_.setSideChainSource(source);
+    updateSampleName();
+}
+
 void SpectrumWorxEditor::newSampleFileSelected(fs::path const &file)
 {
     auto const *const pErrorMessage(editorHost_.setNewSample(file));
@@ -1635,9 +1662,17 @@ void SpectrumWorxEditor::savePreset(fs::path const &presetFile, bool const ignor
 {
     fs::path const externalSample(ignoreExternalSample ? fs::path()
                                                        : editorHost_.currentSampleFile());
+    /// \note A preset saved with the browser's "Ignore external audio" on names
+    /// no file, so it cannot honestly say its side channel comes from one. The
+    /// other two sources are unaffected: what that toggle withholds is somebody
+    /// else's audio, not the patch's routing.
+    auto source(editorHost_.sideChainSource());
+    if (externalSample.empty() && (source == SideChainSource::File))
+        source = SideChainSource::Main;
+
     /// \note Where the interface's `juce::String` becomes the format's bytes, and
     /// the last thing presetFile.cpp used to do before it was deleted.
-    SW::savePreset(presetFile, externalSample,
+    SW::savePreset(presetFile, externalSample, source,
                    std::string_view(comment.toRawUTF8(), comment.getNumBytesAsUTF8()), program());
 }
 
@@ -3260,9 +3295,11 @@ void SpectrumWorxEditor::SampleArea::mouseUp(juce::MouseEvent const &event)
 {
     SpectrumWorxEditor &editor(this->editor());
     juce::ModifierKeys const mouseButtons(event.mods);
+    /// \note The right button used to clear the file, which meant "the main
+    /// input" without saying so. It says so.
     if (mouseButtons.isRightButtonDown())
     {
-        editor.newSampleFileSelected({});
+        editor.sideChainSourceSelected(SideChainSource::Main);
         return;
     }
     if (!mouseButtons.isLeftButtonDown() || menu_.menuActive())
@@ -3273,16 +3310,30 @@ void SpectrumWorxEditor::SampleArea::mouseUp(juce::MouseEvent const &event)
     enum : PopupMenu::ItemID
     {
         browse = 0,
-        clear,
+        mainAsSideChain,
+        hostSideChain,
         firstFactorySample
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The three sources first, because they are what this control is for,
+    /// and "No external audio" is gone from among them: it named the *absence* of
+    /// one source rather than the presence of another, which is why a user who
+    /// cleared a file could not say what they wanted instead. \see issue #113.
+    ///
+    /// \note Neither of the two is disabled when it is already selected. They are
+    /// a choice rather than a command, and greying out the current one is how the
+    /// old `clear` entry came to be disabled in exactly the state a user most
+    /// wanted to see what it said.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
     menu_.clear();
+    menu_.addItem(mainAsSideChain, "Main as sidechain");
+    menu_.addItem(hostSideChain, "Host sidechain");
+    menu_.addSectionHeader("Audio file");
     menu_.addItem(browse, "Load audio file...");
-    menu_.addItem(clear, "No external audio",
-                  /*icon*/ nullptr,
-                  /*enabled*/ !editor.editorHost().currentSampleFile().empty());
-    menu_.addSectionHeader("Factory samples");
     for (std::size_t sample(0); sample < factorySamples.size(); ++sample)
         menu_.addItem(static_cast<PopupMenu::ItemID>(firstFactorySample + sample),
                       LE::IO::pathToUTF8(factorySamples[sample].stem()).c_str());
@@ -3295,8 +3346,10 @@ void SpectrumWorxEditor::SampleArea::mouseUp(juce::MouseEvent const &event)
         {
         case browse:
             return browseForFile();
-        case clear:
-            return pEditor->newSampleFileSelected({});
+        case mainAsSideChain:
+            return pEditor->sideChainSourceSelected(SideChainSource::Main);
+        case hostSideChain:
+            return pEditor->sideChainSourceSelected(SideChainSource::Host);
         default:
             return pEditor->newSampleFileSelected(factorySamples[*chosen - firstFactorySample]);
         }

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -525,6 +525,14 @@ class SpectrumWorxEditor final : private SkinLifetime,
   private:
     void newSampleFileSelected(fs::path const &);
 
+  public:
+    /// \brief One of the two sources that is not a file, which is what the sample
+    /// menu's first two entries pick. Public because the menu itself is not
+    /// reachable headlessly -- opening one needs a message loop -- so this is
+    /// where a test stands in for a click.
+    void sideChainSourceSelected(SideChainSource);
+
+  private:
     /// \brief Parents \p panel to the editor, on top, wherever the placement puts
     /// it.
     void showPanel(juce::Component &panel);
@@ -569,24 +577,22 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \brief The other end of the same bar: what the engine currently believes
-    /// it is running at -- sample rate, and how many channels in and out.
+    /// \brief The other end of the same bar: the rate the engine is running at,
+    /// or "no rate" before a host has activated it.
     ///
-    ///   Reads `2main,0side in, 2main out`. The side count is spelt out rather
-    /// than folded into a total, because it is the interesting one and a sum
-    /// hides it: `4 in` could be four main channels or two and a side chain, and
-    /// those are different plugins.
-    ///
-    ///   Whether the host actually *patched* anything into that port is a
-    /// different question and a per-block one -- `SpectrumWorxCLAP::runEngine()`
-    /// decides it from `clap_audio_buffer::constant_mask` every callback and
-    /// falls back to the main input -- so it is deliberately not claimed here.
-    /// What this says is what the engine is *configured* for.
+    /// \note The channel layout was drawn here too until 18.08.2026 --
+    /// `2main,0side in, 2main out` -- and it is gone rather than shortened. It is
+    /// a *bus topology*, which is a handshake between the plugin, the host and
+    /// the track and not something a user acts on; the plugin declares the same
+    /// one unconditionally, so the readout was three constants beside a number
+    /// that moves. What a user does decide about the side chain is which source
+    /// feeds it, and that is answerable where they choose it. \see
+    /// doc/tech/sidechain-approach.md and issue #113.
     ///
     /// \note Live, where buildStampText() is fixed for the life of the process:
-    /// a host can change the sample rate or the layout under an open editor, so
+    /// a host can change the sample rate under an open editor, so
     /// `timerCallback()` watches for it. \see currentEngineState().
-    ///                                       (17.08.2026.)
+    ///                                       (18.08.2026.)
     ///
     ////////////////////////////////////////////////////////////////////////////
     juce::String engineStateText() const;
@@ -611,9 +617,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
     struct EngineState
     {
         float sampleRate{0};
-        std::uint8_t mainChannels{0};
-        std::uint8_t sideChannels{0};
-        std::uint8_t outputChannels{0};
 
         bool operator==(EngineState const &) const = default;
     }; // struct EngineState

--- a/src/le/spectrumworx/presetStorage.cpp
+++ b/src/le/spectrumworx/presetStorage.cpp
@@ -132,7 +132,8 @@ void copyPresetName(char const *const name, std::span<char> const target)
 }
 
 void savePreset(std::filesystem::path const &file, std::filesystem::path const &externalSample,
-                std::string_view const comment, Program const &program)
+                SideChainSource const sideChainSource, std::string_view const comment,
+                Program const &program)
 {
     std::error_code error;
     LE_ASSERT(std::filesystem::is_directory(file.parent_path(), error));
@@ -143,7 +144,7 @@ void savePreset(std::filesystem::path const &file, std::filesystem::path const &
     /// layer up, in presetFile.cpp, and it was the only thing that file did.
     auto const sample(externalSample.u8string());
 
-    auto const preset(savePreset(sample, comment, program));
+    auto const preset(savePreset(sample, sideChainSource, comment, program));
 
     if (!writePresetFile(file, preset.c_str(), static_cast<unsigned int>(preset.size() + 1)))
         reportPresetProblem(PresetProblem::SaveFailed);

--- a/src/le/spectrumworx/presetStorage.hpp
+++ b/src/le/spectrumworx/presetStorage.hpp
@@ -87,7 +87,7 @@ void copyPresetName(char const *name, std::span<char> target);
 ////////////////////////////////////////////////////////////////////////////////
 
 void savePreset(std::filesystem::path const &file, std::filesystem::path const &externalSample,
-                std::string_view comment, Program const &);
+                SideChainSource sideChainSource, std::string_view comment, Program const &);
 
 ////////////////////////////////////////////////////////////////////////////////
 ///

--- a/src/le/spectrumworx/presets.cpp
+++ b/src/le/spectrumworx/presets.cpp
@@ -107,6 +107,16 @@ char const globalParametersNodeName_[] = "Global";
 char const moduleParametersNodeName_[] = "Modules";
 char const sampleAttributeName_[] = "Sample";
 
+/// \note Beside the sample and keyed like it, because it answers the same
+/// question -- \see sideChainSource.hpp. No 2.x file has one; `Input_mode` below
+/// is what those are migrated from.
+char const sideChainSourceAttributeName_[] = "Side chain source";
+
+/// \note 2016's parameter, which every one of the 288 shipped presets carries
+/// and which is no longer a parameter here. Read once, at load, and never
+/// written. \see doc/tech/sidechain-approach.md.
+char const legacyInputModeAttributeName_[] = "Input mode";
+
 /// \name The 3.0 grammar's own names.
 /// \note Short on purpose: `<p>` and its two attributes are repeated once per
 /// parameter, up to 55 times per preset, and this is a format read by machines
@@ -703,6 +713,24 @@ std::string_view ParametersLoader::getSampleFileName()
     return pSampleFileName ? std::string_view(pSampleFileName) : std::string_view();
 }
 
+std::string_view ParametersLoader::getSideChainSource()
+{
+    LE_ASSERT_MSG(!switchedToModuleParameters(),
+                  "The side chain source must be fetched before switching to module parameters.");
+    auto const *const pSource(getParameterAttribute(sideChainSourceAttributeName_));
+    return pSource ? std::string_view(pSource) : std::string_view();
+}
+
+std::optional<unsigned int> ParametersLoader::getLegacyInputMode()
+{
+    LE_ASSERT_MSG(!switchedToModuleParameters(),
+                  "The input mode must be fetched before switching to module parameters.");
+    auto const *const pInputMode(getParameterAttribute(legacyInputModeAttributeName_));
+    if (!pInputMode)
+        return std::nullopt;
+    return Utility::lexical_cast<unsigned int>(pInputMode);
+}
+
 namespace
 {
 class LFODataLoader
@@ -1067,6 +1095,15 @@ void ParametersSaver::setSampleFileName(std::string_view const &sampleFileName)
     saveParameter(sampleAttributeName_, std::string(sampleFileName));
 }
 
+/// \note Written always, where the sample name is written only when there is one.
+/// The sample is a thing a patch may or may not have; the source is a thing every
+/// patch has, and a file that omitted it would be indistinguishable from a 2.x
+/// file and get migrated rather than read.
+void ParametersSaver::setSideChainSource(SideChainSource const source)
+{
+    saveParameter(sideChainSourceAttributeName_, std::string(toString(source)));
+}
+
 /// \note It took JUCE's file and string types and converted both to UTF-8 here,
 /// under a `JUCE_STRING_UTF_TYPE` switch with an `_alloca` in one arm. The
 /// conversion belongs at the interface's edge rather than in the format layer,
@@ -1079,8 +1116,8 @@ void ParametersSaver::setSampleFileName(std::string_view const &sampleFileName)
 /// and it is converted by the editor. \see tests/checkNoJuceFile.cmake.
 ///                                           (09.08.2026.) (SW port)
 std::string savePreset(std::string_view const externalSampleFilePath,
-                       std::string_view const comment, Program const &program,
-                       DawExtraState const *const pDawExtraState)
+                       SideChainSource const sideChainSource, std::string_view const comment,
+                       Program const &program, DawExtraState const *const pDawExtraState)
 {
     PresetHeader const presetHeader(comment);
     SavedPreset preset;
@@ -1111,6 +1148,8 @@ std::string savePreset(std::string_view const externalSampleFilePath,
         */
         parametersSaver.setSampleFileName(externalSampleFilePath);
     }
+
+    parametersSaver.setSideChainSource(sideChainSource);
 
     parametersSaver.saveEffectModuleChain(program.moduleChain());
 

--- a/src/le/spectrumworx/presets.hpp
+++ b/src/le/spectrumworx/presets.hpp
@@ -28,6 +28,7 @@
 /// `isAnEvent`, which is what "an event always streams off" is spelt with.
 #include "le/parameters/trigger/tag.hpp"
 #include "le/spectrumworx/engine/parameters.hpp"
+#include "le/spectrumworx/sideChainSource.hpp"
 #include "le/utility/countof.hpp"
 #include "le/utility/lexicalCast.hpp"
 #include "le/utility/platformSpecifics.hpp"
@@ -527,6 +528,31 @@ class ParametersLoader : private PresetHandler
 
     std::string_view getSampleFileName();
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What the patch says feeds its side channel, as written -- empty
+    /// when it does not say, which is every 2.x file and every 3.0 file older
+    /// than 18.08.2026.
+    ///
+    /// \note Handed back as text rather than as a `SideChainSource`, so that "the
+    /// patch does not say" and "the patch says something this build does not
+    /// know" are the caller's to tell apart. The first migrates; the second is a
+    /// file from a newer SpectrumWorx and takes the default.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    std::string_view getSideChainSource();
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief 2016's `Input_mode`, for migrating a patch that records no source.
+    ///
+    /// \note Read and **not** counted as a parameter: it is not one any more, so
+    /// a file that omits it is not missing anything. \see
+    /// sideChainSourceFromLegacyInputMode().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    std::optional<unsigned int> getLegacyInputMode();
+
     bool syncedLFOFound() const { return syncedLFOFound_; }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -740,6 +766,7 @@ class ParametersSaver : private PresetHandler
     //...mrmlj...temporarily reverting to old code for the 2.1 release...
     //void setSampleFileName( juce::String const & sampleFileName );
     void setSampleFileName(std::string_view const &sampleFileName);
+    void setSideChainSource(SideChainSource);
 
     std::string saveTo() const;
 
@@ -898,17 +925,21 @@ bool loadPreset(char *LE_RESTRICT const inMemoryPreset, bool const ignoreExterna
 
         auto loader(consumer.presetLoader(ignoreExternalSample));
 
-        if (loader.wantsSampleFile())
-        {
-            // Implementation note:
-            //   The sample file name must be fetched before switching to module
-            // parameters (see the implementation of the
-            // ParametersLoader::getSampleFileName() member function).
-            //                                (15.12.2011.) (Domagoj Saric)
-            /// \todo Clean up this spaghetti.
-            ///                               (15.12.2011.) (Domagoj Saric)
-            loader.setSample(parametersLoader.getSampleFileName());
-        }
+        ////////////////////////////////////////////////////////////////////////
+        ///
+        /// \note Both read before the reader switches to module parameters --
+        /// `getSampleFileName()`'s own assertion says why -- and both handed over
+        /// in one call, because the source is only decidable with the sample name
+        /// in hand: a patch that names a file and records no source is a 2.x
+        /// patch, and 2.x played the file. \see Loader::setSideChain() and
+        /// doc/tech/sidechain-approach.md.
+        ///
+        ////////////////////////////////////////////////////////////////////////
+        auto const sampleFileName(parametersLoader.getSampleFileName());
+        auto const recordedSource(parametersLoader.getSideChainSource());
+        auto const legacyInputMode(parametersLoader.getLegacyInputMode());
+        if (loader.wantsSideChain())
+            loader.setSideChain(recordedSource, legacyInputMode, sampleFileName);
 
         GlobalParameters::Parameters newParameters;
         LE::Parameters::forEach(newParameters, parametersLoader);
@@ -966,11 +997,15 @@ class Program;
 /// type either.
 ///
 /// \param externalSampleFilePath empty when no sample is loaded.
+/// \param sideChainSource what feeds the side channel. Written beside the sample
+/// rather than with the parameters, because it is the same answer -- the file
+/// selector's -- and not an automatable value. \see sideChainSource.hpp.
 /// \param pDawExtraState null for a `.swp`, which carries only what the plugin
 /// sounds like; non-null for the session state a host holds, which carries that
 /// plus where the user had got to. See DawExtraState.
-std::string savePreset(std::string_view externalSampleFilePath, std::string_view comment,
-                       Program const &, DawExtraState const *pDawExtraState = nullptr);
+std::string savePreset(std::string_view externalSampleFilePath, SideChainSource sideChainSource,
+                       std::string_view comment, Program const &,
+                       DawExtraState const *pDawExtraState = nullptr);
 
 } // namespace SW
 

--- a/src/le/spectrumworx/sideChainSource.hpp
+++ b/src/le/spectrumworx/sideChainSource.hpp
@@ -1,0 +1,170 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file sideChainSource.hpp
+/// -------------------------
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef sideChainSource_hpp__0A3F5C81_6D24_4B93_9E7A_2C15D0F8B647
+#define sideChainSource_hpp__0A3F5C81_6D24_4B93_9E7A_2C15D0F8B647
+//------------------------------------------------------------------------------
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace LE::SW
+{
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \enum SideChainSource
+///
+/// \brief What feeds the engine's side channel. Three answers, and there is no
+/// fourth.
+///
+///   This is the patch's, and it is the user's: it is what the audio-file
+/// selector answers. It is deliberately **not** a statement about the plugin's
+/// bus topology -- how many ports the plugin has and how many channels each
+/// carries is a handshake between the plugin, the host and the track, and a
+/// setting that claimed to decide it would be claiming something it does not
+/// get to decide. \see doc/tech/sidechain-approach.md and issue #113.
+///
+/// \note 2016 spelled this as an `InputMode` parameter -- a *bus* setting --
+/// crossed with "is a file loaded", which produced a truth table with one corner
+/// nobody could explain (2x2 with no file, which quietly meant `Main`). The three
+/// values below are that table with the corner named. `presets.hpp` migrates an
+/// old file's `Input_mode` into one of them.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+enum struct SideChainSource : std::uint8_t
+{
+    /// A decoded audio file, read forwards and wrapping at its end.
+    File,
+    /// The main input, so that an effect side-chains against itself.
+    Main,
+    /// The host's second input port.
+    Host
+};
+
+/// \brief What a new patch gets.
+///
+/// \note `Host`, so that a user who has patched a send hears it without going
+/// looking for a setting first. With nothing patched it reads as `Main` anyway --
+/// \see the fallbacks in sidechain-approach.md -- so the cost of being wrong
+/// about it is nothing.
+inline constexpr SideChainSource defaultSideChainSource{SideChainSource::Host};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The spelling that goes into a file.
+///
+/// \note **By name, not by ordinal.** A fourth value appended later cannot then
+/// change what an existing file means, which an ordinal would leave to luck. It
+/// is the rule the preferences file already follows for its two enumerations
+/// (`streaming_format.md` §4.4), and the reason it is worth restating here is
+/// that every *parameter* in this tree streams as a number -- so this is the
+/// exception, and it is one deliberately.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr char const *toString(SideChainSource const source)
+{
+    switch (source)
+    {
+    case SideChainSource::File:
+        return "file";
+    case SideChainSource::Main:
+        return "main";
+    case SideChainSource::Host:
+        return "host";
+    }
+    return "host";
+}
+
+/// \brief `toString()` backwards. Nothing for a spelling this build does not
+/// know, which is what lets the caller tell "the patch does not say" from "the
+/// patch says something".
+constexpr std::optional<SideChainSource> sideChainSourceFromString(std::string_view const text)
+{
+    if (text == "file")
+        return SideChainSource::File;
+    if (text == "main")
+        return SideChainSource::Main;
+    if (text == "host")
+        return SideChainSource::Host;
+    return std::nullopt;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief 2016's `Input_mode`, as a source.
+///
+/// \note The four values were `(Stereo)(StereoSideChain)(Mono)(MonoSideChain)`,
+/// so the odd ones are the two that asked the host for a side chain. Every one of
+/// the 288 shipped presets carries one, and this is the whole of what it means
+/// once a file is out of the picture -- when a patch names a file, the file is
+/// the source whatever the mode said, which is what 2016 did.
+///
+/// \note Mono is not a source and never was. It says how many channels each of
+/// these carries, which is issue #114.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr SideChainSource sideChainSourceFromLegacyInputMode(unsigned int const inputMode)
+{
+    return (inputMode % 2 != 0) ? SideChainSource::Host : SideChainSource::Main;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief What a patch being loaded means, whether or not it says so.
+///
+/// \param recorded what the patch wrote, empty when it wrote nothing -- which is
+///        every 2.x file and every 3.0 file older than 18.08.2026.
+/// \param legacyInputMode 2016's `Input_mode`, where the patch has one.
+/// \param haveSample whether a file ended up loaded. Not "whether the patch named
+///        one": a patch loaded with the browser's "Ignore external audio" on
+///        names one and gets none, and a named file that will not decode is
+///        cleared and reported.
+///
+/// \note **The migration is 2016's truth table, recovered exactly.** That table
+/// read as a bus setting crossed with "is a file loaded":
+///
+///     file loaded -> the file, in either mode
+///     no file     -> 2x2: the main input, 4x2: the host's port
+///
+/// so the file wins where there is one, and `Input_mode` decides the rest. Its
+/// odd values are the two that asked the host.
+///
+/// \note Shared by the plugin's loader and by the test harness deliberately: a
+/// migration each of them implemented separately would be a migration only one of
+/// them was testing.
+///
+/// \note A `File` that cannot be honoured is not returned. Nothing downstream has
+/// to cope with a source naming a file that is not there -- \see the same rule in
+/// `SpectrumWorxCLAP::setSideChainSource()`.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr SideChainSource resolveSideChainSource(std::string_view const recorded,
+                                                 std::optional<unsigned int> const legacyInputMode,
+                                                 bool const haveSample)
+{
+    auto const source(sideChainSourceFromString(recorded));
+    if (source)
+        return ((*source == SideChainSource::File) && !haveSample) ? SideChainSource::Main
+                                                                   : *source;
+
+    if (haveSample)
+        return SideChainSource::File;
+
+    return sideChainSourceFromLegacyInputMode(legacyInputMode.value_or(0));
+}
+
+} // namespace LE::SW
+
+#endif // sideChainSource_hpp

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1429,7 +1429,23 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
     ///
     ////////////////////////////////////////////////////////////////////////////
 
-    bool const sideChainCarriesSignal((process->audio_inputs_count > 1) &&
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And whether the port is consulted at all is the patch's, through
+    /// `SideChainSource` -- which is the audio-file selector's answer rather than
+    /// a claim about bus topology. \see doc/tech/sidechain-approach.md and issue
+    /// #113. `Host` is the only value that reads port 1; the fallbacks above are
+    /// what it gets when the host has not filled it.
+    ///
+    /// \note `sideChainSource_` is the engine's copy, set by `drainCommands()` in
+    /// the same message that swaps the sample -- so a block can never be rendered
+    /// with a new source and the sample the previous one named.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    bool const hostSideChainWanted(sideChainSource_ == SideChainSource::Host);
+
+    bool const sideChainCarriesSignal(hostSideChainWanted && (process->audio_inputs_count > 1) &&
                                       process->audio_inputs[1].data32 &&
                                       !isDeclaredSilent(process->audio_inputs[1]));
 
@@ -1437,7 +1453,7 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
                                                             : input.data32);
 
     ////////////////////////////////////////////////////////////////////////////
-    // An external audio file, when one is loaded, in place of the port.
+    // The decoded audio file, when that is what the patch selected.
     //
     // \note A `try_lock` on the processing lock stood around this, because the
     // message thread swapped the decoded data under the reader. Nothing swaps
@@ -1447,13 +1463,25 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
     // another thread happened to be busy.
     //                                        (02.08.2026.) (SW port)
     ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **`File` is a selection now, not a precedence.** Until 18.08.2026
+    /// this block simply overwrote whatever the port arm had chosen, which is
+    /// 2016's "we give higher priority to external samples loaded through SW"
+    /// -- correct in its effects and unable to say why. It says why now: the
+    /// three sources are exclusive and this is one of them.
+    ///
+    ///   `pSample_` is still tested rather than trusted. Nothing should be able
+    /// to leave `File` selected with no sample loaded -- both the setter and the
+    /// preset loader refuse it -- and a source the engine cannot honour falls
+    /// back to the main input rather than to a null dereference.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// \note A Sample is always stereo, so a wider engine configuration -- which
-    /// nothing produces today; activate() asks for 2 x 2 -- keeps the port.
     float const *sampleChannels[Sample::numberOfChannels];
     bool sideIsScratch(false);
-    if (pSample_ && *pSample_ && (channels <= std::size(sampleChannels)) &&
-        (buffers().numberOfSideChannels() >= channels) && (frames <= buffers().blockSize()))
+    if ((sideChainSource_ == SideChainSource::File) && pSample_ && *pSample_ &&
+        (channels <= std::size(sampleChannels)) && (buffers().numberOfSideChannels() >= channels) &&
+        (frames <= buffers().blockSize()))
     {
         auto const startingPosition(pSample_->samplePosition());
         std::uint32_t position(startingPosition);
@@ -1608,6 +1636,12 @@ void SpectrumWorxCLAP::drainCommands()
 
         case Threading::ToEngine::Kind::SwapSample:
         {
+            /// \note The source always; the sample only when one travelled.
+            /// Picking `Main` or `Host` leaves a loaded file where it is, so that
+            /// switching back to it needs no second decode.
+            sideChainSource_ = static_cast<SideChainSource>(command.swapSample.source);
+            if (!command.swapSample.replacesSample)
+                break;
             auto *const pOutgoing(
                 std::exchange(pSample_, static_cast<Sample *>(command.swapSample.pSample)));
             clearSideChannelData();
@@ -2275,7 +2309,8 @@ try
     /// \note `u8string()`, and the format's own `std::string_view` overload: the
     /// sample path goes into `<p n="Sample">` as UTF-8 bytes on every platform,
     /// which is what makes a session written on one openable on another.
-    auto const state(savePreset(LE::IO::pathToUTF8(sampleFile_), {}, programMain_, &dawExtraState));
+    auto const state(savePreset(LE::IO::pathToUTF8(sampleFile_), sideChainSourceMain_, {},
+                                programMain_, &dawExtraState));
 
     /// \note The terminator goes into the stream, because loadFrom() parses a
     /// C string and a host is free to hand back exactly what it was given with
@@ -2650,29 +2685,93 @@ char const *SpectrumWorxCLAP::setNewSample(fs::path const &newSampleFile)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-void SpectrumWorxCLAP::publishSample(Sample *const pNewSample)
+void SpectrumWorxCLAP::publishSideChain(Sample *const pNewSample, bool const replacesSample,
+                                        SideChainSource const source)
 {
     auto const recordWhatTheEngineHasNow([&] {
-        sampleFile_ = pNewSample ? pNewSample->sampleFile() : fs::path();
-        decodedSampleRate_ = pNewSample ? pNewSample->sampleRate() : 0;
+        if (replacesSample)
+        {
+            sampleFile_ = pNewSample ? pNewSample->sampleFile() : fs::path();
+            decodedSampleRate_ = pNewSample ? pNewSample->sampleRate() : 0;
+        }
+        sideChainSourceMain_ = source;
     });
 
     if (!engineIsRunning())
     {
-        delete std::exchange(pSample_, pNewSample);
-        clearSideChannelData();
+        sideChainSource_ = source;
+        if (replacesSample)
+        {
+            delete std::exchange(pSample_, pNewSample);
+            clearSideChannelData();
+        }
         recordWhatTheEngineHasNow();
         return;
     }
 
-    if (pushed(toEngine_.push(Threading::swapSample(pNewSample)),
-               "The command queue is full; a sample load was dropped."))
+    if (pushed(toEngine_.push(Threading::swapSample(pNewSample, replacesSample,
+                                                    static_cast<std::uint8_t>(source))),
+               "The command queue is full; a side chain change was dropped."))
     {
         recordWhatTheEngineHasNow();
         return;
     }
 
     delete pNewSample;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Loading a file *is* selecting it as the source, and clearing one is
+/// selecting the main input -- there is no arrangement in which a file is loaded
+/// and unheard by accident. A user who wants the host's port with a file still
+/// loaded says so through `setSideChainSource()`, which leaves the file alone.
+/// \see doc/tech/sidechain-approach.md.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxCLAP::publishSample(Sample *const pNewSample)
+{
+    publishSideChain(pNewSample, true,
+                     pNewSample ? SideChainSource::File
+                                : ((sideChainSourceMain_ == SideChainSource::File)
+                                       ? SideChainSource::Main
+                                       : sideChainSourceMain_));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **Selecting `Main` or `Host` discards the loaded file**, rather than
+/// leaving it loaded and unheard. Keeping it was tried and reverted on
+/// 18.08.2026: it made the box's three answers hide a fourth piece of state, so a
+/// patch could carry an audio file nothing would ever play, `stateSave` would
+/// write a `Sample=` the source contradicted, and "what is my side chain" had two
+/// answers that had to be read together. One selection, one thing selected.
+///
+///   The cost is a second decode if a user switches back, and it is the right
+/// cost: the alternative is a plugin that quietly remembers.
+///
+/// \note `File` is the exception and does not clear anything -- it is reached
+/// with a sample already published, from `Loader::setSideChain()` restoring a
+/// patch that names one. With no sample it is refused outright: the selector
+/// would otherwise show a file that is not there and the engine would hold a
+/// source it cannot honour.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxCLAP::setSideChainSource(SideChainSource const source)
+{
+    LE_ASSERT(Threading::isMainThread() || !Threading::isAudioThread());
+
+    if (source == SideChainSource::File)
+    {
+        if (sampleFile_.empty())
+            return setSideChainSource(SideChainSource::Main);
+        return publishSideChain(nullptr, false, SideChainSource::File);
+    }
+
+    publishSideChain(nullptr, true /*the file goes with it*/, source);
+    markCurrentProgramAsModified();
 }
 
 bool SpectrumWorxCLAP::registerOrUnregisterTimer(clap_id &id, int const milliseconds,

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -28,6 +28,7 @@
 #include "core/threading/valueMailbox.hpp"
 #include "external_audio/sample.hpp"
 #include "gui/editor/editorHost.hpp"
+#include "le/spectrumworx/sideChainSource.hpp"
 
 #include "le/plugins/clap/tag.hpp"
 
@@ -287,6 +288,9 @@ class SpectrumWorxCLAP final
 
     fs::path currentSampleFile() const override { return sampleFile_; }
     char const *setNewSample(fs::path const &) override;
+
+    SideChainSource sideChainSource() const override { return sideChainSourceMain_; }
+    void setSideChainSource(SideChainSource) override;
     /// \note Always false while the load above is synchronous: by the time
     /// anything can ask, it has finished. See the note on the interface.
     bool isSampleLoadInProgress() const override { return false; }
@@ -411,6 +415,9 @@ class SpectrumWorxCLAP final
 
     /// \brief Installs \p pNewSample (owned, null clears) as the side channel's
     /// source. `[main-thread]` \see the definition.
+    /// \brief One message either way: a new sample with the source that goes
+    /// with it, or a source on its own with whatever sample is loaded left alone.
+    void publishSideChain(Sample *pNewSample, bool replacesSample, SideChainSource);
     void publishSample(Sample *pNewSample);
 
     /// \brief Decodes \p sampleFile for the engine's current rate and installs
@@ -627,6 +634,21 @@ class SpectrumWorxCLAP final
     Sample *pSample_{nullptr};
     fs::path sampleFile_;
     unsigned int decodedSampleRate_{0};
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What feeds the side channel, split the same way and for the same
+    /// reason as the sample above it.
+    ///
+    /// \note `sideChainSource_` is the engine's and travels in the same message
+    /// as a sample swap, so the audio thread never holds a source and a sample
+    /// that disagree. `sideChainSourceMain_` is what the interface shows and what
+    /// `stateSave` writes, and it is the main thread's outright.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    SideChainSource sideChainSource_{defaultSideChainSource};
+    SideChainSource sideChainSourceMain_{defaultSideChainSource};
 
     /// \note Owned by the shim, which destroys it before this. Cleared in the
     /// editor's own destructor path so a queued notification cannot reach a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(sw-plugin-tests
         gui/overlayPanelTests.cpp
         gui/pathsTests.cpp
         gui/preferencesTests.cpp
+        gui/sideChainSelectorTests.cpp
         gui/skinTests.cpp
         gui/twoInstanceTests.cpp
         io/jucePathTests.cpp

--- a/tests/clap/parameterTextTests.cpp
+++ b/tests/clap/parameterTextTests.cpp
@@ -243,6 +243,11 @@ TEST_CASE("Text that is not a value is declined rather than guessed", "[clap][te
     CHECK_FALSE(params.text_to_value(&*plugin, windowType, "3", &value));
     CHECK(params.text_to_value(&*plugin, windowType, "Blackman", &value));
     CHECK(value == 2);
+
+    /// \note There is no third global to check here. `Input mode` was one for a
+    /// day, on 17.08.2026, and is not a parameter at all now: what feeds the side
+    /// channel is the audio-file selector's answer rather than an automatable
+    /// value, and it streams beside the sample. \see issue #113.
 }
 
 TEST_CASE("A typed value is read in display units, not storage units", "[clap][text]")

--- a/tests/clap/pluginTests.cpp
+++ b/tests/clap/pluginTests.cpp
@@ -46,6 +46,7 @@
 #include <filesystem>
 #include <cstring>
 #include <numbers>
+#include <optional>
 #include <functional>
 #include <set>
 #include <vector>
@@ -322,6 +323,12 @@ TEST_CASE("Audio ports are stereo in, stereo out, plus a side chain", "[clap]")
 /// engine receives, and that the two ways a host can decline to fill it both
 /// fall back rather than fault.
 ///
+/// \note **Every run here is in the default source, which is `Host`.** The port
+/// is read because the patch says to read it, and a fresh instance says to --
+/// which is deliberate, so that a user who has patched a send hears it without
+/// going looking for a setting. The case below this one is what pins the
+/// selection itself. \see issue #113.
+///
 ////////////////////////////////////////////////////////////////////////////////
 
 TEST_CASE("What a host puts on the side chain port reaches the engine", "[clap][side-chain]")
@@ -449,6 +456,95 @@ TEST_CASE("What a host puts on the side chain port reaches the engine", "[clap][
     ///
     ////////////////////////////////////////////////////////////////////////////
     CHECK(silentButUndeclared != noPort);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The other half, and the one the selector exists for: a fully patched,
+/// signal-carrying port is **ignored** while the patch's source is `Main`.
+/// Nothing about the host changes between the two runs below -- same buffers,
+/// same carrier, same port count -- so the only thing that can move the output is
+/// the selection, which is the property that was missing while the source was
+/// inferred from what the host handed over.
+///
+/// \note And the `Main` run is bit-identical to one with no port at all, rather
+/// than merely different: "ignored" is a stronger claim than "weighted less", and
+/// it is what makes `sidechain=main` mean what it says -- an effect sees the same
+/// spectrum on both channels. \see issue #113.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The patch's source decides whether the side chain port is read at all",
+          "[clap][side-chain][issue-113]")
+{
+    constexpr float sampleRate{48000};
+    constexpr std::uint32_t blockSize{512};
+    constexpr unsigned int blocks{24}; // past the engine's latency
+
+    auto const colorifer(SWTest::effectByStreamingName("Colorifer"));
+
+    /// \param source what to select, or nothing to leave the instance in whatever
+    ///        a fresh one is in -- which is what says what the default *is*
+    ///        rather than merely that the two values differ.
+    /// \param connectPort whether the host offers a second port at all.
+    auto const run(
+        [&](std::optional<LE::SW::SideChainSource> const source, bool const connectPort) {
+            Entry const entry;
+            ActivePlugin plugin(sampleRate, blockSize);
+
+            OneParameterEvent const fillSlotOne(parameterID(moduleChainType, 0), colorifer);
+            parameters(*plugin).flush(&*plugin, &*fillSlotOne, &discardedOutputEvents());
+            plugin.pumpMainThread();
+
+            if (source)
+                editorHostOf(*plugin).setSideChainSource(*source);
+
+            std::vector<float> leftIn(blockSize), rightIn(blockSize);
+            std::vector<float> sideLeft(blockSize, 0.0f), sideRight(blockSize, 0.0f);
+            std::vector<float> leftOut(blockSize), rightOut(blockSize);
+
+            if (connectPort)
+                plugin.connectSideChain(sideLeft, sideRight);
+
+            for (unsigned int block(0); block < blocks; ++block)
+            {
+                fillWithSine(leftIn, sampleRate, 440.0f, block * blockSize);
+                rightIn = leftIn;
+                fillWithSine(sideLeft, sampleRate, 1100.0f, block * blockSize);
+                sideRight = sideLeft;
+
+                plugin.process(leftIn, rightIn, leftOut, rightOut);
+                REQUIRE(allFinite(leftOut));
+            }
+            return leftOut;
+        });
+
+    using LE::SW::SideChainSource;
+
+    auto const noPort(run(SideChainSource::Host, false));
+    auto const heard(run(SideChainSource::Host, true));
+    auto const ignored(run(SideChainSource::Main, true));
+    auto const byDefault(run(std::nullopt, true));
+
+    REQUIRE(noPort.size() == heard.size());
+    CHECK(peak(heard) > 0);
+
+    // The control: with `Host` selected, the carrier reaches the engine.
+    CHECK(heard != noPort);
+
+    // The claim: the same carrier, on the same port, with `Main` selected, does
+    // not -- and not merely less of it.
+    CHECK(ignored == noPort);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And an untouched patch reads it, because the default source is
+    /// `Host`. Pinned here rather than left to the enum's declaration, because it
+    /// is the default's *audible* consequence: a user who has patched a send and
+    /// touched nothing else hears it.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(byDefault == heard);
 }
 
 TEST_CASE("The engine reports the latency its FFT size implies", "[clap]")

--- a/tests/clap/stateTests.cpp
+++ b/tests/clap/stateTests.cpp
@@ -496,7 +496,8 @@ TEST_CASE("Session state is the preset format plus a dawExtraState block", "[cla
     /// opening somebody's preset would silently overwrite where your browser was
     /// pointing and which settings you had -- the exact confusion between "what
     /// this sounds like" and "where I was" that the block exists to avoid.
-    auto const asPreset(LE::SW::savePreset({}, {}, plugin.implementation().program()));
+    auto const asPreset(LE::SW::savePreset({}, LE::SW::defaultSideChainSource, {},
+                                           plugin.implementation().program()));
     CHECK(asPreset.find("<SpectrumWorxPreset") != std::string::npos);
     CHECK(asPreset.find("<dawExtraState") == std::string::npos);
 }

--- a/tests/external_audio/sampleFeedTests.cpp
+++ b/tests/external_audio/sampleFeedTests.cpp
@@ -93,6 +93,25 @@ struct Arrangement
 {
     bool loadSample{false};
     bool connectPort{false};
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Which of the three sources the patch selects.
+    ///
+    /// \note Defaulted to `Main`, which is **not** the plugin's default -- that
+    /// is `Host`. This field is the arrangement a case asks for rather than the
+    /// one a fresh instance is in, and `run()` always sets it, so an omitted
+    /// `.source` means "the source in which neither the port nor a file is
+    /// heard". That is the arrangement every case in this file was implicitly in
+    /// before there was anything to name. \see pluginTests.cpp for the default.
+    ///
+    /// \note `loadSample` and `source` are independent on purpose. A file can be
+    /// loaded while another source is selected -- that is the whole of what the
+    /// old "a loaded file always wins" precedence could not express, and the case
+    /// below is about it.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    LE::SW::SideChainSource source{LE::SW::SideChainSource::Main};
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,6 +149,10 @@ std::vector<float> run(Arrangement const arrangement)
         REQUIRE(editorHostOf(*plugin).currentSampleFile().filename() == "Carrier.mp3");
     }
 
+    /// \note After the load, because loading a file *is* selecting it -- a case
+    /// that wants a file loaded and a different source has to say so second.
+    editorHostOf(*plugin).setSideChainSource(arrangement.source);
+
     for (unsigned int block(0); block < blocks; ++block)
     {
         fillWithSine(leftIn, 440.0f, block * blockSize);
@@ -150,39 +173,121 @@ std::vector<float> run(Arrangement const arrangement)
 } // anonymous namespace
 //------------------------------------------------------------------------------
 
-TEST_CASE("A loaded sample feeds the side channel in place of the port",
-          "[external-audio][side-chain]")
+TEST_CASE("Each of the three sources reaches the DSP, and only the selected one",
+          "[external-audio][side-chain][issue-113]")
 {
     juce::ScopedJuceInitialiser_GUI const juceIsUp;
 
-    auto const nothing(run({.loadSample = false, .connectPort = false}));
-    auto const portOnly(run({.loadSample = false, .connectPort = true}));
-    auto const sampleOnly(run({.loadSample = true, .connectPort = false}));
-    auto const both(run({.loadSample = true, .connectPort = true}));
+    using LE::SW::SideChainSource;
 
-    REQUIRE(nothing.size() == blockSize);
-    CHECK(peak(nothing) > 0); // the effect is producing audio at all
+    ////////////////////////////////////////////////////////////////////////////
+    // The three, each alone.
+    ////////////////////////////////////////////////////////////////////////////
 
-    // The sample reached the DSP: with nothing on the port, loading a file
-    // changed what came out.
-    CHECK(sampleOnly != nothing);
+    auto const self(run({.loadSample = false, .connectPort = false}));
+    auto const file(
+        run({.loadSample = true, .connectPort = false, .source = SideChainSource::File}));
+    auto const host(
+        run({.loadSample = false, .connectPort = true, .source = SideChainSource::Host}));
 
-    // The control, so that the line above is about the *sample* rather than
-    // about anything a second source does: the port reaches the engine too.
-    CHECK(portOnly != nothing);
-    CHECK(portOnly != sampleOnly);
+    REQUIRE(self.size() == blockSize);
+    CHECK(peak(self) > 0); // the effect is producing audio at all
+
+    // Three genuinely different renders, or nothing below distinguishes anything.
+    CHECK(file != self);
+    CHECK(host != self);
+    CHECK(host != file);
 
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note And the claim the case is named for. `runEngine()` overwrites
-    /// `sideChannels` with the sample's chunks *after* choosing the port, so a
-    /// loaded sample wins outright -- the port is not mixed with it, not
-    /// preferred over it, and not used for the channels the sample does not
-    /// have. Bit-identical to the sample alone is the only outcome consistent
-    /// with that, and it is what a user assumes when they load a file.
+    /// \note And now with everything present at once, three times over. The
+    /// selected source is the *only* one heard: not preferred, not mixed with,
+    /// not used for the channels another does not have. Bit-identical to the same
+    /// source alone is the only outcome consistent with that.
+    ///
+    ///   Two of these three were unaskable before 18.08.2026, and that is the
+    /// point of the change rather than a by-product of it. A loaded file beat the
+    /// port unconditionally, so "the host's send, and keep my file loaded" had no
+    /// spelling at all, and "the main input, with a file loaded" had none either.
+    /// \see issue #113.
     ///
     ////////////////////////////////////////////////////////////////////////////
-    CHECK(both == sampleOnly);
+
+    CHECK(run({.loadSample = true, .connectPort = true, .source = SideChainSource::File}) == file);
+    CHECK(run({.loadSample = true, .connectPort = true, .source = SideChainSource::Host}) == host);
+    CHECK(run({.loadSample = true, .connectPort = true, .source = SideChainSource::Main}) == self);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note What each source does when the thing it names is not there. Neither is
+/// an error and both land on the main input, which is what makes "an unpatched
+/// side chain blends the signal with itself" true of all three.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A source with nothing behind it is the main input",
+          "[external-audio][side-chain][issue-113]")
+{
+    juce::ScopedJuceInitialiser_GUI const juceIsUp;
+
+    using LE::SW::SideChainSource;
+
+    auto const self(run({.loadSample = false, .connectPort = false}));
+    REQUIRE(self.size() == blockSize);
+
+    // `Host` with no second port offered.
+    CHECK(run({.loadSample = false, .connectPort = false, .source = SideChainSource::Host}) ==
+          self);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note `File` with nothing loaded is not a state that can be reached at
+    /// all: the setter refuses it and leaves `Main` selected, so the selector can
+    /// never come to be showing a file that is not there and the engine can never
+    /// hold a source it cannot honour. Asserted on the *host* rather than only
+    /// through the audio, because "it sounds like Main" and "it is Main" are two
+    /// different claims and the second is the one being made.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    {
+        Entry const entry;
+        SWTest::ScopedProblemCounter const quiet;
+        ActivePlugin plugin(sampleRate, blockSize);
+
+        REQUIRE(editorHostOf(*plugin).currentSampleFile().empty());
+        editorHostOf(*plugin).setSideChainSource(SideChainSource::File);
+        CHECK(editorHostOf(*plugin).sideChainSource() == SideChainSource::Main);
+
+        // ...and with one loaded it is honoured, so the refusal is about the
+        // absent file rather than about the value.
+        editorHostOf(*plugin).setNewSample(carrier());
+        editorHostOf(*plugin).setSideChainSource(SideChainSource::File);
+        CHECK(editorHostOf(*plugin).sideChainSource() == SideChainSource::File);
+
+        ////////////////////////////////////////////////////////////////////////
+        ///
+        /// \note And selecting either of the others **discards** the file rather
+        /// than leaving it loaded and unheard. That is what keeps the selector's
+        /// three answers the whole of the state: a patch cannot come to carry
+        /// audio nothing will play, and `stateSave` cannot write a `Sample=` its
+        /// own source contradicts.
+        ///
+        ///   Which also puts `File` back out of reach, by the rule above -- the
+        /// two assertions together are the invariant, not two separate facts.
+        ///
+        ////////////////////////////////////////////////////////////////////////
+        editorHostOf(*plugin).setSideChainSource(SideChainSource::Host);
+        CHECK(editorHostOf(*plugin).sideChainSource() == SideChainSource::Host);
+        CHECK(editorHostOf(*plugin).currentSampleFile().empty());
+
+        editorHostOf(*plugin).setSideChainSource(SideChainSource::File);
+        CHECK(editorHostOf(*plugin).sideChainSource() == SideChainSource::Main);
+    }
+
+    CHECK(run({.loadSample = false, .connectPort = false, .source = SideChainSource::File}) ==
+          self);
+    CHECK(run({.loadSample = false, .connectPort = true, .source = SideChainSource::File}) == self);
 }
 
 TEST_CASE("The sample is read forwards rather than held", "[external-audio][side-chain]")
@@ -235,12 +340,20 @@ TEST_CASE("The sample is read forwards rather than held", "[external-audio][side
     CHECK(peak(captured[63]) > 0);
 }
 
-TEST_CASE("Clearing the sample gives the port back", "[external-audio][side-chain]")
+TEST_CASE("Clearing the sample stops it being heard", "[external-audio][side-chain]")
 {
     /// \note The other half of the swap, and the one a user reaches by loading a
     /// file and then removing it. `publishSample(nullptr)` has to leave the
-    /// engine reading the port again rather than the last chunk it saw -- a
+    /// engine reading its fallback again rather than the last chunk it saw -- a
     /// stale `pSample_` would keep feeding a file nothing has open.
+    ///
+    /// \note The case was "Clearing the sample gives the port back" until
+    /// 18.08.2026, and the port is not what it gives back any more: clearing a
+    /// file selects `Main`, so the fallback is the main input and the port is not
+    /// consulted either before the clear or after it. The port stays connected
+    /// below all the same, because a stale-pointer bug that only shows up when a
+    /// second source is present is exactly the shape this is watching for.
+    /// \see issue #113.
     juce::ScopedJuceInitialiser_GUI const juceIsUp;
 
     Entry const entry;

--- a/tests/goldens/engineHarness.hpp
+++ b/tests/goldens/engineHarness.hpp
@@ -24,6 +24,7 @@
 #include "le/spectrumworx/effects/configuration/constants.hpp"
 #include "le/spectrumworx/engine/moduleParameters.hpp"
 #include "le/spectrumworx/engine/parameters.hpp"
+#include "le/spectrumworx/sideChainSource.hpp"
 #include "le/utility/buffers.hpp"
 
 #include <cmath>
@@ -81,8 +82,17 @@ class Engine : public LE::SW::SpectrumWorxCore
 
     LE::SW::GlobalParameters::Parameters &parameters() { return program_.parameters(); }
 
+    /// \brief What a loaded preset said feeds the side channel.
+    ///
+    /// \note Recorded rather than acted on: this harness has no sample loader and
+    /// no host port, so what it can test about the side chain is the *format's*
+    /// half -- which is where the 2.x migration lives. \see PresetLoader.
+    LE::SW::SideChainSource sideChainSource() const { return sideChainSource_; }
+    void setSideChainSource(LE::SW::SideChainSource const source) { sideChainSource_ = source; }
+
   private:
     Program program_;
+    LE::SW::SideChainSource sideChainSource_{LE::SW::defaultSideChainSource};
 }; // class Engine
 
 //------------------------------------------------------------------------------

--- a/tests/gui/buildStampTests.cpp
+++ b/tests/gui/buildStampTests.cpp
@@ -141,22 +141,22 @@ TEST_CASE("The stamp names a date, a time and a commit", "[gui][buildstamp]")
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \brief The other end of the bar: what the plugin believes it is running at.
+/// \brief The other end of the bar: the rate, and only the rate.
 ///
-/// \note The channel count is the reason this is worth drawing, and the side
-/// count is spelt out rather than summed into the input total: `4 in` could be
-/// four main channels or two and a side chain, and those are different plugins.
+/// \note The channel layout was drawn here too until 18.08.2026 --
+/// `2main,0side in, 2main out` -- and this case asserted it against the engine.
+/// It is gone rather than shortened: a layout is a *bus topology*, which is a
+/// handshake between the plugin, the host and the track rather than anything a
+/// user acts on, and the plugin declares the same one unconditionally. So it was
+/// three constants sitting beside the one number in that bar that moves.
 ///
-/// \note What the readout deliberately does not claim is whether the host
-/// patched anything into that port. `runEngine()` decides that per block from
-/// `clap_audio_buffer::constant_mask` and falls back to the main input, so it is
-/// not a property of the configuration at all -- which is also why this case
-/// asserts against the engine rather than against a literal.
-///                                           (17.08.2026.)
+///   What a user does decide about the side chain is which of three sources
+/// feeds it, and that is answerable where they choose it rather than in a
+/// diagnostic strip. \see doc/tech/sidechain-approach.md and issue #113.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("The bar says the rate and the channel layout", "[gui][buildstamp]")
+TEST_CASE("The bar says the rate", "[gui][buildstamp]")
 {
     SWTest::HostSideJuce const juce;
     SWTest::Instance instance;
@@ -169,13 +169,8 @@ TEST_CASE("The bar says the rate and the channel layout", "[gui][buildstamp]")
     /// decimal point -- "48000 Hz" rather than "48000.0 Hz".
     CHECK(line.contains("48000 Hz"));
 
-    /// \note Built from the engine rather than written out, so this says "the
-    /// bar reports the configuration" rather than "the harness is stereo" --
-    /// which is the claim worth making and the one that survives the harness
-    /// being reconfigured.
-    auto const &core(instance.core());
-    auto const layout(std::to_string(core.numberOfInputChannels()) + "main," +
-                      std::to_string(core.numberOfSideChannels()) + "side in, " +
-                      std::to_string(core.numberOfOutputChannels()) + "main out");
-    CHECK(line.contains(layout.c_str()));
+    /// \note And nothing else. Asserted by length rather than by naming the
+    /// strings that are gone, so that anything new appearing in this half of the
+    /// bar has to come past this case.
+    CHECK(line.trim() == "48000 Hz");
 }

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -90,6 +90,20 @@ class Instance final : public GUI::EditorHost
         return *pEditor_;
     }
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The side chain's source, held and handed back.
+    ///
+    /// \note No sample loader under this harness, so `File` is not reachable
+    /// through it -- what the editor cases are about is that the selector *shows*
+    /// the source and that picking one reaches the host. \see
+    /// tests/external_audio/sampleFeedTests.cpp for what each source does to the
+    /// audio.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SideChainSource sideChainSource() const override { return sideChainSource_; }
+    void setSideChainSource(SideChainSource const source) override { sideChainSource_ = source; }
+
     SpectrumWorxCore &core() override { return engine_; }
     Plugin2HostInteropControler &automation() override { return notifications_; }
 
@@ -205,6 +219,7 @@ class Instance final : public GUI::EditorHost
     mutable Threading::ToEngineQueue toEngine_;
     Threading::ValueMailbox values_;
     std::unique_ptr<GUI::SpectrumWorxEditor> pEditor_;
+    SideChainSource sideChainSource_{defaultSideChainSource};
 }; // class Instance
 
 /// \brief JUCE, owned the way the shim owns it: one reference held across

--- a/tests/gui/sideChainSelectorTests.cpp
+++ b/tests/gui/sideChainSelectorTests.cpp
@@ -1,0 +1,121 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// sideChainSelectorTests.cpp
+/// --------------------------
+///
+///   The box under the LFO panel, which used to be called "External audio" and
+/// used to be able to say only two things: the name of a file, or nothing.
+///
+///   "Nothing" was 2016's way of writing `Main` without a word for it, which is
+/// why a user who cleared a file could not say what they wanted instead, and why
+/// the plugin's own truth table had a corner nobody could explain. The box
+/// answers "what goes into the side channel" now, and there are three answers.
+/// \see doc/tech/sidechain-approach.md and issue #113.
+///
+/// \note Pixels rather than the widget tree, for the reason overlayPanelTests
+/// gives at length: a label that holds the right string and is laid out under
+/// something else answers every question but the one that matters.
+///
+/// \note What is *not* here is the popup menu, and it is not reachable: opening
+/// one needs a message loop, which JUCE 8 compiles out of a binary with no
+/// message thread. What the menu items call is `sideChainSourceSelected()`, and
+/// that is driven directly.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module: the module chain downcasts a
+/// node to it, and this is the header with the complete type.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "le/spectrumworx/sideChainSource.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using Editor = GUI::SpectrumWorxEditor;
+
+juce::Image rendered(Editor &editor)
+{
+    juce::Image image(juce::Image::ARGB, editor.getWidth(), editor.getHeight(), true);
+    juce::Graphics graphics(image);
+    editor.paintEntireComponent(graphics, true);
+    return image;
+}
+
+/// \brief How many pixels two same-sized renders disagree about.
+std::size_t differingPixels(juce::Image const &left, juce::Image const &right)
+{
+    REQUIRE(left.getBounds() == right.getBounds());
+
+    juce::Image::BitmapData const leftPixels(left, juce::Image::BitmapData::readOnly);
+    juce::Image::BitmapData const rightPixels(right, juce::Image::BitmapData::readOnly);
+
+    std::size_t different{0};
+    for (int y(0); y < left.getHeight(); ++y)
+        for (int x(0); x < left.getWidth(); ++x)
+            different += (leftPixels.getPixelColour(x, y) != rightPixels.getPixelColour(x, y));
+    return different;
+}
+
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+TEST_CASE("The side chain box shows which source is selected", "[gui][side-chain][issue-113]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    instance.openEditor(Editor::PanelPlacement::overlay);
+    auto &editor(instance.editor());
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note A fresh editor is in `Host`, which is the plugin's default -- pinned
+    /// here because it is the one place a user meets it without having chosen
+    /// anything, and because the render below would otherwise be measuring a
+    /// difference from an arrangement nobody starts in.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(instance.sideChainSource() == defaultSideChainSource);
+    CHECK(defaultSideChainSource == SideChainSource::Host);
+
+    auto const showingHost(rendered(editor));
+
+    editor.sideChainSourceSelected(SideChainSource::Main);
+    CHECK(instance.sideChainSource() == SideChainSource::Main);
+    auto const showingMain(rendered(editor));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Two things at once, and both matter. The box *draws* something
+    /// different, so the selection is visible rather than merely stored -- and
+    /// the editor asked its host for the change, so picking a source is not a
+    /// thing the interface believes on its own.
+    ///
+    /// \note Some difference rather than a fraction: what moves is one line of
+    /// text in a 563 x 396 editor, so a floor worth having would be tuned to the
+    /// string lengths. Zero is the failure and it is the only one worth naming --
+    /// a box that never re-read the source, which is exactly what an empty
+    /// "External audio" field did for every state that was not a file.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(differingPixels(showingHost, showingMain) > 0);
+
+    // ...and back, so that neither string is the one it happens to start on.
+    editor.sideChainSourceSelected(SideChainSource::Host);
+    CHECK(instance.sideChainSource() == SideChainSource::Host);
+    CHECK(differingPixels(rendered(editor), showingHost) == 0);
+}

--- a/tests/presets/data/format3.swp
+++ b/tests/presets/data/format3.swp
@@ -6,6 +6,8 @@
 		<p n="FFT size" v="2048" />
 		<p n="Overlap factor" v="4" />
 		<p n="Window type" v="1" />
+		<p n="Side chain source" v="main" />
+		<p n="Input mode" v="1" />
 	</Global>
 	<Modules>
 		<Module effect="Pitch Shifter">

--- a/tests/presets/data/presetFixtures.txt
+++ b/tests/presets/data/presetFixtures.txt
@@ -16,11 +16,11 @@
 #     a 2009-2011 file against a 2016 effect. The digest is FNV-1a over the
 #     full parameter dump, values at six significant figures;
 #     SW_PRESET_DUMP=<substring> prints those dumps.
-Autotune/Aeolian.swp | 1 | TuneWorx | 18 | 0 | 25dceb7f6a39ecb2
-ESS/Once Upon A Time.swp | 2 | Freqverb,Reverser | 15 | 1 | 2877d1fbda5cfb1c
-Echoes/Great Escape.swp | 3 | Freqverb,Frecho,Gain | 22 | 1 | 08c64ce125a730d7
-Echoes/Jumbo Jet.swp | 4 | Freqverb,Freqverb,Freqverb,Freqverb | 36 | 4 | a7ee667221011e48
-Gamma Shift/Bird Song.swp | 5 | Exaggerator,Swappah,Freqverb,Bandpass,Frecho | 38 | 1 | 8eb84ca604791f0b
-Gamma Shift/Bojangles.swp | 4 | PVD start,Imploder (pvd),PVD stop,Bandstop | 25 | 0 | 157f3efa1cb2224b
-Overt Dynamics/Stalactite Rock Steady.swp | 5 | Freqverb,Slicer,Swappah,Exaggerator,Freqverb | 41 | 2 | ad1a65a1fea8477e
-Voices/Robokid.swp | 3 | Freqverb,Armonizer,Robotizer | 20 | 1 | 5646b85c45745135
+Autotune/Aeolian.swp | 1 | TuneWorx | 18 | 0 | 281669ac251cb78b
+ESS/Once Upon A Time.swp | 2 | Freqverb,Reverser | 15 | 1 | d25ee9de34df73e5
+Echoes/Great Escape.swp | 3 | Freqverb,Frecho,Gain | 22 | 1 | 1aee8bdd0079aaf8
+Echoes/Jumbo Jet.swp | 4 | Freqverb,Freqverb,Freqverb,Freqverb | 36 | 4 | 330c4603a5f5e141
+Gamma Shift/Bird Song.swp | 5 | Exaggerator,Swappah,Freqverb,Bandpass,Frecho | 38 | 1 | 17fd3582168bbe4c
+Gamma Shift/Bojangles.swp | 4 | PVD start,Imploder (pvd),PVD stop,Bandstop | 25 | 0 | 2c408206f2670e8c
+Overt Dynamics/Stalactite Rock Steady.swp | 5 | Freqverb,Slicer,Swappah,Exaggerator,Freqverb | 41 | 2 | d4fa75d96e10ae07
+Voices/Robokid.swp | 3 | Freqverb,Armonizer,Robotizer | 20 | 1 | 6cf5d61e1d12704e

--- a/tests/presets/presetCorpusTests.cpp
+++ b/tests/presets/presetCorpusTests.cpp
@@ -203,7 +203,7 @@ Loaded loadBuffer(std::vector<char> data, bool &succeeded, std::string *const pR
     CHECK(SWTest::presetProblems().unknownEffect == 0);
 
     if (pRewritten)
-        *pRewritten = savePreset({}, {}, engine.program());
+        *pRewritten = savePreset({}, engine.sideChainSource(), {}, engine.program());
 
     succeeded = true;
     auto loaded(dump(engine));
@@ -430,6 +430,74 @@ TEST_CASE("Every factory preset survives translation into the 3.0 format", "[pre
         /// is the one thing that legitimately differs between the two dumps.
         CHECK(reloaded.missing == 0); // a file this build wrote cannot be missing a parameter
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What the shipped files say about their side chain
+// -------------------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   Every shipped preset carries `Input_mode`, and until 18.08.2026 nothing read
+/// it: the 2016 parameter behind it was compiled out and then deleted, so 288
+/// files had been recording an intention the plugin had no way to act on. It is
+/// not a parameter here and never will be again -- bus topology is not a setting
+/// -- but it is exactly enough to recover what those files *meant*, which is
+/// which of the three sources feeds their side channel. \see
+/// doc/tech/sidechain-approach.md and issue #113.
+///
+///   In this harness no sample is ever applied (`wantsSampleFile()` declines
+/// them, as the browser's "Ignore external audio" does), so every preset takes
+/// the migration's second arm and `Input_mode` decides alone. The bank named
+/// `Sidechainables` is the ten that asked for a host send; everything else is
+/// self side chain. A build that read the attribute wrongly -- wrong key, an
+/// off-by-one, odd-vs-even inverted -- would either lose all ten or gain the
+/// other 278.
+///
+/// \note What this cannot show is the arm those ten take *in the plugin*, where
+/// a sample is applied and the file wins: all ten name a carrier chosen to match.
+/// `tests/external_audio/sampleFeedTests.cpp` is where that half lives.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("An old preset's input mode becomes the source it always meant",
+          "[preset-corpus][side-chain][issue-113]")
+{
+    auto const files(corpus());
+    REQUIRE_FALSE(files.empty());
+
+    std::vector<std::string> fromHost;
+    for (auto const &[key, path] : files)
+    {
+        INFO("preset " << key);
+
+        bool succeeded{false};
+        auto const loaded(load(path, succeeded, nullptr));
+        REQUIRE(succeeded);
+
+        /// \note One or the other and never neither, and never `file`: nothing
+        /// here loads a sample, so a `file` row would be a migration that had
+        /// invented a source it cannot honour.
+        auto const readsHost(loaded.text.find("side chain source = host\n") != std::string::npos);
+        CHECK((readsHost || (loaded.text.find("side chain source = main\n") != std::string::npos)));
+
+        if (readsHost)
+            fromHost.push_back(key);
+    }
+
+    /// \note The bank rather than the count, so that a preset added to or removed
+    /// from `Sidechainables` reads as ordinary content work and a preset
+    /// *elsewhere* that starts asking for a host send reads as a finding.
+    REQUIRE_FALSE(fromHost.empty());
+    for (auto const &key : fromHost)
+        CHECK(std::string_view(key).starts_with("Sidechainables/"));
+
+    /// ...and the whole bank, not part of it.
+    std::size_t inTheBank{0};
+    for (auto const &[key, path] : files)
+        inTheBank += std::string_view(key).starts_with("Sidechainables/");
+    CHECK(fromHost.size() == inTheBank);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/presets/presetHarness.cpp
+++ b/tests/presets/presetHarness.cpp
@@ -167,6 +167,19 @@ void countProblem(PresetProblem const problem, std::string_view const /*detail*/
 } // anonymous namespace
 //------------------------------------------------------------------------------
 
+void PresetLoader::setSideChain(std::string_view const recordedSource,
+                                std::optional<unsigned int> const legacyInputMode,
+                                std::string_view const sampleFileName) const
+{
+    /// \note `false` for "have a sample": wantsSampleFile() declines them, so a
+    /// preset that names one loads without it -- which is exactly the arrangement
+    /// the browser's "Ignore external audio" produces, and therefore exactly the
+    /// migration arm those files take there too.
+    LE::Utility::ignoreUnused(sampleFileName);
+    engine.setSideChainSource(
+        LE::SW::resolveSideChainSource(recordedSource, legacyInputMode, false));
+}
+
 bool PresetLoader::setNewGlobalParameters(
     LE::SW::GlobalParameters::Parameters const &newParameters) const
 {
@@ -218,6 +231,11 @@ Loaded dump(Engine &engine)
     });
 
     loaded.text += "modules = " + std::to_string(loaded.modules) + '\n';
+
+    /// \note In the dump, so that the 2.x migration is inside what
+    /// presetFixtures.txt hashes -- a shipped preset whose `Input_mode` stopped
+    /// being read would move its row rather than passing quietly.
+    loaded.text += std::string("side chain source = ") + toString(engine.sideChainSource()) + '\n';
     return loaded;
 }
 

--- a/tests/presets/presetHarness.hpp
+++ b/tests/presets/presetHarness.hpp
@@ -90,6 +90,21 @@ struct PresetLoader
     static bool wantsSampleFile() { return false; }
     static void setSample(std::string_view) {}
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The side chain's source, which this harness records rather than
+    /// applies -- there is no host under it to load a file on.
+    ///
+    /// \note Recorded all the same, because the *migration* is a claim about the
+    /// format rather than about the plugin: a 2.x file's `Input_mode` becoming
+    /// `Main` or `Host` is exactly the sort of thing presetCorpusTests exists to
+    /// pin. \see doc/tech/sidechain-approach.md.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static bool wantsSideChain() { return true; }
+    void setSideChain(std::string_view recordedSource, std::optional<unsigned int> legacyInputMode,
+                      std::string_view sampleFileName) const;
+
     bool setNewGlobalParameters(LE::SW::GlobalParameters::Parameters const &) const;
 
     static void moduleChainFinished(std::uint8_t /*moduleCount*/, bool /*syncedLFOFound*/) {}

--- a/tests/presets/presetRoundTripTests.cpp
+++ b/tests/presets/presetRoundTripTests.cpp
@@ -287,7 +287,7 @@ TEST_CASE("A saved preset loads back as itself", "[preset-roundtrip]")
 
             original = dump(engine).text;
 
-            saved = savePreset({}, "round trip", engine.program());
+            saved = savePreset({}, engine.sideChainSource(), "round trip", engine.program());
             REQUIRE_FALSE(saved.empty());
         }
 
@@ -381,7 +381,7 @@ TEST_CASE("Saving while an LFO is running stores the setting, not the sweep",
         [&](ModuleParameters const &module) { liveValue = module.getBaseParameter(gain); });
     REQUIRE(liveValue != setValue);
 
-    auto const saved(savePreset({}, "lfo running", engine.program()));
+    auto const saved(savePreset({}, engine.sideChainSource(), "lfo running", engine.program()));
     REQUIRE_FALSE(saved.empty());
 
     INFO("saved preset:\n" << saved);
@@ -412,7 +412,7 @@ TEST_CASE("A parameter under an enabled LFO takes its value from the LFO", "[pre
 
         REQUIRE(drivenValue != 0);
 
-        saved = savePreset({}, "lfo", engine.program());
+        saved = savePreset({}, engine.sideChainSource(), "lfo", engine.program());
         REQUIRE_FALSE(saved.empty());
     }
 
@@ -491,7 +491,8 @@ TEST_CASE("A preset saved to a file loads back from it", "[preset-roundtrip]")
 
         original = dump(engine).text;
 
-        auto const preset(savePreset({}, "through a file", engine.program()));
+        auto const preset(
+            savePreset({}, engine.sideChainSource(), "through a file", engine.program()));
         REQUIRE(
             writePresetFile(file, preset.c_str(), static_cast<unsigned int>(preset.size() + 1)));
     }
@@ -570,7 +571,7 @@ TEST_CASE("A preset saved under the host's locale is a preset anywhere else",
             });
 
         original = dump(engine).text;
-        saved = savePreset({}, "written abroad", engine.program());
+        saved = savePreset({}, engine.sideChainSource(), "written abroad", engine.program());
         REQUIRE_FALSE(saved.empty());
     }
 
@@ -639,6 +640,19 @@ TEST_CASE("The committed 3.0 fixture loads without the writer's help", "[preset-
     CHECK(globals.get<GlobalParameters::InputGain>().getValue() == Catch::Approx(0.5f));
     CHECK(globals.get<GlobalParameters::OutputGain>().getValue() == Catch::Approx(1.25f));
     CHECK(globals.get<GlobalParameters::MixPercentage>().getValue() == Catch::Approx(0.75f));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note The side chain's source, and the fixture is built so that only one
+    /// reading of it passes. `main` is not the default -- that is `host` -- so a
+    /// build that failed to find the element would answer `host`. And the fixture
+    /// *also* carries `Input mode="1"`, which migrates to `host`, so a build that
+    /// preferred the legacy key over the recorded source would answer `host` too.
+    /// `main` is only reachable by reading `Side chain source` and letting it win.
+    /// \see issue #113 and doc/tech/sidechain-approach.md.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(engine.sideChainSource() == SideChainSource::Main);
 
     /// Two modules, in document order, named by their streaming names.
     std::vector<std::string> effects;

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -171,10 +171,22 @@ class HarnessHost final : public GUI::EditorHost
     /// state. Loading one is what sampleTests.cpp covers.
     fs::path currentSampleFile() const override { return {}; }
     char const *setNewSample(fs::path const &) override { return nullptr; }
+
+    /// \note `Main`, not the plugin's default, so that a rendered page is a
+    /// function of the build rather than of what would be selected on a track
+    /// nobody has patched. \see doc/tech/sidechain-approach.md.
+    SideChainSource sideChainSource() const override { return sideChainSource_; }
+    void setSideChainSource(SideChainSource const source) override { sideChainSource_ = source; }
+
     bool isSampleLoadInProgress() const override { return false; }
+
     void registerSampleLoadedListener(GUI::SpectrumWorxEditor &) override {}
     void deregisterSampleLoadedListener(GUI::SpectrumWorxEditor const &) override {}
 
+  private:
+    SideChainSource sideChainSource_{SideChainSource::Main};
+
+  public:
     bool completelyDisableIOChanges() const override { return false; }
 
   private:


### PR DESCRIPTION
Where the side channel came from was inferred from what the host handed over, and the inference is not reliable in a real DAW: an unpatched port and a patched silent one are the same thing to constant_mask, a host that offers no way to patch port 1 leaves the feature unreachable with nothing said, and a loaded audio file beat the port by an accident of ordering rather than by anyone's choice.

The user's control is what goes into the side channel, and there are three answers: an audio file, the main input, or the host's port. Bus topology is not one of them -- how many ports there are and how many channels each carries is a handshake between the plugin, the host and the track, not a setting.

So the choice lives on the audio-file selector, which already answered that question and simply could not say "the main input" or "the host". It is always populated; "No external audio" goes, having named the absence of one source rather than the presence of another. Selecting a source discards whatever the last one held, so the three answers are the whole of the state.

The source streams beside the sample rather than as a parameter, since it is the same act and the same selection, and reaches the audio thread in the same message so the two can never be seen apart. Older patches derive it from 2016's Input_mode -- which all 288 shipped presets carry and nothing had read since it was deleted -- together with whether a file was applied, reproducing the old behaviour row for row, including the ten Sidechainables presets and their carriers.

The build-stamp bar drops the channel layout it used to draw beside the sample rate, for the same reason: it was three constants describing a handshake.

doc/tech/sidechain-approach.md is the sixth tech document.

Closes #113.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>