### PR TITLE
Let an enumerated parameter choose the order its menu reads down

### DIFF
--- a/doc/tech/effect_contract.md
+++ b/doc/tech/effect_contract.md
@@ -268,6 +268,20 @@ show, used by that box and by nothing else. Reach for it when a value string doe
 not fit — `Vaxateer::Mode` is the shipped example. `parameter_system.md`, "A value
 may be read differently from how it is listed", has the rule.
 
+`EFFECT_ENUMERATED_PARAMETER_MENU_ORDER` is the fifth and is also optional: the
+same values a third time, bare and in the order the menu should offer them.
+
+```cpp
+EFFECT_ENUMERATED_PARAMETER_MENU_ORDER( CommonParameters, Mode,
+    Magnitudes, Phases, Both )
+```
+
+Declaration order is ABI — a value is its own index, and presets and automation
+lanes are written in it — so this is the only way to move a row. Each row carries
+its own value, so nothing but the menu changes. The list must be a permutation of
+the parameter's values and a compile error says so if it is not.
+`parameter_system.md`, "An enumerated parameter's rows are not its values".
+
 ### How many parameters you get
 
 Five. `maxNumberOfParametersPerModule` is 10 (`src/configuration/constants.hpp:22`)

--- a/doc/tech/parameter_system.md
+++ b/doc/tech/parameter_system.md
@@ -410,21 +410,46 @@ actually shipped:
 
 ### An enumerated parameter's rows are not its values
 
-`DiscreteValues<Parameter>::strings` maps a value to its name, and the plugin's
-own combo box is filled from it in declaration order — with one exception, and
-the exception is the rule worth knowing. Tune Worx's `Key` is declared `A` first,
-because the value **is** the index: it is what a `.swp` stores, what a host
-automates, and what the DSP adds to a note offset counted up from a 27.5 Hz A
-(`musicalScales.cpp`). Reordering the enumerators would have silently retuned
-every preset that names a key. A chromatic scale nevertheless reads from C, so
-`fillComboBoxForParameter< Key >` (`gui/modules/moduleWidgets.cpp`) lists the same
-twelve values from C, each row carrying its own — the rows move, the values do
-not (issue #89, 17.08.2026; pinned by `tests/gui/discreteParameterTests.cpp`).
+`DiscreteValues<Parameter>::strings` maps a value to its name, and a value **is**
+its own index: it is what a `.swp` stores, what a host automates and what the DSP
+switches on. So the declaration order is ABI and cannot move. The order a menu
+reads down is a different question, and `MenuOrder<Parameter>` (`uiElements.hpp`)
+is where the different answer goes:
 
-An explicit specialisation of `fillComboBoxForParameter<>` is how that is said,
-and it has to be **declared before the point of instantiation**. There is one
-such point — `WidgetInitialiser` in `moduleWidgets.cpp`, which is also where
-`ModuleKnob::QuantizationFor< PitchMagnet::Target >` lives for the same reason.
+```cpp
+EFFECT_ENUMERATED_PARAMETER_MENU_ORDER( CommonParameters, Mode,
+    Magnitudes, Phases, Both )
+```
+
+Values, not pairs — this list says nothing about what a value is called, only
+about where it sits. `MenuOrder` is empty by default and `menuOrder<Parameter>()`
+then hands back `0, 1, 2 …`, exactly as `ShortValues` / `shortValueStrings()` do
+below, so a parameter that has not been given an order is listed as declared.
+Every row carries its value as its combo box item **ID**, so nothing under the UI
+notices: the rows move, the values do not.
+
+What is checked, at compile time and by name, is that the list is a permutation
+rather than a rewrite. A repeated value costs the one it displaced — a value no
+row offers and nothing else in the build would miss — so `Detail::menuOrderValues`
+throws out of a `consteval`, in the shape `valueStrings()` uses for the same
+reason.
+
+The two that have one as of 19.08.2026:
+
+| Parameter | Declared | Listed | Why |
+|---|---|---|---|
+| `CommonParameters::Mode` | Both, Magnitudes, Phases | Magnitudes, Phases, Both | the two things a target is, then the one that is both; `Both` is zero because it is the default and because that is what every file since 2011 calls zero. Shared by Ethereal, Inserter and Swappah — one declaration, three menus |
+| `TuneWorx::Key` | A … G♯ | C … B | the value is a semitone count up from a 27.5 Hz A (`musicalScales.cpp`), so A stays zero; a musician reads a chromatic scale from C (issue #89) |
+
+`Key` was an explicit specialisation of `fillComboBoxForParameter<>` in
+`moduleWidgets.cpp` until 19.08.2026, which worked but had to be **declared
+before the point of instantiation** and so could only live in the one translation
+unit that builds module widgets. A `MenuOrder` specialisation goes in the header
+beside the parameter like every other one of these. `fillComboBoxForParameter<>`
+is still the customisation point for a combo box that is not a list of values at
+all — `Engine::OverlapFactor` in `spectrumWorxEditor.cpp` is the remaining one.
+
+Both are pinned by `tests/gui/discreteParameterTests.cpp`.
 
 ### A value may be read differently from how it is listed
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1601,18 +1601,14 @@ void addPowerOfTwoValueStringsToComboBox(unsigned int const firstValue,
 
 void addEnumeratedParameterValueStringsToComboBox(LE::Utility::Span<char const *const> strings,
                                                   LE::Utility::Span<char const *const> shortStrings,
+                                                  LE::Utility::Span<std::uint8_t const> menuOrder,
                                                   ComboBox &comboBox)
 {
     LE_ASSERT_MSG(comboBox.numberOfItems() == 0, "ComboBox already filled.");
     LE_ASSERT(strings.size() == shortStrings.size());
-    ComboBox::value_type parameterValue(0);
-    while (strings)
-    {
-        comboBox.addItem(parameterValue, strings.front(), shortStrings.front());
-        ++parameterValue;
-        strings.advance_begin(1);
-        shortStrings.advance_begin(1);
-    }
+    LE_ASSERT(strings.size() == menuOrder.size());
+    for (auto const parameterValue : menuOrder)
+        comboBox.addItem(parameterValue, strings[parameterValue], shortStrings[parameterValue]);
     comboBox.setValue(0);
 }
 } // namespace Detail

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -77,6 +77,8 @@ template <class Parameter> struct Name;
 /// \see issue #120.
 template <class Parameter>
 constexpr typename DiscreteValues<Parameter>::Strings const &shortValueStrings();
+/// \note The same, for the order the rows come in. \see MenuOrder.
+template <class Parameter> constexpr typename DiscreteValues<Parameter>::Order const &menuOrder();
 } // namespace Parameters
 
 namespace SW
@@ -1263,8 +1265,14 @@ void addPowerOfTwoValueStringsToComboBox(unsigned int firstValue, unsigned int l
 /// \note Two lists of the same length: what the menu lists each value under and
 /// what the box reads once it is chosen. They are the same array for every
 /// parameter that has not been given abbreviations. \see issue #120.
+///
+/// \note Both are indexed by *value*, and \p menuOrder says which value each row
+/// holds -- declaration order for almost every parameter, and its own list for
+/// the ones given a MenuOrder. An item carries its value as its ID, so nothing
+/// downstream reads a row number.
 void addEnumeratedParameterValueStringsToComboBox(LE::Utility::Span<char const *const> strings,
                                                   LE::Utility::Span<char const *const> shortStrings,
+                                                  LE::Utility::Span<std::uint8_t const> menuOrder,
                                                   ComboBox &comboBox);
 
 template <class Parameter>
@@ -1278,7 +1286,8 @@ void fillComboBoxForParameter(ComboBox &comboBox, LE::Parameters::EnumeratedPara
 {
     addEnumeratedParameterValueStringsToComboBox(
         LE::Utility::makeSpan(LE::Parameters::DiscreteValues<Parameter>::strings),
-        LE::Utility::makeSpan(LE::Parameters::shortValueStrings<Parameter>()), comboBox);
+        LE::Utility::makeSpan(LE::Parameters::shortValueStrings<Parameter>()),
+        LE::Utility::makeSpan(LE::Parameters::menuOrder<Parameter>()), comboBox);
 }
 } // namespace Detail
 

--- a/src/gui/modules/moduleWidgets.cpp
+++ b/src/gui/modules/moduleWidgets.cpp
@@ -13,7 +13,6 @@
 #include "gui/modules/moduleUI.hpp"
 
 #include "le/spectrumworx/effects/pitch_magnet/pitchMagnet.hpp"
-#include "le/spectrumworx/effects/tune_worx/tuneWorx.hpp"
 
 #include "le/spectrumworx/effects/configuration/constants.hpp"
 #include "le/spectrumworx/effects/configuration/includedEffects.hpp"
@@ -46,44 +45,6 @@ template <> struct ModuleKnob::QuantizationFor<Effects::Detail::PitchMagnetBase:
 {
     static ModuleKnob::Quantization const value = ModuleKnob::Fixed;
 };
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// fillComboBoxForParameter< TuneWorx::Key >()
-// -------------------------------------------
-//
-////////////////////////////////////////////////////////////////////////////////
-///
-/// \brief Tune Worx's scale root, listed from C rather than from A.
-///
-///   The declaration order is A first, because the value *is* the index and the
-/// DSP counts semitones up from a 27.5 Hz A -- so it is what presets, sessions
-/// and automation lanes have always meant and it does not move. What a musician
-/// reads down is a chromatic scale, and that one starts at C. \see issue #89, and
-/// the note beside the value strings in tuneWorx.hpp.
-///
-/// \note Here, in the one translation unit that builds module widgets, for the
-/// same reason the quantisation above is: it has to be declared before
-/// `WidgetInitialiser` instantiates the primary template for this parameter, and
-/// this file is the only place that happens.
-///                                           (17.08.2026.)
-///
-////////////////////////////////////////////////////////////////////////////////
-
-template <> void fillComboBoxForParameter<Effects::Detail::TuneWorxBase::Key>(ComboBox &comboBox)
-{
-    using Key = Effects::Detail::TuneWorxBase::Key;
-    auto const &names(LE::Parameters::DiscreteValues<Key>::strings);
-
-    LE_ASSERT_MSG(comboBox.numberOfItems() == 0, "ComboBox already filled.");
-    for (auto const value : {Key::C, Key::Cis, Key::D, Key::Dis, Key::E, Key::F, Key::Fis, Key::G,
-                             Key::Gis, Key::A, Key::Ais, Key::B})
-        comboBox.addItem(value, names[value]);
-
-    /// \note The parameter's default rather than the first row, which is what the
-    /// generic filler's `setValue( 0 )` amounts to only while the two coincide.
-    comboBox.setValue(Key::default_());
-}
 
 //------------------------------------------------------------------------------
 namespace

--- a/src/le/parameters/uiElements.hpp
+++ b/src/le/parameters/uiElements.hpp
@@ -133,6 +133,10 @@ template <class Parameter> struct DiscreteValues
     using Strings = std::array<char const *, Parameter::numberOfDiscreteValues>;
     static Strings const strings;
 
+    /// \brief The same list read as row numbers rather than as names: the values
+    /// of \p Parameter in the order a menu offers them. \see MenuOrder.
+    using Order = std::array<std::uint8_t, Parameter::numberOfDiscreteValues>;
+
     /// \note What ParameterInfo carries, beside the nullptr a parameter with no
     /// value strings gives it. constexpr to match NonEnumeratedParameter's, now
     /// that ENUMERATED_PARAMETER_STRINGS produces a constant.
@@ -247,6 +251,95 @@ constexpr typename DiscreteValues<Parameter>::Strings const &shortValueStrings()
         return ShortValues<Parameter>::strings;
     else
         return DiscreteValues<Parameter>::strings;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \struct MenuOrder
+///
+/// \brief The order an enumerated parameter's values are *offered* in, where
+/// that is not the order they are declared in.
+///
+/// \details A value is its own index: it is what a preset stores, what a host
+/// automates and what the DSP switches on, so the declaration order is ABI and
+/// does not move. What a user reads down a menu is a different question --
+/// Ethereal's target is declared Both, Magnitudes, Phases and reads better as
+/// Magnitudes, Phases, Both -- and this is where that answer goes. Each row
+/// carries its own value, so nothing below the UI notices: the rows move, the
+/// values do not.
+///
+/// \note Empty by default and asked about with a requires-expression, as
+/// ShortValues is and for its reasons; menuOrder() below supplies declaration
+/// order for the parameters -- almost all of them -- that want it.
+///
+/// \note And, as with ShortValues, the specialisation belongs in the header that
+/// declares the parameter: a translation unit that does not see it builds the
+/// menu in declaration order rather than saying so.
+///                                           (19.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+template <class Parameter> struct MenuOrder
+{
+};
+
+namespace Detail ///< \internal
+{
+template <class Parameter> consteval typename DiscreteValues<Parameter>::Order identityOrder()
+{
+    typename DiscreteValues<Parameter>::Order order{};
+    for (std::size_t row{0}; row < order.size(); ++row)
+        order[row] = static_cast<std::uint8_t>(row);
+    return order;
+}
+
+/// \note A variable rather than a call, because menuOrder() hands back a
+/// reference and a consteval function's result is a temporary.
+template <class Parameter>
+inline constexpr
+    typename DiscreteValues<Parameter>::Order declarationOrder{identityOrder<Parameter>()};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief \p values as a row order, having checked that it is a permutation of
+/// \p Parameter's values rather than merely a list of them.
+///
+///   A repeat costs the value it displaced -- one that no menu row then offers
+/// and no jog wheel then reaches -- which is a parameter a user cannot set and
+/// nothing else in the build would notice. So it is a compile error naming the
+/// parameter, in the shape valueStrings() above uses for the same reason.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+template <class Parameter, std::size_t count>
+consteval typename DiscreteValues<Parameter>::Order
+menuOrderValues(typename Parameter::value_type const (&values)[count])
+{
+    static_assert(count == Parameter::numberOfDiscreteValues,
+                  "An enumerated parameter's menu order must list every one of its values");
+
+    typename DiscreteValues<Parameter>::Order order{};
+    bool listed[count]{};
+    for (std::size_t row{0}; row < count; ++row)
+    {
+        auto const value{static_cast<std::size_t>(values[row])};
+        if (value >= count || listed[value])
+            throw "An enumerated parameter's menu order must list each value exactly once";
+        listed[value] = true;
+        order[row] = static_cast<std::uint8_t>(value);
+    }
+    return order;
+}
+} // namespace Detail
+
+/// \brief \p Parameter's menu row order if it has been given one, its
+/// declaration order if it has not.
+template <class Parameter> constexpr typename DiscreteValues<Parameter>::Order const &menuOrder()
+{
+    if constexpr (requires { MenuOrder<Parameter>::order; })
+        return MenuOrder<Parameter>::order;
+    else
+        return Detail::declarationOrder<Parameter>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -382,6 +475,39 @@ template <class Parameter> struct DisplayValueTransformer
     namespace LE::Parameters                                                                       \
     {                                                                                              \
     ENUMERATED_PARAMETER_SHORT_STRINGS(SW::Effects::parentClass, parameter, __VA_ARGS__)                                                             \
+    }                                                                                              \
+    namespace LE::SW::Effects                                                                      \
+    {
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \def ENUMERATED_PARAMETER_MENU_ORDER
+///
+/// \brief The values again, in the order a menu should offer them. \see
+/// MenuOrder.
+///
+/// \note Optional, and values rather than pairs: this list says nothing about
+/// what a value is called, only about where it sits, so an entry is just the
+/// enumerator -- named unqualified, as in the two lists above and by the same
+/// `using enum`. What is checked is that it is a permutation rather than a
+/// rewrite, which is the one mistake here that would cost a user a value.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#define ENUMERATED_PARAMETER_MENU_ORDER(parentNameSpaceOrClass, parameter, ...)                    \
+    template <> struct MenuOrder<parentNameSpaceOrClass::parameter>                                \
+    {                                                                                              \
+        static constexpr DiscreteValues<parentNameSpaceOrClass::parameter>::Order order{[] {       \
+            using enum parentNameSpaceOrClass::parameter::value_type;                              \
+            return Detail::menuOrderValues<parentNameSpaceOrClass::parameter>({__VA_ARGS__});      \
+        }()};                                                                                      \
+    };
+
+#define EFFECT_ENUMERATED_PARAMETER_MENU_ORDER(parentClass, parameter, ...)                        \
+    }                                                                                              \
+    namespace LE::Parameters                                                                       \
+    {                                                                                              \
+    ENUMERATED_PARAMETER_MENU_ORDER(SW::Effects::parentClass, parameter, __VA_ARGS__)              \
     }                                                                                              \
     namespace LE::SW::Effects                                                                      \
     {

--- a/src/le/spectrumworx/effects/commonParameters.hpp
+++ b/src/le/spectrumworx/effects/commonParameters.hpp
@@ -69,6 +69,18 @@ EFFECT_ENUMERATED_PARAMETER_STRINGS(CommonParameters, SpringType,
     {Up, "Up"},
     {Down, "Down"})
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The two things a target is are listed before the one that is both of
+/// them. `Both` is the value zero because it is the default and because it is
+/// what every preset and automation lane since 2011 has called zero -- so it
+/// stays there, and only the menu reads down in the order a user chooses in.
+/// \see Parameters::MenuOrder.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+EFFECT_ENUMERATED_PARAMETER_MENU_ORDER(CommonParameters, Mode, Magnitudes, Phases, Both)
+
 } // namespace LE::SW::Effects
 /// @}
 

--- a/src/le/spectrumworx/effects/tune_worx/tuneWorx.hpp
+++ b/src/le/spectrumworx/effects/tune_worx/tuneWorx.hpp
@@ -159,9 +159,8 @@ EFFECT_PARAMETER_NAME(Detail::TuneWorxBase::Semi12, "12")
 /// \note **The order here is the parameter's, and the order the menu shows is
 /// not.** A value is an index: it is what a `.swp` stores, what a host automates
 /// and what the DSP adds to a note offset off a 27.5 Hz A
-/// (musicalScales.cpp:109), so A stays zero. What starts at C is the combo box,
-/// which lists the same twelve values in musical order --
-/// `fillComboBoxForParameter< Key >` in gui/modules/moduleWidgets.cpp.
+/// (musicalScales.cpp:109), so A stays zero. What starts at C is the menu, which
+/// is what the MENU_ORDER list below says. \see Parameters::MenuOrder.
 ///                                           (17.08.2026.)
 ///
 ////////////////////////////////////////////////////////////////////////////////
@@ -179,6 +178,10 @@ EFFECT_ENUMERATED_PARAMETER_STRINGS(Detail::TuneWorxBase, Key,
     {Fis, "F#/Gb"},
     {G, "G"},
     {Gis, "G#/Ab"})
+
+/// \note The same twelve, read down as a musician reads a chromatic scale.
+EFFECT_ENUMERATED_PARAMETER_MENU_ORDER(Detail::TuneWorxBase, Key, C, Cis, D, Dis, E, F, Fis, G, Gis,
+                                       A, Ais, B)
 
 } // namespace LE::SW::Effects
 

--- a/tests/gui/discreteParameterTests.cpp
+++ b/tests/gui/discreteParameterTests.cpp
@@ -26,6 +26,7 @@
 #include "gui/modules/moduleUI.hpp"
 
 #include "le/spectrumworx/effects/configuration/effectNames.hpp"
+#include "le/spectrumworx/effects/ethereal/ethereal.hpp"
 #include "le/spectrumworx/effects/tune_worx/tuneWorx.hpp"
 #include "le/spectrumworx/effects/vaxateer/vaxateer.hpp"
 
@@ -159,6 +160,85 @@ TEST_CASE("Every black key is named both ways", "[gui][modules][combo]")
     CHECK(std::string(names[Key::E]) == "E");
     CHECK(std::string(names[Key::F]) == "F");
     CHECK(std::string(names[Key::G]) == "G");
+}
+
+TEST_CASE("A shared target is listed in the order it is chosen in", "[gui][modules][combo]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note `CommonParameters::Mode` is declared Both, Magnitudes, Phases and
+    /// listed Magnitudes, Phases, Both: the two things it can be, and then the
+    /// one that is both of them. Zero stays Both because zero is the default and
+    /// because that is what every preset and automation lane written since 2011
+    /// calls it -- so the rows move and the values do not, which is the whole of
+    /// what `MenuOrder` is for.
+    ///
+    ///   The specialisation is on the shared parameter rather than on an effect,
+    /// so it is one declaration for the three effects that take it. Ethereal is
+    /// the one asked here; Inserter and Swappah get the same menu.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto &strip(stripFor(instance.editor(), "Ethereal"));
+
+    using Mode = Effects::Ethereal::Mode;
+    auto &comboBox(
+        comboBoxFor(strip, Parameters::IndexOf<Effects::Ethereal::Parameters, Mode>::value));
+
+    std::vector<Mode::value_type> const expected{Mode::Magnitudes, Mode::Phases, Mode::Both};
+
+    REQUIRE(comboBox.numberOfItems() == expected.size());
+
+    auto const &names(Parameters::DiscreteValues<Mode>::strings);
+    for (unsigned int row(0); row < expected.size(); ++row)
+    {
+        INFO("row " << row);
+        auto const value(expected[row]);
+        CHECK(comboBox.getItemText(row) == juce::String(names[value]));
+
+        // The row's own value, which is what selecting it writes.
+        comboBox.setSelectedIndex(row);
+        CHECK(comboBox.getSelectedID() == value);
+    }
+
+    CHECK(comboBox.getItemText(0) == "Magnitudes");
+    CHECK(Mode::Both == 0);
+
+    /// \note The parameter still reads its own declaration order, which is what
+    /// the host, a preset and the DSP switch see. Only the menu was reordered.
+    CHECK(std::string(names[0]) == "Both");
+}
+
+TEST_CASE("A parameter with no menu order of its own is listed as declared",
+          "[gui][modules][combo]")
+{
+    /// \note The other half: `MenuOrder` is empty by default and `menuOrder()`
+    /// then hands back 0, 1, 2 ... so a row number *is* a value, which is what
+    /// all but two of the enumerated parameters want. Ethereal's swap condition
+    /// is the nearest one to ask, and it sits on the same strip as the target
+    /// above.
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto &strip(stripFor(instance.editor(), "Ethereal"));
+
+    using Condition = Effects::Ethereal::Condition;
+    auto &comboBox(
+        comboBoxFor(strip, Parameters::IndexOf<Effects::Ethereal::Parameters, Condition>::value));
+
+    REQUIRE(comboBox.numberOfItems() == Condition::numberOfDiscreteValues);
+    for (unsigned int row(0); row < comboBox.numberOfItems(); ++row)
+    {
+        INFO("row " << row);
+        comboBox.setSelectedIndex(row);
+        CHECK(comboBox.getSelectedID() == row);
+    }
 }
 
 TEST_CASE("A swap condition is listed in full and read abbreviated", "[gui][modules][combo]")


### PR DESCRIPTION
A value is its own index -- it is what a preset stores, what a host automates and what the DSP switches on -- so the declaration order is ABI and the menu was stuck with it. The order a user chooses in is a different question, and MenuOrder is where the different answer goes: an optional list of the same values, bare, in the order the rows should come. Each row carries its value as its item ID, so nothing under the UI notices.

Ethereal, Inserter and Swappah now offer Magnitudes, Phases and then Both rather than leading with the one that is both of them; Both is still zero.

Tune Worx's key was the same rearrangement written by hand, as an explicit fillComboBoxForParameter specialisation that could only live in the one translation unit building module widgets. It says the same thing in the header beside the parameter now.

A list that repeats a value costs the one it displaced -- a value no row offers and nothing else would miss -- so it is a compile error naming the parameter.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>