### PR TITLE
Let the user choose a colour scheme

### DIFF
--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -263,7 +263,7 @@ void AboutPage::Link::paintButton(juce::Graphics &graphics, bool const isMouseOv
 {
     auto const alpha(isButtonDown ? 0.6f : (isMouseOverButton ? 1.0f : 0.8f));
 
-    graphics.setColour(ColourMap::getColour(ColourMap::Blue).withAlpha(alpha));
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent).withAlpha(alpha));
     graphics.setFont(font());
     graphics.drawText(asText(flashing_ ? flashText_ : text_), getLocalBounds(),
                       juce::Justification::centredLeft);
@@ -401,7 +401,7 @@ void AboutPage::paint(juce::Graphics &graphics)
     }
 
     drawLine(graphics, asText(Content::originalAuthorsHeading), Layout::authorsHeadingY,
-             headingFont(), ColourMap::getColour(ColourMap::Blue), width);
+             headingFont(), ColourMap::getColour(ColourMap::Accent), width);
 
     {
         auto y(Layout::authorsY);

--- a/src/gui/colourMap.cpp
+++ b/src/gui/colourMap.cpp
@@ -10,15 +10,94 @@
 //------------------------------------------------------------------------------
 #include "colourMap.hpp"
 
+#include "le/utility/assert.hpp"
 #include "le/utility/platformSpecifics.hpp"
 
 namespace LE::SW::GUI
 {
 
+namespace
+{
+ColourMap::Palette current_{ColourMap::Classic};
+std::uint32_t generation_{0};
+
 ////////////////////////////////////////////////////////////////////////////////
 //
-// ColourMap::getColour()
-// ----------------------
+// turned()
+// --------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Classic, with its hue moved somewhere else.
+///
+/// \note A colour Classic left neutral is returned untouched. That is not a
+/// special case being handled, it is the whole reason this works: the skin's
+/// bevels, rules, ink and shadows have no hue to move, so turning the palette
+/// turns exactly the things that carry the accent -- the lit ring on a knob,
+/// the steel down a capsule, the wordmark's cold white -- and leaves the
+/// modelling alone.
+///
+/// \note The brightness correction is scaled by how coloured the colour is, for
+/// the same reason. A green at the blue's brightness reads far lighter than the
+/// blue did and a red far darker -- green weighs 0.691 of perceived brightness
+/// against blue's 0.068 -- so each palette carries a correction; applying it
+/// flat would drag every grey in the skin with it.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+struct Rotation
+{
+    float hue;        ///< turns of the colour wheel, added
+    float saturation; ///< multiplied
+    float brightness; ///< multiplied, in full at full saturation and not at all at none
+}; // struct Rotation
+
+juce::Colour turned(juce::Colour const colour, Rotation const &rotation)
+{
+    auto const saturation(colour.getSaturation());
+    if (saturation <= 0)
+        return colour;
+
+    return colour.withRotatedHue(rotation.hue)
+        .withMultipliedSaturation(rotation.saturation)
+        .withMultipliedBrightness(1 + saturation * (rotation.brightness - 1));
+}
+
+/// \brief Classic, with the colour taken out rather than moved.
+///
+/// \note By perceived brightness rather than by HSB's: the point of a grey
+/// scale is that nothing changes weight, and HSB calls a saturated blue and a
+/// saturated yellow equally bright.
+juce::Colour drained(juce::Colour const colour)
+{
+    return juce::Colour::greyLevel(colour.getPerceivedBrightness())
+        .withAlpha(colour.getFloatAlpha());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \name Where each palette puts the accent
+///
+///   Classic's is #13B5EA: hue 194.8 degrees, saturation 0.92, and 0.638 of
+/// perceived brightness. The hue below each is the turn from there, and the
+/// other two numbers are fitted to land back on that same 0.638 -- so the
+/// accent keeps the weight the artwork was drawn around, whatever colour it is.
+/// Amber cannot quite be muted into place and is left where SCXT has it.
+///
+///@{
+/// To 2 degrees: #FF6C67, perceived 0.613.
+Rotation constexpr redRotation{0.4645f, 0.65f, 1.10f};
+/// To 135 degrees: #33BF56, perceived 0.636.
+Rotation constexpr greenRotation{0.8339f, 0.80f, 0.80f};
+/// To 37 degrees, which is SCXT's accent_1a. \see ColourMap::sstDark().
+Rotation constexpr amberRotation{0.5615f, 0.78f, 1.05f};
+///@}
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// ColourMap::classic()
+// --------------------
 //
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -28,13 +107,13 @@ namespace LE::SW::GUI
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-juce::Colour ColourMap::getColour(Name const name)
+juce::Colour ColourMap::classic(Name const name)
 {
     switch (name)
     {
     ///   19, 181, 234, which is what Theme said and what the skin's vectors
     /// were traced to within three parts in 255. \see the note in the header.
-    case Blue:
+    case Accent:
         return juce::Colour(0xFF13B5EAu);
     case Text:
         return juce::Colour(0xFFFFFFFFu);
@@ -167,6 +246,171 @@ juce::Colour ColourMap::getColour(Name const name)
         break;
     }
 
+    LE_UNREACHABLE_CODE();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// ColourMap::sstDark()
+// --------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   Shortcircuit XT's wireframe-dark, from its themes/wireframe-dark.json: an
+/// amber accent over three flat greys, with the content in four weights of
+/// neutral.
+///
+/// \note The one palette with a `default:`, and it is the difference between
+/// this and Reds. SST Dark is a statement about the *chassis* -- what the
+/// editor's grounds and its ink are -- and it has nothing to say about the
+/// second highlight near the foot of a slider bead or the shade a knob's bevel
+/// turns over at. Those keep the artwork's own modelling, turned to amber. So
+/// what is listed below is exactly what SCXT has an opinion about.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+juce::Colour ColourMap::sstDark(Name const name)
+{
+    switch (name)
+    {
+    ///   accent_1b rather than accent_1a. SCXT uses the brighter amber for
+    /// small marks; here the accent is also what every panel's gradient is
+    /// lifted *towards*, and #FFB949 at 0.78 of perceived brightness turns that
+    /// wash into the loudest thing on the page. This one sits at 0.62, which is
+    /// where Classic's blue sits, so the chassis keeps the weight it was drawn
+    /// with. \see BackgroundStyle::Ramp::lift.
+    case Accent:
+        return juce::Colour(0xFFD09030u); // accent_1b
+
+    ///   The chassis, inverted. Classic's surround is a light grey with dark
+    /// panels on it; every ground here is one of the three darks.
+    case EditorSurround:
+        return juce::Colour(0xFF1B1D20u); // bg_main
+    case EditorPanel:
+        return juce::Colour(0xFF262A2Fu); // bg_2
+    case EditorWell:
+        return juce::Colour(0xFF1B1D20u); // bg_1
+    case EditorWellFace:
+        return juce::Colour(0xFF141619u); // under bg_main, as Classic's is under its own
+    case PanelBackground:
+        return juce::Colour(0xFF1B1D20u);
+    case ModuleBackground:
+        return juce::Colour(0xFF262A2Fu);
+    case ComboBackground:
+        return juce::Colour(0xFF1B1D20u);
+    case MenuBackground:
+        return juce::Colour(0xFF1B1D20u);
+    case Ground:
+        return juce::Colour(0xFF141619u);
+
+    ///   The rules. White hairlines round every panel would be the loudest
+    /// thing on a ground this dark, so they go to the grey SCXT divides panels
+    /// with.
+    case EditorRule:
+        return juce::Colour(0xFF393939u); // grid_primary, opaque
+    case PanelFrame:
+        return juce::Colour(0xFF777777u); // generic_content_low
+    case MenuOutline:
+        return juce::Colour(0xFF333333u); // bg_3
+
+    /// The ink, in SCXT's four weights.
+    case Text:
+        return juce::Colour(0xFFFFFFFFu); // generic_content_highest
+    case TextDimmed:
+        return juce::Colour(0xFFDFDFDFu); // generic_content_high
+    case TextFaint:
+        return juce::Colour(0xFF777777u); // generic_content_low
+    case Wordmark:
+        return juce::Colour(0xFFAFAFAFu); // generic_content_medium
+
+    ///   A button. Classic's runs from white to black with dark ink on it,
+    /// which on this chassis would be a slab of daylight; SCXT's buttons are
+    /// the mid grey against the panel behind them.
+    case ButtonFaceTop:
+        return juce::Colour(0xFFAFAFAFu);
+    case ButtonFaceBottom:
+        return juce::Colour(0xFF262A2Fu);
+    case ButtonCaption:
+        return juce::Colour(0xFF1B1D20u);
+    case TabFaceTop:
+        return juce::Colour(0xFF777777u);
+    case TabFaceBottom:
+        return juce::Colour(0xFF262A2Fu);
+
+    default:
+        return turned(classic(name), amberRotation);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// ColourMap::getColour()
+// ----------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note An HSB round trip per colour asked for, on the palettes that turn one.
+/// Measured against the alternative -- a table filled on setPalette() -- it is
+/// not worth the invalidation: the editor asks for a few hundred colours a
+/// frame, thirty times a second, and each one is a dozen floating-point
+/// operations.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+juce::Colour ColourMap::getColour(Name const name)
+{
+    switch (current_)
+    {
+    case Classic:
+        return classic(name);
+    case SSTDark:
+        return sstDark(name);
+    case Grays:
+        return drained(classic(name));
+    case Reds:
+        return turned(classic(name), redRotation);
+    case Greens:
+        return turned(classic(name), greenRotation);
+
+    /// \note No `default:` here either, for the reason getColour()'s has none.
+    case numberOfPalettes:
+        break;
+    }
+
+    LE_UNREACHABLE_CODE();
+}
+
+ColourMap::Palette ColourMap::palette() { return current_; }
+
+std::uint32_t ColourMap::generation() { return generation_; }
+
+void ColourMap::setPalette(Palette const palette)
+{
+    LE_ASSERT(palette < numberOfPalettes);
+    if (palette == current_)
+        return;
+
+    current_ = palette;
+    ++generation_;
+}
+
+char const *ColourMap::nameOf(Palette const palette)
+{
+    switch (palette)
+    {
+    case Classic:
+        return "Classic";
+    case SSTDark:
+        return "SSTDark";
+    case Grays:
+        return "Grays";
+    case Reds:
+        return "Reds";
+    case Greens:
+        return "Greens";
+    case numberOfPalettes:
+        break;
+    }
     LE_UNREACHABLE_CODE();
 }
 

--- a/src/gui/colourMap.hpp
+++ b/src/gui/colourMap.hpp
@@ -20,8 +20,16 @@
 /// would.
 ///
 /// \note A switch rather than a table so that the answer can grow a condition
-/// -- a second palette, a host-supplied accent -- without every call site
-/// learning about it. Nothing needs that yet.
+/// without every call site learning about it. Five palettes need that now, and
+/// not one of the two hundred call sites changed to get them.
+///
+///   Only Classic is written out. It is traced from artwork and every tint in
+/// it leans on the accent's hue, so Reds and Greens are that hue turned -- and
+/// a colour the artwork left neutral has no hue to turn, which is what keeps
+/// the greys grey without a list of exceptions. Grays is the same trick with
+/// the colour taken out rather than moved. SST Dark is the one that is not a
+/// recolour: it inverts the chassis, so it names what it changes and turns the
+/// rest.
 ///
 /// \note Sits in the same layer as theme.hpp and below everything else in
 /// src/gui, and depends on juce_graphics and nothing of ours.
@@ -35,6 +43,8 @@
 #define colourMap_hpp__DD5E31D8_98D4_41FF_A352_7AA31EFA1DA1
 //------------------------------------------------------------------------------
 #include <juce_graphics/juce_graphics.h>
+
+#include <cstdint>
 
 namespace LE::SW::GUI
 {
@@ -58,12 +68,12 @@ class ColourMap
         ////////////////////////////////////////////////////////////////////////
         /// \name The skin's own three
         ///
-        ///   Blue is the accent and it means one thing throughout: *this is the
+        ///   The accent means one thing throughout: *this is the
         /// value*, *this one is selected*, *this is on*. Everything that is not
         /// the accent is text on a dark ground, at one of three weights.
         ////////////////////////////////////////////////////////////////////////
         ///@{
-        Blue,
+        Accent,
         Text,       ///< what a label or a value is written in
         TextDimmed, ///< present, but not what is being looked at
         TextFaint,  ///< there because leaving it out would be a lie
@@ -91,7 +101,7 @@ class ColourMap
         /// \name A module's knob
         ///
         /// \note Its wedge is not here: the wedge is the accent, so it asks for
-        /// Blue. \see ModuleKnobStyle in modules/moduleUI.hpp.
+        /// Accent. \see ModuleKnobStyle in modules/moduleUI.hpp.
         ////////////////////////////////////////////////////////////////////////
         ///@{
         ModuleKnobDomeCentre, ///< the dome where the cap ends
@@ -109,7 +119,7 @@ class ColourMap
         /// and its caption is dark ink on that. A tab is the same shape in
         /// slightly softer greys, or in the accent when it is the one showing.
         ///
-        /// \note The selected tab's ramp runs from Blue to TabFaceBottom, so it
+        /// \note The selected tab's ramp runs from Accent to TabFaceBottom, so it
         /// has no top colour of its own. \see buttonPainter.hpp.
         ////////////////////////////////////////////////////////////////////////
         ///@{
@@ -132,7 +142,7 @@ class ColourMap
         ////////////////////////////////////////////////////////////////////
         /// \name The capsule that says something is running
         ///
-        /// \note Lit, it is Blue with a halo going from white to blue as it
+        /// \note Lit, it is the accent with a halo going from white to it as it
         /// spreads. Dark, it is a ramp across its own width -- almost black at
         /// the left and a cold steel at the right, which is the whole of the
         /// sheen on a shape five pixels tall. \see capsulePainter.hpp.
@@ -163,7 +173,7 @@ class ColourMap
         /// \name The editor's own chassis
         ///
         /// \note Two darks and a rule. Every panel in the editor is one of the
-        /// darks eased into Blue by an amount of its own, which is the whole of
+        /// darks eased into Accent by an amount of its own, which is the whole of
         /// what its six gradients were. \see backgroundPainter.hpp.
         ////////////////////////////////////////////////////////////////////////
         ///@{
@@ -183,7 +193,7 @@ class ColourMap
 
         /// \brief Inside a module's frame, behind its controls.
         ///
-        /// \note The rim around it is Blue and the halo on the focused one is
+        /// \note The rim around it is Accent and the halo on the focused one is
         /// FocusHalo, so this is the whole of what a strip adds to the palette.
         /// \see ModuleStripStyle in modules/moduleUI.hpp.
         ModuleBackground,
@@ -244,7 +254,70 @@ class ColourMap
         numberOfColours
     }; // enum Name
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Which set of answers getColour() gives.
+    ///
+    /// \note Streamed by name into the preferences file, like every other
+    /// enumeration the user picks from, so the order here is free. \see
+    /// nameOf() and GUI::Preferences::palette().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    enum Palette
+    {
+        Classic, ///< the skin as it was drawn, and the only one written out
+        SSTDark, ///< Shortcircuit XT's wireframe-dark, as near as this skin goes
+        Grays,
+        Reds,
+        Greens,
+        numberOfPalettes
+    }; // enum Palette
+
     static juce::Colour getColour(Name);
+
+    static Palette palette();
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Repaints nothing. `[main-thread]`
+    ///
+    ///   The palette is process-wide, so a second plugin instance in the same
+    /// host has just had its colours changed by a settings page it does not
+    /// know about. Telling it is generation()'s job.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    static void setPalette(Palette);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Bumped by every setPalette() that changes anything.
+    ///
+    ///   What a live editor compares against to find out that the palette moved
+    /// under it. Only ever compared for inequality -- so the wrap at 2^32 is
+    /// not a case to think about -- and only ever from the message thread,
+    /// which is what makes a plain counter enough. \see
+    /// SpectrumWorxEditor::applyPaletteIfChanged().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    static std::uint32_t generation();
+
+    /// \brief The enumerator's own spelling, for the preferences file and for
+    /// SW_SHOW_UI_PALETTE. What a user *sees* is the settings page's business.
+    static char const *nameOf(Palette);
+
+  private:
+    ////////////////////////////////////////////////////////////////////////////
+    /// \name The two palettes that name colours rather than derive them
+    ///
+    /// \note Members rather than file statics only so that the switches inside
+    /// them can say `Accent` instead of `ColourMap::Accent` fifty-six times.
+    ///@{
+    static juce::Colour classic(Name);
+    static juce::Colour sstDark(Name);
+    ///@}
 
   public:
     ColourMap() = delete; // a namespace with a nested enum, not an object

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1134,7 +1134,7 @@ struct EditorMainAreaText
 {
     juce::String const *pText;
     juce::Font const *pFont;
-    juce::Colour const colour;
+    ColourMap::Name const colour;
     unsigned int const verticalOffset;
     juce::Justification const justification;
     unsigned int const textLinesToUse;
@@ -1148,16 +1148,20 @@ struct EditorMainAreaText
 // but construct our own white juce::Colour here.
 //                                        (25.01.2011.) (Domagoj Saric)
 //
-/// \note ColourMap::getColour() keeps that property -- it is a call returning
-/// by value, so there is no other object to be initialised before this one.
+/// \note Which the name below settles for good: there is no colour here to be
+/// initialised in any order at all. It was a juce::Colour until the palettes
+/// arrived, and a colour taken at static-initialisation time is taken before a
+/// palette has been chosen -- so these four strings stayed the skin's original
+/// blue and white whatever the user had picked.
+///                                       (18.08.2026.)
 EditorMainAreaText mainAreaTexts[] = {
-    {0, 0, ColourMap::getColour(ColourMap::Blue), Constants::Layout::moduleNameVerticalOffset,
+    {0, 0, ColourMap::Accent, Constants::Layout::moduleNameVerticalOffset,
      juce::Justification::centred, 1}, // active module name
-    {0, 0, ColourMap::getColour(ColourMap::Text), Constants::Layout::controlNameVerticalOffset,
+    {0, 0, ColourMap::Text, Constants::Layout::controlNameVerticalOffset,
      juce::Justification::top | juce::Justification::horizontallyCentred, 2}, // control name
-    {0, 0, ColourMap::getColour(ColourMap::Text), Constants::Layout::controlValueVerticalOffset,
+    {0, 0, ColourMap::Text, Constants::Layout::controlValueVerticalOffset,
      juce::Justification::centred, 1}, // control value
-    {0, 0, ColourMap::getColour(ColourMap::Blue), Constants::Layout::sampleNameVerticalOffset,
+    {0, 0, ColourMap::Accent, Constants::Layout::sampleNameVerticalOffset,
      juce::Justification::centred, 1}, // sample name
 };
 
@@ -1165,7 +1169,7 @@ void drawMainAreaText(juce::Graphics &graphics, EditorMainAreaText const &text)
 {
     using namespace Constants::Layout;
 
-    graphics.setColour(text.colour);
+    graphics.setColour(ColourMap::getColour(text.colour));
     graphics.setFont(*text.pFont);
     graphics.drawFittedText(*text.pText, textBoxHorizontalOffset + textBoxMargin,
                             text.verticalOffset, textBoxWidth - 2 * textBoxMargin,
@@ -1345,7 +1349,7 @@ void SpectrumWorxEditor::paintBuildStamp(juce::Graphics &graphics) const
     /// \note The skin's own accent, at the smallest size its font stays legible
     /// at. This is a developer's readout on a user's window, so it should be
     /// readable when looked for and quiet when not.
-    graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
     graphics.setFont(juce::Font(juce::FontOptions(regularTypeface()).withHeight(11.0f)));
 
     auto const text(bar.reduced(8, 0));
@@ -2376,6 +2380,8 @@ void SpectrumWorxEditor::parameterChangedElsewhere(ParameterID const parameterID
 
 void SpectrumWorxEditor::timerCallback()
 {
+    applyPaletteIfChanged();
+
     pumpModulatedValues();
 
     /// \note Compared as numbers rather than as the formatted line, so the common
@@ -2386,6 +2392,62 @@ void SpectrumWorxEditor::timerCallback()
         engineState_ = state;
         repaint(buildStampBar());
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// SpectrumWorxEditor::applyPaletteIfChanged()
+// -------------------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Polled rather than pushed because the change may not be this editor's.
+/// The palette is process-wide, so a second instance in the same host has just
+/// had its colours swapped by a settings page it has never heard of and nothing
+/// has marked a pixel of it dirty. Every editor watching one counter is what
+/// makes "change it once, change it everywhere" true without a registry of live
+/// editors to keep correct.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::applyPaletteIfChanged()
+{
+    LE_ASSERT(isThisTheGUIThread());
+
+    auto const generation(ColourMap::generation());
+    if (generation == palette_)
+        return;
+    palette_ = generation;
+
+    /// \note Before the repaint, and idempotent: whichever editor gets here
+    /// first takes the colours and the rest find them taken.
+    Theme::singleton().reloadColours();
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note The wrapper rather than this, where there is one: ZoomedEditor
+    /// paints ColourMap::Ground behind the transform -- the half pixel rounding
+    /// leaves down the right edge -- and it is this editor's *parent*, so a
+    /// repaint from here would not reach it. \see setZoom(), which reaches for
+    /// it the same way.
+    ///
+    /// \note And sendLookAndFeelChange() rather than repaint(): it repaints
+    /// every descendant *and* tells each one its colours moved, which is what a
+    /// widget holding a LookAndFeel colour of its own needs to hear.
+    ////////////////////////////////////////////////////////////////////////////
+    auto *const pWrapper(findParentComponentOfClass<ZoomedEditor>());
+    juce::Component &root(pWrapper ? static_cast<juce::Component &>(*pWrapper) : *this);
+    root.sendLookAndFeelChange();
+}
+
+void SpectrumWorxEditor::setPalette(ColourMap::Palette const palette)
+{
+    preferences().setPalette(palette);
+    ColourMap::setPalette(palette);
+
+    /// \note Not applied here. This editor picks the change up on its next tick
+    /// through exactly the path a *second* instance does, so there is one way
+    /// a palette reaches the screen rather than two that have to agree.
+    /// \see applyPaletteIfChanged().
 }
 
 void SpectrumWorxEditor::pumpModulatedValues()
@@ -2461,7 +2523,7 @@ void SpectrumWorxEditor::updateModuleParameterAndNotifyHost(ModuleUI &moduleUI,
 
 SpectrumWorxEditor::ModuleMenuButton::ModuleMenuButton(SpectrumWorxEditor &parent)
     : ArrowButton(parent.mainArea(), ArrowStyle::addModuleWidth, ArrowStyle::addModuleHeight,
-                  true /*fades in from its base*/, ColourMap::getColour(ColourMap::Blue))
+                  true /*fades in from its base*/, ColourMap::Accent)
 {
 }
 
@@ -2549,7 +2611,7 @@ void SpectrumWorxEditor::DropIndicator::showInsert(std::uint8_t const gapIndex)
 /// through -- which is what says *which* strip is being pointed at.
 void SpectrumWorxEditor::DropIndicator::paint(juce::Graphics &graphics)
 {
-    auto const blue(ColourMap::getColour(ColourMap::Blue));
+    auto const blue(ColourMap::getColour(ColourMap::Accent));
 
     if (insert_)
     {
@@ -2617,7 +2679,7 @@ SpectrumWorxEditor::LFODisplay::LFODisplay()
       quarter_(*this, 62, 5, " N "), triplet_(*this, 62 + 18 * 1, 5, " T "),
       dotted_(*this, 62 + 18 * 2 - 2, 5, " D "),
       typeArrow_(*this, ArrowStyle::stepWidth, ArrowStyle::stepHeight, false,
-                 ColourMap::getColour(ColourMap::MouseOverGlow)),
+                 ColourMap::MouseOverGlow),
       pModuleControl_(nullptr)
 {
     for (auto const pComponent : componentsToDisableKeyboardGrabingFor)
@@ -3494,6 +3556,10 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
     {
         editor.setZoom(value);
     }
+    else if (&comboBox == &settings.interfacePage_.paletteComboBox())
+    {
+        editor.setPalette(static_cast<ColourMap::Palette>(value));
+    }
     else if (&comboBox == &settings.interfacePage_.mouseOverComboBox())
     {
         preferences().setModuleUIMouseOverReaction(
@@ -3624,9 +3690,10 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep, "Zoom"),
-      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 1 * yStep, "Mouse Over Reaction"),
-      lfoUpdateBehaviour_(*this, xMargin, yMargin + 2 * yStep, "LFO Update Behaviour"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep, "Hide cursor on knob drag")
+      palette_(*this, xMargin, yMargin + 1 * yStep, "Colour Scheme"),
+      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 2 * yStep, "Mouse Over Reaction"),
+      lfoUpdateBehaviour_(*this, xMargin, yMargin + 3 * yStep, "LFO Update Behaviour"),
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 4 * yStep, "Hide cursor on knob drag")
 {
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));
@@ -3641,6 +3708,19 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
         zoom_.addItem(percent, text.data());
     }
     zoom_.setSelectedID(preferences().zoomPercent());
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note Spelled here rather than taken from ColourMap::nameOf(), which
+    /// answers with the enumerator: what goes in the preferences file has to be
+    /// greppable in the source and what goes in this list has to be readable,
+    /// and "SSTDark" cannot be both. Same split as every other box on this page.
+    ////////////////////////////////////////////////////////////////////////////
+    palette_.addItem(ColourMap::Classic, "Classic");
+    palette_.addItem(ColourMap::SSTDark, "SST Dark");
+    palette_.addItem(ColourMap::Grays, "Grays");
+    palette_.addItem(ColourMap::Reds, "Reds");
+    palette_.addItem(ColourMap::Greens, "Greens");
+    palette_.setSelectedIndex(preferences().palette());
 
     moduleUIMouseOverReaction_.addItem(Preferences::Never, "Never");
     moduleUIMouseOverReaction_.addItem(Preferences::WhenParentModuleSelected, "Module selected");

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -443,6 +443,22 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// it.
     void pumpModulatedValues();
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Takes the palette again if it has moved, and repaints everything.
+    ///
+    /// \note Public for the same reason pumpModulatedValues() is: this is what
+    /// `timerCallback()` does, and a headless test has no message loop to turn,
+    /// so a test that changes the palette has to be the clock. \see the
+    /// definition.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void applyPaletteIfChanged();
+
+    /// \brief What the Interface page's colour scheme box does: remembers it
+    /// and hands it to the map. `[main-thread]`
+    void setPalette(ColourMap::Palette);
+
     /// \brief Lets go of a strip's controls before it is destroyed, so that
     /// JUCE's focus handling cannot re-enter through a control that is going.
     void detachFrom(ModuleUI &);
@@ -627,6 +643,13 @@ class SpectrumWorxEditor final : private SkinLifetime,
     /// paintBuildStamp() reads the engine, so a repaint from any other cause
     /// still shows the truth rather than this.
     EngineState engineState_;
+
+    /// \brief Which ColourMap::generation() this editor was last painted for.
+    ///
+    /// \note Seeded with the current one rather than with zero, so that an
+    /// editor opened into a session that has already changed palette does not
+    /// spend its first tick reloading colours it was just built with.
+    std::uint32_t palette_{ColourMap::generation()};
 
   private: // JUCE Component overrides.
     /// \note Only what is outside the skin: the panel column's chrome and the
@@ -1316,6 +1339,7 @@ class SpectrumWorxEditor final : private SkinLifetime,
           public:
             InterfacePage();
 
+            TitledComboBox const &paletteComboBox() const { return palette_; }
             TitledComboBox const &mouseOverComboBox() const { return moduleUIMouseOverReaction_; }
             TitledComboBox const &lfoUpdateComboBox() const { return lfoUpdateBehaviour_; }
 
@@ -1327,11 +1351,13 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
           private:
             friend class Settings;
-            /// \note Zoom first: it is the one a user reaches for, and the two
-            /// below it are set once and forgotten. Nothing is baked into the
-            /// page bitmap -- each control draws its own title -- so the order
-            /// is a layout decision rather than an artwork one.
+            /// \note Zoom first and the colour scheme under it: those are the
+            /// two a user reaches for, and the two below them are set once and
+            /// forgotten. Nothing is baked into the page bitmap -- each control
+            /// draws its own title -- so the order is a layout decision rather
+            /// than an artwork one.
             TitledComboBox zoom_;
+            TitledComboBox palette_;
             TitledComboBox moduleUIMouseOverReaction_;
             TitledComboBox lfoUpdateBehaviour_;
             LEDTextButton hideCursorOnKnobDrag_;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -68,6 +68,11 @@ SkinLifetime::SkinLifetime()
 #if defined(_WIN32)
         juce::Process::setCurrentModuleInstanceHandle(&__ImageBase);
 #endif // _WIN32
+        /// \note Before the Theme, which takes its colours from the map in its
+        /// constructor. \see Theme::reloadColours(), which is what a *later*
+        /// change goes through.
+        ColourMap::setPalette(preferences().palette());
+
         Theme::createSingleton();
         juce::LookAndFeel::setDefaultLookAndFeel(&Theme::singleton());
     }
@@ -773,7 +778,7 @@ void ComboBox::paint(juce::Graphics &graphics)
         graphics,
         juce::Rectangle<float>(0, 0, static_cast<float>(getWidth()),
                                static_cast<float>(boxHeight_)),
-        frame_, ColourMap::getColour(hasDirectFocus() ? ColourMap::FocusHalo : ColourMap::Blue),
+        frame_, ColourMap::getColour(hasDirectFocus() ? ColourMap::FocusHalo : ColourMap::Accent),
         ColourMap::getColour(ColourMap::ComboBackground), true /*halo*/);
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
@@ -890,7 +895,7 @@ void withPointerTint(juce::Button const &button, juce::Graphics &graphics,
 } // anonymous namespace
 
 ArrowButton::ArrowButton(juce::Component &parent, int const width, int const height,
-                         bool const fadeFromBase, juce::Colour const tintWhenOver)
+                         bool const fadeFromBase, ColourMap::Name const tintWhenOver)
     : fadeFromBase_(fadeFromBase), tintWhenOver_(tintWhenOver)
 {
     setWantsKeyboardFocus(false);
@@ -907,7 +912,7 @@ void ArrowButton::paintButton(juce::Graphics &graphics, bool const isMouseOverBu
 {
     auto const bounds(getLocalBounds().toFloat());
     ArrowPainter::paint(graphics, bounds, fadeFromBase_);
-    withPointerTint(*this, graphics, isMouseOverButton, tintWhenOver_,
+    withPointerTint(*this, graphics, isMouseOverButton, ColourMap::getColour(tintWhenOver_),
                     [&](juce::Colour const tint) { ArrowPainter::tint(graphics, bounds, tint); });
 }
 
@@ -983,7 +988,7 @@ void TextButton::paintButton(juce::Graphics &g, bool const isMouseOverButton, bo
     juce::Font font(Theme::singleton().labelFont());
     font.setHeight(static_cast<float>(height));
 
-    g.setColour(ColourMap::getColour(ColourMap::Blue).withAlpha(alpha));
+    g.setColour(ColourMap::getColour(ColourMap::Accent).withAlpha(alpha));
     g.setFont(font);
     g.drawSingleLineText(getName(), 0, height);
 }

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -890,14 +890,17 @@ class ArrowButton : public WidgetBase<juce::Button>
 {
   public:
     ArrowButton(juce::Component &parent, int width, int height, bool fadeFromBase,
-                juce::Colour tintWhenOver);
+                ColourMap::Name tintWhenOver);
 
   private: // juce::Component overrides
     void paintButton(juce::Graphics &, bool isMouseOverButton, bool isButtonDown) override;
 
   private:
     bool const fadeFromBase_;
-    juce::Colour const tintWhenOver_;
+    /// \note The name rather than the colour, so that the tint follows the
+    /// palette. A widget that holds a juce::Colour holds the palette that was
+    /// current when it was built. \see ColourMap::setPalette().
+    ColourMap::Name const tintWhenOver_;
 }; // class ArrowButton
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -636,7 +636,7 @@ void ModuleUI::moveToSlot(std::uint8_t const slotIndex)
 void ModuleUI::paint(juce::Graphics &graphics)
 {
     paintModuleStrip(graphics, getLocalBounds().toFloat(), selected());
-    graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
     graphics.drawHorizontalLine(nameRule, static_cast<float>(ModuleUI::border),
                                 Math::convert<float>(getWidth() - ModuleUI::border));
 

--- a/src/gui/painters/arrowPainter.cpp
+++ b/src/gui/painters/arrowPainter.cpp
@@ -34,7 +34,7 @@ void ArrowPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const 
                          bool const fadeFromBase)
 {
     auto const base(bounds.getX() + ArrowStyle::baseInset * bounds.getWidth());
-    auto const blue(ColourMap::getColour(ColourMap::Blue));
+    auto const blue(ColourMap::getColour(ColourMap::Accent));
 
     if (fadeFromBase)
         graphics.setGradientFill(juce::ColourGradient(blue.withAlpha(0.0f), base, bounds.getY(),

--- a/src/gui/painters/backgroundPainter.cpp
+++ b/src/gui/painters/backgroundPainter.cpp
@@ -58,7 +58,7 @@ void paintRule(juce::Graphics &graphics, juce::Rectangle<float> const shape, flo
 juce::ColourGradient fillOf(Ramp const &ramp)
 {
     auto const dark(ColourMap::getColour(ramp.darkening));
-    auto const lit(dark.interpolatedWith(ColourMap::getColour(ColourMap::Blue), ramp.lift));
+    auto const lit(dark.interpolatedWith(ColourMap::getColour(ColourMap::Accent), ramp.lift));
 
     juce::ColourGradient gradient(dark, ramp.fromX, ramp.fromY, lit, ramp.toX, ramp.toY, false);
     gradient.addColour(ramp.flatStop, dark);
@@ -232,7 +232,7 @@ void BackgroundPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> c
     paintPanel(graphics, centreColumn, centreColumnRamp);
 
     paintBox(graphics, moduleNameBox, ColourMap::EditorWell, ColourMap::EditorRule);
-    paintBox(graphics, activeControlBox, ColourMap::EditorPanel, ColourMap::Blue);
+    paintBox(graphics, activeControlBox, ColourMap::EditorPanel, ColourMap::Accent);
     paintBox(graphics, controlValueBox, ColourMap::EditorWell, ColourMap::EditorRule);
 
     {
@@ -260,7 +260,7 @@ void BackgroundPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> c
     {
         paintWell(graphics, knob.x, knob.y, knobDiameter);
         paintCentredLabel(graphics, knob.label, boldFont(knobLabelHeight),
-                          knob.x + knobDiameter / 2, knob.y - knobLabelRise, ColourMap::Blue);
+                          knob.x + knobDiameter / 2, knob.y - knobLabelRise, ColourMap::Accent);
     }
 
     paintLabel(graphics, lfoLabel, boldFont(lfoLabelHeight), lfoLabelX, lfoLabelY, ColourMap::Text);

--- a/src/gui/painters/backgroundPainter.hpp
+++ b/src/gui/painters/backgroundPainter.hpp
@@ -77,7 +77,7 @@ struct Ramp
     float toX, toY;
     float flatStop; ///< how far down it the dark is held
     float ease;
-    float lift;                ///< 0 stays dark, 1 arrives at ColourMap::Blue
+    float lift;                ///< 0 stays dark, 1 arrives at ColourMap::Accent
     ColourMap::Name darkening; ///< which dark it starts from
 };
 

--- a/src/gui/painters/buttonPainter.cpp
+++ b/src/gui/painters/buttonPainter.cpp
@@ -103,7 +103,7 @@ void ButtonPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const
         paintGlow(graphics, pill, radius);
 
     if ((shape == Tab) && selected)
-        graphics.setGradientFill(face(pill, ColourMap::getColour(ColourMap::Blue),
+        graphics.setGradientFill(face(pill, ColourMap::getColour(ColourMap::Accent),
                                       ColourMap::getColour(ColourMap::TabFaceBottom),
                                       selectedTabEase, selectedTabStops));
     else if (shape == Tab)
@@ -117,7 +117,7 @@ void ButtonPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const
 
     if ((shape == Rectangular) && selected)
     {
-        graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+        graphics.setColour(ColourMap::getColour(ColourMap::Accent));
         graphics.drawRoundedRectangle(pill, radius, rimThickness);
     }
 

--- a/src/gui/painters/buttonPainter.hpp
+++ b/src/gui/painters/buttonPainter.hpp
@@ -47,7 +47,7 @@ namespace LE::SW::GUI
 
 /// \brief Everything a button is drawn from that is not a colour.
 ///
-/// \see ColourMap for the colours -- Button*, Tab*, Blue and FocusHalo.
+/// \see ColourMap for the colours -- Button*, Tab*, Accent and FocusHalo.
 namespace ButtonStyle
 {
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gui/painters/capsulePainter.cpp
+++ b/src/gui/painters/capsulePainter.cpp
@@ -23,7 +23,7 @@ void CapsulePainter::paint(juce::Graphics &graphics, juce::Rectangle<float> cons
     auto const radius(style.height / 2);
 
     auto const white(ColourMap::getColour(ColourMap::FocusHalo));
-    auto const blue(ColourMap::getColour(ColourMap::Blue));
+    auto const blue(ColourMap::getColour(ColourMap::Accent));
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/src/gui/painters/ejectPainter.cpp
+++ b/src/gui/painters/ejectPainter.cpp
@@ -37,7 +37,7 @@ juce::Path tongue(juce::Rectangle<float> const bounds, float const inset)
 
 void EjectPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const bounds)
 {
-    graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
     graphics.fillPath(tongue(bounds, 0.0f));
 
     graphics.setColour(ColourMap::getColour(ColourMap::EjectFace));
@@ -52,7 +52,7 @@ void EjectPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const 
     cross.startNewSubPath(centre.translated(crossHalfWidth, -crossHalfHeight));
     cross.lineTo(centre.translated(-crossHalfWidth, crossHalfHeight));
 
-    graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
     graphics.strokePath(cross, juce::PathStrokeType(crossThickness, juce::PathStrokeType::mitered,
                                                     juce::PathStrokeType::rounded));
 }

--- a/src/gui/painters/moduleKnobPainter.cpp
+++ b/src/gui/painters/moduleKnobPainter.cpp
@@ -56,7 +56,7 @@ void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const boun
             bounds.withSizeKeepingCentre(2 * radius * wedgeRadius, 2 * radius * wedgeRadius),
             juce::degreesToRadians(std::min(from, to)), juce::degreesToRadians(std::max(from, to)),
             0.0f);
-        graphics.setColour(ColourMap::getColour(ColourMap::Blue));
+        graphics.setColour(ColourMap::getColour(ColourMap::Accent));
         graphics.fillPath(pie);
     }
 
@@ -87,7 +87,7 @@ void paintTriggerButton(juce::Graphics &graphics, juce::Rectangle<float> const b
                           ColourMap::getColour(ColourMap::ModuleKnobCap));
     if (on)
         KnobPainter::paintCap(graphics, bounds, litRadius, litEdgeRadius,
-                              ColourMap::getColour(ColourMap::Blue));
+                              ColourMap::getColour(ColourMap::Accent));
     KnobPainter::paintDomeRim(graphics, bounds, ModuleKnobStyle::rimThickness);
 }
 

--- a/src/gui/painters/moduleKnobPainter.hpp
+++ b/src/gui/painters/moduleKnobPainter.hpp
@@ -54,7 +54,7 @@ namespace LE::SW::GUI
 namespace ModuleKnobStyle
 {
 /// \note The five colours stood here and are ColourMap's now -- three of its
-/// ModuleKnob* entries, plus Blue for the wedge and FocusHalo for the ring. The
+/// ModuleKnob* entries, plus Accent for the wedge and FocusHalo for the ring. The
 /// wedge's was 0xFF13B7EA against Theme's 0xFF13B5EA, which is the sort of
 /// two-parts-in-255 drift a central palette exists to stop.
 ///                                       (18.08.2026.)

--- a/src/gui/painters/moduleStripPainter.cpp
+++ b/src/gui/painters/moduleStripPainter.cpp
@@ -25,7 +25,7 @@ namespace LE::SW::GUI
 void paintModuleStrip(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
                       bool const selected)
 {
-    FramePainter::paint(graphics, bounds, moduleStripFrame, ColourMap::getColour(ColourMap::Blue),
+    FramePainter::paint(graphics, bounds, moduleStripFrame, ColourMap::getColour(ColourMap::Accent),
                         ColourMap::getColour(ColourMap::ModuleBackground), selected);
 }
 

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -46,6 +46,7 @@ enum PreferenceKey
     lfoUpdateBehaviourKey,
     hideCursorOnKnobDragKey,
     zoomPercentKey,
+    paletteKey,
     numberOfPreferenceKeys
 };
 
@@ -64,6 +65,8 @@ std::string preferenceKeyName(PreferenceKey const key)
         return "hideCursorOnKnobDrag";
     case zoomPercentKey:
         return "zoomPercent";
+    case paletteKey:
+        return "palette";
     case numberOfPreferenceKeys:
         break;
     }
@@ -115,6 +118,20 @@ Enumeration valueNamed(std::string const &name, std::array<char const *, count> 
     return valueIfUnrecognised;
 }
 
+/// \note The same, over ColourMap::nameOf() rather than over a table here: the
+/// palettes are the map's own enumeration and their spellings belong with it.
+ColourMap::Palette paletteNamed(std::string const &name,
+                                ColourMap::Palette const valueIfUnrecognised)
+{
+    for (unsigned int index(0); index < ColourMap::numberOfPalettes; ++index)
+    {
+        auto const palette(static_cast<ColourMap::Palette>(index));
+        if (name == ColourMap::nameOf(palette))
+            return palette;
+    }
+    return valueIfUnrecognised;
+}
+
 /// \note An optional rather than a function-local static, because
 /// setPreferencesFolder() has to be able to replace it. `[main-thread]`, which is
 /// what makes that safe: everything that reads these runs under the host's
@@ -161,6 +178,9 @@ Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Sto
                        lfoUpdateBehaviourKey, nameOf(lfoUpdateBehaviour_, lfoUpdateBehaviourNames)),
                    lfoUpdateBehaviourNames, lfoUpdateBehaviour_);
 
+    palette_ = paletteNamed(provider.getUserDefaultValue(paletteKey, ColourMap::nameOf(palette_)),
+                            palette_);
+
     hideCursorOnKnobDrag_ =
         provider.getUserDefaultValue(hideCursorOnKnobDragKey, hideCursorOnKnobDrag_) != 0;
 
@@ -194,6 +214,12 @@ void Preferences::setLFOUpdateBehaviour(LFOUpdateBehaviour const value)
     lfoUpdateBehaviour_ = value;
     storage_->provider.updateUserDefaultValue(lfoUpdateBehaviourKey,
                                               nameOf(value, lfoUpdateBehaviourNames));
+}
+
+void Preferences::setPalette(ColourMap::Palette const value)
+{
+    palette_ = value;
+    storage_->provider.updateUserDefaultValue(paletteKey, ColourMap::nameOf(value));
 }
 
 void Preferences::setHideCursorOnKnobDrag(bool const value)

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -3,8 +3,8 @@
 /// \file preferences.hpp
 /// ---------------------
 ///
-///   The three answers the settings panel's Interface page asks for, and the
-/// file they survive in.
+///   The answers the settings panel's Interface page asks for, and the file
+/// they survive in.
 ///
 /// \note These were `Theme::Settings`, three members of a process-wide static
 /// that nothing ever read off disk or wrote back to it: every session started at
@@ -28,6 +28,9 @@
 #ifndef preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
 #define preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
 //------------------------------------------------------------------------------
+/// `ColourMap::Palette`, which is one of the answers.
+#include "colourMap.hpp"
+
 /// `fs`, for the folder the file lives in.
 #include "filesystem/import.h"
 
@@ -116,6 +119,7 @@ class Preferences
         return moduleUIMouseOverReaction_;
     }
     LFOUpdateBehaviour lfoUpdateBehaviour() const { return lfoUpdateBehaviour_; }
+    ColourMap::Palette palette() const { return palette_; }
     bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
     /// Always one of zoomPercentages.
     unsigned int zoomPercent() const { return zoomPercent_; }
@@ -123,6 +127,10 @@ class Preferences
     /// Each of these writes the file. `[main-thread]`
     void setModuleUIMouseOverReaction(ModuleUIMouseOverReaction);
     void setLFOUpdateBehaviour(LFOUpdateBehaviour);
+    /// \note Stores it. Painting in it is ColourMap::setPalette()'s half, and
+    /// the two are done together -- \see SpectrumWorxEditor::setPalette(),
+    /// which is the only place a user changes this.
+    void setPalette(ColourMap::Palette);
     void setHideCursorOnKnobDrag(bool);
     /// \note A percentage this build does not offer is ignored, for the same
     /// reason an unrecognised enumeration name is: the file is the user's to
@@ -141,6 +149,7 @@ class Preferences
 
     ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
     LFOUpdateBehaviour lfoUpdateBehaviour_{Always};
+    ColourMap::Palette palette_{ColourMap::Classic};
     bool hideCursorOnKnobDrag_{true};
     unsigned int zoomPercent_{defaultZoomPercent};
 }; // class Preferences

--- a/src/gui/preset_browser/presetBrowser.cpp
+++ b/src/gui/preset_browser/presetBrowser.cpp
@@ -52,7 +52,7 @@ PresetBrowser::PresetBrowser()
       save_(*this, "Save", 54, 22, false), saveAs_(*this, "Save as", 54, 22, false),
       delete_(*this, "Delete", 54, 22, false),
       browseArrow_(*this, ArrowStyle::stepWidth, ArrowStyle::stepHeight, false,
-                   ColourMap::getColour(ColourMap::MouseOverGlow)),
+                   ColourMap::MouseOverGlow),
       ignoreExternalSamples_(*this, 15, 58, "Ignore external audio"), ignoreSelectionChange_(false),
       addOneRow_(false), newPresetPending_(false), dirtyCommentPresetIndex_(-1)
 {
@@ -95,10 +95,6 @@ PresetBrowser::PresetBrowser()
     addChildComponent(&presetNameEditBox_);
     presetNameEditBox_.setAlwaysOnTop(true);
     presetNameEditBox_.setFont(Theme::singleton().labelFont());
-    presetNameEditBox_.setColour(juce::TextEditor::backgroundColourId,
-                                 ColourMap::getColour(ColourMap::Ground));
-    presetNameEditBox_.setColour(juce::TextEditor::focusedOutlineColourId,
-                                 ColourMap::getColour(ColourMap::Blue));
     presetNameEditBox_.addListener(this);
 
     listBox_.setOpaque(false);
@@ -112,12 +108,9 @@ PresetBrowser::PresetBrowser()
     comment().setMultiLine(true);
     comment().setReturnKeyStartsNewLine(true);
     comment().setPopupMenuEnabled(true);
-    comment().setColour(juce::TextEditor::backgroundColourId,
-                        ColourMap::getColour(ColourMap::Transparent));
-    comment().setColour(juce::TextEditor::textColourId, ColourMap::getColour(ColourMap::Blue));
-    comment().setColour(juce::TextEditor::highlightColourId,
-                        ColourMap::getColour(ColourMap::TextDimmed));
     comment().addListener(this);
+
+    takeColours();
     {
         juce::Font font(Theme::singleton().Theme::getPopupMenuFont());
         font.setHeight(11);
@@ -1117,6 +1110,20 @@ juce::String PresetBrowser::locationLabel() const
         return LE::IO::pathToJuceString(currentDirectory_);
     }
     LE_UNREACHABLE_CODE();
+}
+
+void PresetBrowser::takeColours()
+{
+    presetNameEditBox_.setColour(juce::TextEditor::backgroundColourId,
+                                 ColourMap::getColour(ColourMap::Ground));
+    presetNameEditBox_.setColour(juce::TextEditor::focusedOutlineColourId,
+                                 ColourMap::getColour(ColourMap::Accent));
+
+    comment().setColour(juce::TextEditor::backgroundColourId,
+                        ColourMap::getColour(ColourMap::Transparent));
+    comment().setColour(juce::TextEditor::textColourId, ColourMap::getColour(ColourMap::Accent));
+    comment().setColour(juce::TextEditor::highlightColourId,
+                        ColourMap::getColour(ColourMap::TextDimmed));
 }
 
 void PresetBrowser::paint(juce::Graphics &graphics)

--- a/src/gui/preset_browser/presetBrowser.hpp
+++ b/src/gui/preset_browser/presetBrowser.hpp
@@ -47,6 +47,24 @@ class PresetBrowser final : public PanelBackground,
   private: // JUCE Component overrides.
     void paint(juce::Graphics &) override;
 
+    /// \note Reached from SpectrumWorxEditor::applyPaletteIfChanged(), by way
+    /// of juce::Component::sendLookAndFeelChange(). \see takeColours().
+    void lookAndFeelChanged() override { takeColours(); }
+
+  private:
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Tells the two text editors what to paint themselves in.
+    ///
+    /// \note Not a one-off in the constructor, because these are the one thing
+    /// in the browser that *holds* colours rather than asking for them each
+    /// paint: juce::TextEditor::setColour() overrides the LookAndFeel's answer
+    /// for good, so a palette change leaves them in the palette they were built
+    /// under until they are told again.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void takeColours();
+
   private: // JUCE ButtonListener overrides.
     void buttonClicked(juce::Button *) override;
 

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -58,10 +58,28 @@ void paintSliderThumb(juce::Graphics &graphics, float const position,
 ///                                       (16.08.2026.)
 Theme::Theme()
     : headingFont_(juce::FontOptions(regularTypeface()).withHeight(14.0f)),
-      labelFont_(juce::FontOptions(regularTypeface()).withHeight(12.0f))
+      labelFont_(juce::FontOptions(regularTypeface()).withHeight(12.0f)),
+      palette_(ColourMap::generation())
 {
     setDefaultSansSerifTypeface(regularTypeface());
+    takeColours();
+}
 
+void Theme::reloadColours()
+{
+    if (palette_ == ColourMap::generation())
+        return;
+
+    palette_ = ColourMap::generation();
+    takeColours();
+
+    /// \note And the folder icon, which is not a colour but has two of them
+    /// baked into it. Rebuilt on the next ask. \see getDefaultFolderImage().
+    folderIcon_.reset();
+}
+
+void Theme::takeColours()
+{
     /// \note Every colour here comes out of ColourMap, and the ones that are
     /// not there are transparent -- an absence rather than a choice. \see
     /// colourMap.hpp.
@@ -75,7 +93,7 @@ Theme::Theme()
               colour(ColourMap::MenuBackground).withAlpha(0.8f));
 
     setColour(juce::TextButton::buttonColourId, colour(ColourMap::Ground));
-    setColour(juce::TextButton::buttonOnColourId, colour(ColourMap::Blue));
+    setColour(juce::TextButton::buttonOnColourId, colour(ColourMap::Accent));
     setColour(juce::TextButton::textColourOnId, colour(ColourMap::Text));
     setColour(juce::TextButton::textColourOffId, colour(ColourMap::Text));
 
@@ -93,10 +111,10 @@ Theme::Theme()
     setColour(juce::TextEditor::backgroundColourId, colour(ColourMap::FieldBackground));
     setColour(juce::TextEditor::focusedOutlineColourId, colour(ColourMap::Transparent));
     setColour(juce::TextEditor::outlineColourId, colour(ColourMap::Transparent));
-    setColour(juce::TextEditor::highlightColourId, colour(ColourMap::Blue));
+    setColour(juce::TextEditor::highlightColourId, colour(ColourMap::Accent));
     setColour(juce::TextEditor::highlightedTextColourId, colour(ColourMap::Text));
     setColour(juce::TextEditor::textColourId, colour(ColourMap::Text));
-    setColour(juce::CaretComponent::caretColourId, colour(ColourMap::Blue));
+    setColour(juce::CaretComponent::caretColourId, colour(ColourMap::Accent));
 
     setColour(juce::ListBox::backgroundColourId, colour(ColourMap::ListBackground));
     setColour(juce::ListBox::outlineColourId, colour(ColourMap::ListOutline));

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -92,6 +92,24 @@ class Theme final : public juce::LookAndFeel_V2
     ~Theme() override;
 
   public:
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Takes the colours again, if the palette has moved since they were
+    /// last taken. `[main-thread]`
+    ///
+    ///   Every other colour in the editor is asked for while painting, so a
+    /// repaint is the whole of what a palette change needs. These are not:
+    /// the constructor copies four dozen of them into JUCE colour IDs and the
+    /// folder icon has two baked into a Drawable, so they go stale in place.
+    ///
+    /// \note Guarded by the generation rather than by a flag the caller sets,
+    /// because every open editor calls this on the tick it notices -- the first
+    /// does the work and the rest cost a comparison.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void reloadColours();
+
+  public:
     /// \brief The two sizes the skin writes in.
     ///
     /// \note These were blueFont() and whiteFont() until the palette moved to
@@ -102,6 +120,11 @@ class Theme final : public juce::LookAndFeel_V2
     ///                                       (18.08.2026.)
     juce::Font const &headingFont() const { return headingFont_; }
     juce::Font const &labelFont() const { return labelFont_; }
+
+  private:
+    /// \brief Everything the constructor and reloadColours() have in common,
+    /// which is all of it.
+    void takeColours();
 
   public: // juce::LookAndFeel_V2 overrides
     void drawLinearSliderBackground(juce::Graphics &, int x, int y, int width, int height,
@@ -168,6 +191,9 @@ class Theme final : public juce::LookAndFeel_V2
     juce::Font const labelFont_;
 
     std::unique_ptr<juce::Drawable> folderIcon_;
+
+    /// Which ColourMap::generation() the two above were taken from.
+    std::uint32_t palette_;
 }; // class Theme
 
 } // namespace LE::SW::GUI

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(sw-plugin-tests
         gui/moduleControlFocusTests.cpp
         gui/moduleDragTests.cpp
         gui/overlayPanelTests.cpp
+        gui/paletteTests.cpp
         gui/pathsTests.cpp
         gui/preferencesTests.cpp
         gui/sideChainSelectorTests.cpp

--- a/tests/gui/paletteTests.cpp
+++ b/tests/gui/paletteTests.cpp
@@ -1,0 +1,330 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// paletteTests.cpp
+/// ----------------
+///
+///   The five colour schemes: that the user's choice survives in the preferences
+/// file, that an editor opens in it, and that changing it reaches an editor that
+/// is already open.
+///
+/// \note Nothing here asserts what any palette *looks like*. A case that pinned
+/// a colour would be a case that has to be edited every time one is retuned, and
+/// a palette is a thing to look at rather than a thing to assert. What is pinned
+/// is the mechanism -- that Grays drains, that every scheme moves the accent,
+/// that a change reaches the screen -- and the skin's own blue is asked for at
+/// run time rather than spelled, so retuning Classic moves the tests with it.
+///
+/// \note The last of those is the point of the file, and it is measured in
+/// pixels. "Does getColour() answer differently" is a question the broken build
+/// answered correctly: a widget that took a juce::Colour into a member when it
+/// was constructed goes on painting the palette it was born in, and there were
+/// three of them -- a static array of text descriptors initialised before any
+/// palette had been chosen at all, an arrow button's mouse-over tint, and the
+/// two text editors in the preset browser. Nothing about the map itself was
+/// wrong in any of those cases. What was wrong was what was on the screen.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+#include "gui/colourMap.hpp"
+#include "gui/preferences.hpp"
+#include "gui/theme.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using ColourMap = GUI::ColourMap;
+using Editor = GUI::SpectrumWorxEditor;
+
+/// Every enumerator of a scoped-by-convention enum, as a range would give it.
+template <typename Body> void forEachColour(Body const &body)
+{
+    for (unsigned int index(0); index < ColourMap::numberOfColours; ++index)
+        body(static_cast<ColourMap::Name>(index));
+}
+
+template <typename Body> void forEachPalette(Body const &body)
+{
+    for (unsigned int index(0); index < ColourMap::numberOfPalettes; ++index)
+        body(static_cast<ColourMap::Palette>(index));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Puts the palette back when a case is done with it.
+///
+/// \note ctest runs a process per case, so this is belt and braces -- but the
+/// palette is a process-wide static and a case that left it turned would be a
+/// case that broke every other case in its file, silently and by colour.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class PaletteRestored
+{
+  public:
+    ~PaletteRestored() { ColourMap::setPalette(was_); }
+
+  private:
+    ColourMap::Palette const was_{ColourMap::palette()};
+}; // class PaletteRestored
+
+/// The skin's own accent, which is what every other palette has to have moved.
+juce::Colour skinBlue()
+{
+    PaletteRestored const restored;
+    ColourMap::setPalette(ColourMap::Classic);
+    return ColourMap::getColour(ColourMap::Accent);
+}
+
+/// \brief The editor as an image, which is what a user sees. \see
+/// gui/overlayPanelTests.cpp, where the same helper measures a different thing.
+juce::Image rendered(Editor &editor)
+{
+    juce::Image image(juce::Image::ARGB, editor.getWidth(), editor.getHeight(), true);
+    juce::Graphics graphics(image);
+    editor.paintEntireComponent(graphics, true);
+    return image;
+}
+
+std::size_t pixelsOfExactly(juce::Image const &image, juce::Colour const wanted)
+{
+    std::size_t found(0);
+    juce::Image::BitmapData const pixels(image, juce::Image::BitmapData::readOnly);
+    for (int y(0); y < image.getHeight(); ++y)
+        for (int x(0); x < image.getWidth(); ++x)
+            found += (pixels.getPixelColour(x, y).getARGB() == wanted.getARGB());
+    return found;
+}
+
+/// \brief The preset browser's comment box, wherever the editor has parented it.
+///
+/// \note Found by walking the tree for the multi-line editor rather than asked
+/// for: PresetBrowser::comment() is private and widening it for one case would
+/// be the test changing the code to suit itself. The browser holds two text
+/// editors and only the comment box is multi-line.
+juce::TextEditor *commentBoxIn(juce::Component &component)
+{
+    for (auto *const child : component.getChildren())
+    {
+        if (auto *const editor = dynamic_cast<juce::TextEditor *>(child))
+            if (editor->isMultiLine())
+                return editor;
+        if (auto *const found = commentBoxIn(*child))
+            return found;
+    }
+    return nullptr;
+}
+
+fs::path caseFolder(char const *const name)
+{
+    auto const folder(fs::path(SW_TEST_OUTPUT_DIR) / "palettes" / name);
+    fs::remove_all(folder);
+    return folder;
+}
+
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+// The map
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Grays answers in greys")
+{
+    PaletteRestored const restored;
+    ColourMap::setPalette(ColourMap::Grays);
+
+    forEachColour([](ColourMap::Name const name) {
+        auto const colour(ColourMap::getColour(name));
+        UNSCOPED_INFO("colour " << static_cast<unsigned int>(name) << " is "
+                                << colour.toDisplayString(true).toStdString());
+        CHECK(colour.getRed() == colour.getGreen());
+        CHECK(colour.getGreen() == colour.getBlue());
+    });
+}
+
+TEST_CASE("Every palette moves the accent")
+{
+    PaletteRestored const restored;
+    auto const blue(skinBlue());
+
+    forEachPalette([&](ColourMap::Palette const palette) {
+        if (palette == ColourMap::Classic)
+            return;
+
+        ColourMap::setPalette(palette);
+        UNSCOPED_INFO("palette: " << ColourMap::nameOf(palette));
+        CHECK(ColourMap::getColour(ColourMap::Accent) != blue);
+    });
+}
+
+TEST_CASE("Changing the palette moves the generation")
+{
+    PaletteRestored const restored;
+    ColourMap::setPalette(ColourMap::Classic);
+
+    auto const before(ColourMap::generation());
+
+    ColourMap::setPalette(ColourMap::Classic);
+    CHECK(ColourMap::generation() == before); // nothing changed, nothing to tell
+
+    ColourMap::setPalette(ColourMap::Reds);
+    CHECK(ColourMap::generation() != before);
+    CHECK(ColourMap::palette() == ColourMap::Reds);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The preference
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The palette survives the preferences file")
+{
+    auto const folder(caseFolder("round-trip"));
+
+    forEachPalette([&](ColourMap::Palette const palette) {
+        {
+            GUI::Preferences written(folder);
+            written.setPalette(palette);
+        }
+        GUI::Preferences const read(folder);
+        UNSCOPED_INFO("palette: " << ColourMap::nameOf(palette));
+        CHECK(read.palette() == palette);
+    });
+}
+
+TEST_CASE("A palette this build does not have reads as Classic")
+{
+    auto const folder(caseFolder("unknown"));
+    fs::create_directories(folder);
+
+    ///   The file is the user's to edit and this one names a scheme from
+    /// somewhere else. \see the note on streaming by name in preferences.hpp:
+    /// an unrecognised name reads as the default, which is what keeps a file
+    /// from a future build from painting a black editor.
+    {
+        std::ofstream stream(folder / "SpectrumWorxUserDefaults.xml");
+        stream << "<?xml version = \"1.0\" encoding = \"UTF-8\" ?>\n"
+                  "<defaults version=\"1\">\n"
+                  "  <default key=\"palette\" value=\"Mauve\" type=\"1\"/>\n"
+                  "</defaults>\n";
+    }
+
+    GUI::Preferences const read(folder);
+    CHECK(read.palette() == ColourMap::Classic);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The screen
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("An editor opens in the palette the user chose")
+{
+    PaletteRestored const restored;
+    GUI::setPreferencesFolder(caseFolder("opens-in"));
+    GUI::preferences().setPalette(ColourMap::Reds);
+
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    //   Not one pixel of the skin's blue, which is a stronger claim than "the
+    // map answers in red": a colour taken into a member at construction -- or,
+    // as this once was, at static-initialisation time before any palette
+    // existed -- would still be on the screen.
+    CHECK(pixelsOfExactly(rendered(instance.editor()), skinBlue()) == 0);
+}
+
+TEST_CASE("Changing the palette reaches an editor that is already open")
+{
+    PaletteRestored const restored;
+    GUI::setPreferencesFolder(caseFolder("already-open"));
+
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto const blue(skinBlue());
+    REQUIRE(pixelsOfExactly(rendered(instance.editor()), blue) > 0); // it is a blue skin
+
+    auto const wasInTheTheme(
+        GUI::Theme::singleton().findColour(juce::CaretComponent::caretColourId));
+
+    instance.editor().setPalette(ColourMap::Greens);
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note By hand, because this is what the editor's 30 Hz timer calls and
+    /// there is no message loop in a test binary to turn it. \see
+    /// SpectrumWorxEditor::applyPaletteIfChanged(), which says so.
+    ////////////////////////////////////////////////////////////////////////////
+    instance.editor().applyPaletteIfChanged();
+
+    CHECK(pixelsOfExactly(rendered(instance.editor()), blue) == 0);
+
+    /// \note And the LookAndFeel, which is the half a repaint cannot do: these
+    /// are copied out of the map once and go stale in place.
+    CHECK(GUI::Theme::singleton().findColour(juce::CaretComponent::caretColourId) != wasInTheTheme);
+
+    CHECK(GUI::preferences().palette() == ColourMap::Greens);
+}
+
+TEST_CASE("An editor left alone does not reload its colours")
+{
+    PaletteRestored const restored;
+    GUI::setPreferencesFolder(caseFolder("left-alone"));
+
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto const before(rendered(instance.editor()));
+
+    instance.editor().applyPaletteIfChanged();
+
+    auto const after(rendered(instance.editor()));
+    CHECK(pixelsOfExactly(after, skinBlue()) == pixelsOfExactly(before, skinBlue()));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The one thing a repaint cannot fix. juce::TextEditor::setColour()
+/// overrides the LookAndFeel for good, so the browser's two editors have to be
+/// *told*, and telling them is what SpectrumWorxEditor::applyPaletteIfChanged()
+/// asks for by calling sendLookAndFeelChange() rather than repaint(). A plain
+/// repaint passes every other case in this file and leaves these two behind.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A palette change reaches the widgets that hold their own colours")
+{
+    PaletteRestored const restored;
+    GUI::setPreferencesFolder(caseFolder("holds-colours"));
+
+    SWTest::Instance instance;
+    instance.openEditor();
+    instance.editor().showPresetBrowser(true);
+
+    auto *const pComment(commentBoxIn(instance.editor()));
+    REQUIRE(pComment != nullptr);
+
+    auto const before(pComment->findColour(juce::TextEditor::textColourId));
+    REQUIRE(before == skinBlue()); // the comment box writes in the accent
+
+    instance.editor().setPalette(ColourMap::Reds);
+    instance.editor().applyPaletteIfChanged();
+
+    CHECK(pComment->findColour(juce::TextEditor::textColourId) != before);
+    CHECK(pComment->findColour(juce::TextEditor::textColourId) ==
+          ColourMap::getColour(ColourMap::Accent));
+}

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -134,11 +134,16 @@ template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Compone
 /// engine page's three combo boxes -- which are TitledComboBoxes too -- are not
 /// in the tree while the Interface tab is up. The count is required rather than
 /// assumed, so that a layout change fails here instead of silently sending the
-/// rest of the case at the wrong widget.
+/// rest of the case at the wrong widget. Which is what it did: the colour scheme
+/// box arrived as a fourth and this said so.
+///                                       (18.08.2026.)
 GUI::TitledComboBox &comboBoxOffering(Editor &editor, std::size_t const choices)
 {
+    /// Zoom, colour scheme, mouse-over reaction and LFO update behaviour.
+    std::size_t constexpr onTheInterfacePage{4};
+
     auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
-    REQUIRE(comboBoxes.size() == 3);
+    REQUIRE(comboBoxes.size() == onTheInterfacePage);
 
     for (auto *const pComboBox : comboBoxes)
         if (pComboBox->numberOfItems() == choices)

--- a/tools/show-ui/main.cpp
+++ b/tools/show-ui/main.cpp
@@ -33,6 +33,7 @@
 //------------------------------------------------------------------------------
 #include "page.hpp"
 
+#include "gui/colourMap.hpp"
 #include "gui/preferences.hpp"
 #include "gui/theme.hpp"
 #include "io/jucePath.hpp"
@@ -328,6 +329,12 @@ int renderPage(juce::String const &pageName, juce::File const &output)
 /// GUI::Preferences::zoomPercentages.
 ///                                           (16.08.2026.) (SW port)
 ///
+/// \note `SW_SHOW_UI_PALETTE` likewise, by ColourMap::nameOf() -- so
+/// `SW_SHOW_UI_PALETTE=Reds` renders any page in that palette. Both the
+/// preference and the map are set: the map because a page that builds no editor
+/// has no SkinLifetime to read the preference, and the preference so that the
+/// settings page shows the palette it is being drawn in.
+///
 ////////////////////////////////////////////////////////////////////////////////
 
 void usePreferencesOfNobodyInParticular(juce::File const &output)
@@ -345,6 +352,26 @@ void usePreferencesOfNobodyInParticular(juce::File const &output)
         else
             std::fprintf(stderr, "sw-show-ui: SW_SHOW_UI_ZOOM=%s is not an offered zoom.\n",
                          requested);
+    }
+
+    if (auto const *const requested = std::getenv("SW_SHOW_UI_PALETTE"))
+    {
+        using ColourMap = LE::SW::GUI::ColourMap;
+        for (unsigned int index(0); index < ColourMap::numberOfPalettes; ++index)
+        {
+            auto const palette(static_cast<ColourMap::Palette>(index));
+            if (std::strcmp(requested, ColourMap::nameOf(palette)) != 0)
+                continue;
+
+            LE::SW::GUI::preferences().setPalette(palette);
+            ColourMap::setPalette(palette);
+            return;
+        }
+        std::fprintf(stderr,
+                     "sw-show-ui: SW_SHOW_UI_PALETTE=%s is not a palette. There are:", requested);
+        for (unsigned int index(0); index < ColourMap::numberOfPalettes; ++index)
+            std::fprintf(stderr, " %s", ColourMap::nameOf(static_cast<ColourMap::Palette>(index)));
+        std::fputs("\n", stderr);
     }
 }
 

--- a/tools/show-ui/pages/themePage.cpp
+++ b/tools/show-ui/pages/themePage.cpp
@@ -80,9 +80,9 @@ class ThemePage final : public juce::Component
         graphics.drawText("Theme -- LookAndFeel_V2", 20, 16, 400, 22,
                           juce::Justification::centredLeft);
 
-        graphics.setColour(GUI::ColourMap::getColour(GUI::ColourMap::Blue));
+        graphics.setColour(GUI::ColourMap::getColour(GUI::ColourMap::Accent));
         graphics.setFont(theme.headingFont());
-        graphics.drawText("headingFont, ColourMap::Blue", 20, 46, 400, 20,
+        graphics.drawText("headingFont, ColourMap::Accent", 20, 46, 400, 20,
                           juce::Justification::centredLeft);
 
         graphics.setColour(GUI::ColourMap::getColour(GUI::ColourMap::Text));


### PR DESCRIPTION
Five of them, on the settings panel's GUI tab and kept in the preferences file beside the zoom: Classic, SST Dark, Grays, Reds and Greens.

Only Classic is written out. Its greys are traced from artwork whose every tint leans on the accent, and a colour the artwork left neutral has no hue to turn -- so Reds and Greens are that hue moved, and the bevels, rules, ink and shadows stay exactly where they were without a list of exceptions to keep. Each carries a brightness correction scaled by how coloured the colour is, because a green at the blue's brightness reads far lighter and a red far darker. Grays is the same trick with the colour taken out. SST Dark is the one that is not a recolour -- it inverts the chassis, so it names the grounds and the ink it takes from Shortcircuit XT's wireframe-dark and turns the rest to amber.

The accent is called Accent rather than Blue, which is what it always was.

A palette change reaches every open editor. The map carries a generation counter and each editor compares it on the tick it is already doing, so an instance whose colours were changed by a settings page in a *different* instance repaints itself -- no registry of live editors to keep correct. Taking the LookAndFeel's colours again is the half a repaint cannot do, and sendLookAndFeelChange() is what tells a widget holding one of its own.

Three of those were holding one. The array of text descriptors behind the module name and the control value took its colours at static-initialisation time, before any palette had been chosen at all; an arrow button and the preset browser's two text editors took theirs when they were constructed. They ask now, and a case renders the editor to say they do.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>