### PR TITLE
Stop guessing whether the side chain port is patched

### DIFF
--- a/doc/tech/effect_contract.md
+++ b/doc/tech/effect_contract.md
@@ -513,13 +513,14 @@ what an old preset's `Input_mode` migrates to. Nothing about it reaches an effec
 which is the point: side-chain routing is not a DSP concern.
 
 **What the engine is handed when the selected source has nothing behind it is the
-main input, not silence** — so a Blender with nothing patched blends the signal
-with itself, and one in `Main` does so always. For the host's port that is three
-arrangements, of which the third is the only one a real DAW produces: no second
-port at all, a second port with no `data32`, and a second port whose channels the
-host declares constant and zero through `clap_audio_buffer::constant_mask`. The
-mask is a hint and a host that sets none is indistinguishable from one carrying
-real silence, which is what issue #13 is still open about.
+main input, not silence** — so a Blender in a host with no side chain blends the
+signal with itself, and one in `Main` does so always. For the host's port that is
+two arrangements, both structural: no second port at all, and a second port with
+no `data32`. Past those the port is read, whatever is in it, so a port a user has
+patched nothing into is heard as the silence the host put there. The plugin used
+to read `clap_audio_buffer::constant_mask` to guess otherwise and no longer does;
+[`sidechain-approach.md`](sidechain-approach.md) §2 says why, and issue #117 is
+where it went.
 
 > **Nothing declares that an effect reads the side chain, and nothing should.**
 > The `process()` overload is the declaration: take a `MainSideChannelData` and

--- a/doc/tech/sidechain-approach.md
+++ b/doc/tech/sidechain-approach.md
@@ -32,24 +32,32 @@ lives, and it is deliberately *not* a parameter — see §5.
 
 ```
 File, and a sample is loaded?     -> the sample's chunks
-Host, and the port carries signal -> process->audio_inputs[ 1 ]
+Host, and there is a port to read -> process->audio_inputs[ 1 ]
 otherwise                         -> the main input
 ```
 
-**Every fallback is the main input, never silence.** A Blender with nothing
-patched blends the signal with itself; that is the documented behaviour and
-`effect_contract.md` §1.8 is where an effect author meets it. An effect cannot
-tell the three apart — `data.side()` is the same span whichever filled it — which
-is what makes the selection a routing decision rather than a DSP one.
+**Every fallback is the main input, never silence** — and there are exactly two
+of them, both structural: no second port in the count at all, and a second port
+with no `data32`. A Blender in a host that offers no side chain blends the signal
+with itself; that is the documented behaviour and `effect_contract.md` §1.8 is
+where an effect author meets it. An effect cannot tell the three sources apart —
+`data.side()` is the same span whichever filled it — which is what makes the
+selection a routing decision rather than a DSP one.
 
-`Host` has three ways to carry no signal, and the third is the only one a real
-DAW produces: no second port in the count, a second port with no `data32`, and a
-second port whose channels the host declares constant and zero through
-`clap_audio_buffer::constant_mask`. The mask is a *hint* and a host that sets none
-is indistinguishable from one carrying real silence — issue #13 is still open on
-whether any host sets one at all. **That unreliability is now confined to one
-arm.** It decides between the port and the main input, and it can no longer
-decide against a file the user loaded, which is what it did until 18.08.2026.
+**Past those two the port is read, whatever is in it.** A user who selects `Host`
+in a host that offers a port and patches nothing into it hears the silence that
+host handed over, not the main input. That is a real consequence and it is the
+chosen one: the plugin infers nothing about routing from the samples it is given.
+
+A third arm read `clap_audio_buffer::constant_mask` between 09.08.2026 and
+19.08.2026, taking a port declared constant and zero as unpatched. It is gone
+(issue #117). The mask is a *hint*, no host was found setting one (issue #13,
+measured in a DAW — so the arm was never once taken), and it cannot tell an
+unpatched port from a patched send that has gone quiet: both are a constant zero,
+so a muted send audibly swapped the side chain for the main input and swapped
+back when it un-muted. Whether a port is connected is a fact for the host to
+state — `audio-ports-activation` is where it does — and until the plugin asks for
+that, it does not guess. Issue #115 is where the user gets told.
 
 ### Two states that cannot occur
 

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1319,46 +1319,6 @@ void SpectrumWorxCLAP::updateLFOTiming(clap_process const *const process) noexce
         timingChanged();
 }
 
-////////////////////////////////////////////////////////////////////////////////
-///
-/// \brief Does the host say every channel of \p buffer is a constant, and is
-/// every one of those constants zero?
-///
-/// \note `constant_mask` is a *hint* -- `audio-buffer.h` says so -- and a host
-/// that sets none reads as "no", which is the behaviour that was here before it
-/// was consulted at all. A host that sets one has undertaken to fill the buffer
-/// with the constant as well ("this implies that the buffer must be filled with
-/// the constant value"), which is what makes reading sample 0 the right question
-/// rather than a guess.
-///
-/// \note Every channel, and no partial arm. A port with one constant channel and
-/// one carrying audio is carrying audio; substituting the constant for the quiet
-/// half would be a third behaviour to explain and nothing has been observed
-/// producing one.
-///                                           (09.08.2026.) (SW port)
-///
-////////////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-bool isDeclaredSilent(clap_audio_buffer const &buffer) noexcept
-{
-    /// \note `constant_mask` is 64 bits wide, so a channel past the 64th has no
-    /// bit and cannot be declared anything.
-    if (!buffer.data32 || (buffer.channel_count == 0) || (buffer.channel_count > 64))
-        return false;
-
-    for (std::uint32_t channel(0); channel < buffer.channel_count; ++channel)
-    {
-        if ((buffer.constant_mask & (std::uint64_t(1) << channel)) == 0)
-            return false;
-        if (!buffer.data32[channel] || (buffer.data32[channel][0] != 0))
-            return false;
-    }
-    return true;
-}
-} // anonymous namespace
-
 /// \see the note on the declaration.
 std::uint32_t SpectrumWorxCLAP::engineChunkSize() const noexcept
 {
@@ -1398,34 +1358,29 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \note The engine reads a side channel whenever the input mode calls for
-    /// one, and does not check that the host connected the port. Three
-    /// arrangements fall back to the main input, which is the documented
-    /// behaviour for an unpatched side chain -- a Blender with nothing patched
-    /// blends the signal with itself:
+    /// one, and does not check that the host connected the port. Two structural
+    /// arrangements fall back to the main input -- no second port in the count at
+    /// all, and a second port with no `data32` -- so an effect in a host that
+    /// offers no side chain at all still has something to read.
     ///
-    ///   - no second port in the count at all;
-    ///   - a second port with no `data32`;
-    ///   - a second port the host declares constant and zero.
+    /// \note **Beyond those two, what the port contains is the host's answer,
+    /// whatever it is.** A port that is present and has buffers is read, so a
+    /// port a user has patched nothing into is whatever the host left in it --
+    /// silence, from any wrapper that zeroes what it hands over.
     ///
-    ///   The third is `clap_audio_buffer::constant_mask` and is new as of
-    /// 09.08.2026. Before it the first two were the whole test, and **no real
-    /// host takes either**: every wrapper hands over a buffer it owns. So what an
-    /// unpatched side chain contained was whatever the host left there, the
-    /// documented behaviour was unreachable, and it is how uninitialised memory
-    /// reached the FFT from an AUv2 bus.
+    ///   `clap_audio_buffer::constant_mask` was consulted here between
+    /// 09.08.2026 and 19.08.2026, to make "an unpatched side chain is the main
+    /// input" reachable in a host that hands over a buffer it owns. Removing it
+    /// is not tidiness. It is a *hint* -- `audio-buffer.h` says so -- no host was
+    /// found setting one (issue #13, measured, so this arm was never once taken),
+    /// and it answered a question it cannot answer: an unpatched port and a
+    /// patched send that has gone quiet are the same constant zero, so a muted
+    /// send audibly swapped the side chain for the main input and swapped back.
     ///
-    /// \note What the mask cannot say is *why* a channel is constant. An
-    /// unpatched port and a patched send that has gone quiet are both a constant
-    /// zero, and they take the same arm here: a side chain carrying no signal is
-    /// the main input, whichever of the two it is. That is a real consequence and
-    /// it is the chosen one -- a muted send audibly switches to blending with
-    /// itself and switches back when it un-mutes.
-    ///
-    /// \note And it is a *hint*: `audio-buffer.h` says so in as many words, and
-    /// neither clap-wrapper nor a given DAW is known to set it. Nothing here
-    /// depends on it. A mask of zero is exactly the behaviour that was here
-    /// before, so a host that never sets one loses nothing and a host that does
-    /// gets the behaviour that was intended in 2016.
+    ///   Whether a port is connected is a routing fact, and a routing fact is the
+    /// host's to state rather than ours to infer from the samples. Until
+    /// `audio-ports-activation` says it, nothing here guesses it.
+    ///                                           (19.08.2026.) (SW port) \see #117
     ///
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1435,7 +1390,7 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
     /// `SideChainSource` -- which is the audio-file selector's answer rather than
     /// a claim about bus topology. \see doc/tech/sidechain-approach.md and issue
     /// #113. `Host` is the only value that reads port 1; the fallbacks above are
-    /// what it gets when the host has not filled it.
+    /// what it gets when the host offers no port to read.
     ///
     /// \note `sideChainSource_` is the engine's copy, set by `drainCommands()` in
     /// the same message that swaps the sample -- so a block can never be rendered
@@ -1445,12 +1400,11 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
 
     bool const hostSideChainWanted(sideChainSource_ == SideChainSource::Host);
 
-    bool const sideChainCarriesSignal(hostSideChainWanted && (process->audio_inputs_count > 1) &&
-                                      process->audio_inputs[1].data32 &&
-                                      !isDeclaredSilent(process->audio_inputs[1]));
+    bool const hostSideChainReadable(hostSideChainWanted && (process->audio_inputs_count > 1) &&
+                                     process->audio_inputs[1].data32);
 
-    float const *const *sideChannels(sideChainCarriesSignal ? process->audio_inputs[1].data32
-                                                            : input.data32);
+    float const *const *sideChannels(hostSideChainReadable ? process->audio_inputs[1].data32
+                                                           : input.data32);
 
     ////////////////////////////////////////////////////////////////////////////
     // The decoded audio file, when that is what the patch selected.

--- a/tests/clap/pluginTests.cpp
+++ b/tests/clap/pluginTests.cpp
@@ -397,36 +397,25 @@ TEST_CASE("What a host puts on the side chain port reaches the engine", "[clap][
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \note The fourth arrangement, and the one every real host actually hands
-    /// over: a port with buffers the host owns and nothing patched into it. No
-    /// pointer distinguishes it from a connected one, which is why the documented
-    /// "an unpatched side chain is the main input" behaviour was unreachable
-    /// until `clap_audio_buffer::constant_mask` was read.
+    /// over: a port with buffers the host owns and nothing patched into them. No
+    /// pointer distinguishes it from a connected one and **nothing here tries
+    /// to** -- a port carrying zeroes is a side chain carrying silence, which is
+    /// all the host has said about it.
     ///
-    ///   Zeroed buffers *and* a mask declaring them constant, because a host that
-    /// sets a bit has undertaken to fill the channel with the constant. Setting
-    /// only one of the two would be testing a host that does not exist.
+    ///   `clap_audio_buffer::constant_mask` was read here until 19.08.2026, to
+    /// make this arrangement land on the main input the way the two structural
+    /// ones do. \see issue #117 for why a hint no host sets cannot answer a
+    /// routing question.
     ///
     ////////////////////////////////////////////////////////////////////////////
-    auto const declaredSilent(run(
-        [](ActivePlugin &plugin, std::vector<float> &left, std::vector<float> &right) {
-            plugin.connectSideChain(left, right);
-            plugin.declareSideChainConstant(0b11);
-        },
-        0.0f));
-
-    /// \note The same zeroed buffers with no claim made about them, which is
-    /// every host that does not set the mask -- the hint is optional and neither
-    /// clap-wrapper nor a given DAW is known to set it. This one has to keep
-    /// behaving exactly as it did: silence on the port is silence in the engine.
-    auto const silentButUndeclared(
+    auto const silentPort(
         run([](ActivePlugin &plugin, std::vector<float> &left,
                std::vector<float> &right) { plugin.connectSideChain(left, right); },
             0.0f));
 
     REQUIRE(noPort.size() == connected.size());
     REQUIRE(noPort.size() == emptyPort.size());
-    REQUIRE(noPort.size() == declaredSilent.size());
-    REQUIRE(noPort.size() == silentButUndeclared.size());
+    REQUIRE(noPort.size() == silentPort.size());
 
     // A carrier the engine could not have got from the main input changed what
     // came out. This is the whole case: without it, every arrangement below is
@@ -436,26 +425,26 @@ TEST_CASE("What a host puts on the side chain port reaches the engine", "[clap][
 
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note And every way of not filling the port lands on the *same* fallback,
-    /// bit for bit. `runEngine()` reads the port count, `data32` and now the
-    /// constant mask, so a host that declares one port, a host that declares two
-    /// and fills one, and a host that declares two and says the second is a
-    /// constant zero all have to be indistinguishable. The middle one is the arm
-    /// that would have dereferenced null had the `&&` been the other way round.
+    /// \note Both *structural* ways of having no port land on the same fallback,
+    /// bit for bit. `runEngine()` reads the port count and `data32` and nothing
+    /// else, so a host that declares one port and a host that declares two and
+    /// hands over no buffers for the second have to be indistinguishable. The
+    /// second is the arm that would have dereferenced null had the `&&` been the
+    /// other way round.
     ///
     ////////////////////////////////////////////////////////////////////////////
     CHECK(emptyPort == noPort);
-    CHECK(declaredSilent == noPort);
 
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note And the mask is the *whole* of what distinguishes them: the same
-    /// zeroed buffers with nothing declared about them are a connected side chain
-    /// carrying silence, and that is not the main input. A host that sets no mask
-    /// therefore gets what it always got.
+    /// \note And a port that *is* there, carrying silence, is not the main input.
+    /// That is the whole of what this plugin infers about routing from the
+    /// samples it was handed: nothing. Whether an unpatched port ought to sound
+    /// like the main input is a question for `audio-ports-activation`, where the
+    /// host answers it instead of being guessed at. \see issues #115 and #117.
     ///
     ////////////////////////////////////////////////////////////////////////////
-    CHECK(silentButUndeclared != noPort);
+    CHECK(silentPort != noPort);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/clap/testHost.hpp
+++ b/tests/clap/testHost.hpp
@@ -750,25 +750,10 @@ class ActivePlugin
         sideChainPortPresent_ = true;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    ///
-    /// \brief What the host declares about the side-chain port's channels, as a
-    /// `clap_audio_buffer::constant_mask`.
-    ///
-    /// \note Zero -- no claim at all -- is the default, and is what most hosts
-    /// and the shipped clap-wrapper are assumed to hand over: the mask is a hint
-    /// and nothing obliges anyone to set it. A case that sets one is testing the
-    /// arm that reads it. Note that a host setting a bit has undertaken to fill
-    /// the channel with the constant, so a case must fill the buffer to match.
-    ///
-    ////////////////////////////////////////////////////////////////////////////
-    void declareSideChainConstant(std::uint64_t const mask) { sideChainConstantMask_ = mask; }
-
     void disconnectSideChain()
     {
         pSideChainLeft_ = pSideChainRight_ = nullptr;
         sideChainPortPresent_ = false;
-        sideChainConstantMask_ = 0;
     }
 
     /// Runs one block of stereo audio through, in place of a host's callback.
@@ -812,7 +797,7 @@ class ActivePlugin
         /// nonsense one.
         clap_audio_buffer inputs[]{
             {&inputChannels[0], nullptr, 2, 0, 0},
-            {pSideChainLeft_ ? &sideChannels[0] : nullptr, nullptr, 2, 0, sideChainConstantMask_}};
+            {pSideChainLeft_ ? &sideChannels[0] : nullptr, nullptr, 2, 0, 0}};
         clap_audio_buffer output{&outputChannels[0], nullptr, 2, 0, 0};
 
         clap_process process{};
@@ -964,7 +949,6 @@ class ActivePlugin
     std::vector<float> *pSideChainLeft_{nullptr};
     std::vector<float> *pSideChainRight_{nullptr};
     bool sideChainPortPresent_{false};
-    std::uint64_t sideChainConstantMask_{0};
 }; // class ActivePlugin
 
 inline clap_plugin_params const &parameters(clap_plugin const &plugin)

--- a/tests/external_audio/sampleFeedTests.cpp
+++ b/tests/external_audio/sampleFeedTests.cpp
@@ -221,8 +221,13 @@ TEST_CASE("Each of the three sources reaches the DSP, and only the selected one"
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// \note What each source does when the thing it names is not there. Neither is
-/// an error and both land on the main input, which is what makes "an unpatched
-/// side chain blends the signal with itself" true of all three.
+/// an error and both land on the main input, which is what makes "a side chain
+/// with nothing behind it blends the signal with itself" true of all three.
+///
+/// \note "Not there" means the host offers no port at all, which is the only
+/// thing `Host` falls back from. A port that is present and carrying silence is
+/// silence -- the plugin stopped reading `constant_mask` to guess otherwise on
+/// 19.08.2026. \see issue #117 and doc/tech/sidechain-approach.md §2.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The plugin no longer reads clap_audio_buffer::constant_mask to decide that a side chain carrying zeroes is unpatched, and so no longer substitutes the main input for it. A port that is present and has buffers is read as handed over.

The mask is a hint, no host was measured setting one, and it cannot tell an unpatched port from a patched send that has gone quiet -- both are a constant zero, so a muted send audibly swapped the side chain for the main input and swapped back. Whether a port is connected is the host's to state, through audio-ports-activation, rather than ours to infer from the samples.

The fallback to the main input survives where the host has structurally offered nothing: no second port in the count, or a port with no data32.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>