### PR TITLE
Open the preset browser inside a tree, and give it a navigation row

### DIFF
--- a/doc/tech/sidechain-approach.md
+++ b/doc/tech/sidechain-approach.md
@@ -139,7 +139,7 @@ otherwise (0, 2, or absent)  -> Main
 Three things worth knowing about it:
 
 - **"A sample was applied", not "the patch names one".** A patch loaded with the
-  preset browser's `Ignore external audio` on names a file and gets none, so it
+  lock beside `Sidechain Source` shut names a file and gets none, so it
   migrates to `Input_mode`'s answer instead — which is what a user who asked not
   to be given somebody else's audio meant. A named file that will not decode is
   reported and cleared, and lands in the same place.

--- a/src/gui.cmake
+++ b/src/gui.cmake
@@ -23,6 +23,7 @@ add_library(sw-gui-resources STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/editorKnobPainter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/ejectPainter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/framePainter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/glyphPainter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/knobPainter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/moduleKnobPainter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/painters/moduleStripPainter.cpp

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -136,7 +136,8 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
       /// pill and the rest the room its halo needed. It is written down here
       /// now, and the two are placed three pixels apart as they were.
       ///                                       (18.08.2026.)
-      preset_(mainArea_, "PRESETS", 57, 24), settingsButton_(mainArea_, "SETTINGS", 57, 24)
+      preset_(mainArea_, "PRESETS", 57, 24), settingsButton_(mainArea_, "SETTINGS", 57, 24),
+      ignoreExternalSample_(mainArea_, GlyphButton::Glyph::Lock, true /*toggles*/)
 {
     using LE::Parameters::IndexOf;
     using namespace GlobalParameters;
@@ -181,6 +182,13 @@ SpectrumWorxEditor::SpectrumWorxEditor(EditorHost &editorHost, PanelPlacement co
 
     preset_.setTopLeftPosition(74, 338);
     settingsButton_.setTopLeftPosition(134, 338);
+
+    /// \note Placed from the label it belongs to rather than from a constant of
+    /// its own -- the pair is centred over the sidechain source box, so where
+    /// the lock goes depends on how wide the words beside it come out.
+    ignoreExternalSample_.setCentrePosition(
+        BackgroundPainter::sideChainLockBounds().getCentre().roundToInt());
+    ignoreExternalSample_.setName("Ignore external audio");
 
     preset_.addListener(this);
     settingsButton_.addListener(this);
@@ -1626,6 +1634,11 @@ void SpectrumWorxEditor::addUserAddedModule(std::uint8_t const effectIndex)
     host().gestureEnd();
 
     refreshModuleRackAsync();
+}
+
+bool SpectrumWorxEditor::ignoreExternalSample() const
+{
+    return ignoreExternalSample_.getToggleState();
 }
 
 bool SpectrumWorxEditor::loadPreset(fs::path const &presetFile, bool const ignoreExternalSample,

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -201,6 +201,10 @@ class SpectrumWorxEditor final : private SkinLifetime,
     void savePreset(fs::path const &, bool ignoreExternalSample, juce::String const &comment) const;
     char const *currentProgramName() const;
 
+    /// \brief Whether the user has locked the sidechain source against presets.
+    /// \see ignoreExternalSample_, and the two calls in PresetBrowser.
+    bool ignoreExternalSample() const;
+
     bool presetLoadingInProgress() const;
 
   public:
@@ -1433,6 +1437,22 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
     PaintedButton preset_;
     PaintedButton settingsButton_;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief "Ignore external audio": whether a preset gets to bring an audio
+    /// file with it, in either direction.
+    ///
+    /// \note The preset browser's, as a captioned LED, until issue #44 wanted
+    /// that row for preset navigation. It says something about the sidechain
+    /// source, so it sits beside the sidechain source -- and it outlives the
+    /// browser here, which the browser being built and destroyed with the
+    /// overlay means it did not before.
+    ///                                       (19.08.2026.)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    GlyphButton ignoreExternalSample_;
 
     // Optional/auxiliary components
     friend class SharedModuleControls;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -960,6 +960,91 @@ void EjectButton::paintButton(juce::Graphics &graphics, bool const isMouseOverBu
                     [&](juce::Colour const tint) { EjectPainter::tint(graphics, bounds, tint); });
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// GlyphButton
+// -----------
+//
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+/// \brief How wide the widget holding \p glyph is; they are all one height.
+int glyphWidgetWidth(GlyphButton::Glyph const glyph)
+{
+    switch (glyph)
+    {
+    case GlyphButton::Glyph::FolderUp:
+        return GlyphStyle::upWidgetWidth;
+    case GlyphButton::Glyph::User:
+        return GlyphStyle::userWidgetWidth;
+    case GlyphButton::Glyph::JogPrevious:
+    case GlyphButton::Glyph::JogNext:
+        return GlyphStyle::jogWidgetWidth;
+    case GlyphButton::Glyph::Lock:
+        return GlyphStyle::lockWidgetWidth;
+    }
+    LE_UNREACHABLE_CODE();
+}
+} // anonymous namespace
+
+GlyphButton::GlyphButton(juce::Component &parent, Glyph const glyph, bool const toggles)
+    : glyph_(glyph)
+{
+    setWantsKeyboardFocus(false);
+    setMouseClickGrabsKeyboardFocus(false);
+
+    setSize(glyphWidgetWidth(glyph),
+            (glyph == Glyph::Lock) ? GlyphStyle::lockWidgetHeight : GlyphStyle::rowHeight);
+    setClickingTogglesState(toggles);
+
+    addToParentAndShow(parent, *this);
+}
+
+/// \note Dimmed by a transparency layer rather than by an alpha on the colour,
+/// for the reason PaintedButton gives: the up arrow is two overlapping shapes
+/// and fading each of them separately would show where they meet.
+void GlyphButton::paintButton(juce::Graphics &graphics, bool isMouseOverButton,
+                              bool const isButtonDown)
+{
+    if (!isEnabled())
+        isMouseOverButton = false;
+
+    auto opacity(isMouseOverButton ? PointerFeedback::over : PointerFeedback::normal);
+    if (!isEnabled())
+        opacity *= PointerFeedback::disabled;
+
+    bool const fade(opacity < 1.0f);
+    if (fade)
+        graphics.beginTransparencyLayer(opacity);
+
+    auto const bounds(getLocalBounds().toFloat());
+    auto const colour(ColourMap::getColour(
+        isEnabled() && (isButtonDown || getToggleState()) ? ColourMap::Accent : ColourMap::Text));
+
+    switch (glyph_)
+    {
+    case Glyph::FolderUp:
+        GlyphPainter::paintFolderUp(graphics, bounds, colour);
+        break;
+    case Glyph::User:
+        GlyphPainter::paintUser(graphics, bounds, colour);
+        break;
+    case Glyph::JogPrevious:
+        GlyphPainter::paintJog(graphics, bounds, false /*points left*/, colour);
+        break;
+    case Glyph::JogNext:
+        GlyphPainter::paintJog(graphics, bounds, true /*points right*/, colour);
+        break;
+    case Glyph::Lock:
+        GlyphPainter::paintLock(graphics, bounds, colour);
+        break;
+    }
+
+    if (fade)
+        graphics.endTransparencyLayer();
+}
+
 LEDTextButton::LEDTextButton(juce::Component &parent, unsigned int const x, unsigned int const y,
                              char const *const text)
     : CapsuleButton(parent, ledCapsule, ledWidth, ledHeight)

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -38,6 +38,7 @@
 #include "painters/ejectPainter.hpp"
 #include "painters/editorKnobPainter.hpp"
 #include "painters/framePainter.hpp"
+#include "painters/glyphPainter.hpp"
 #include "painters/knobPainter.hpp"
 #include "painters/panelPainter.hpp"
 
@@ -944,6 +945,46 @@ class EjectButton : public WidgetBase<juce::Button>
   private: // juce::Component overrides
     void paintButton(juce::Graphics &, bool isMouseOverButton, bool isButtonDown) override;
 }; // class EjectButton
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \class GlyphButton
+///
+////////////////////////////////////////////////////////////////////////////////
+
+/// \brief A mark that stands for a word, and says what it is by its colour.
+///
+///   The preset browser's navigation row: up a folder, the user's own presets,
+/// and the two halves of the preset jog. \see GlyphPainter for the drawings and
+/// for the sizes, which are each glyph's own.
+///
+/// \note White when off and the accent when on, which issue #44 asks for
+/// literally -- so a toggling glyph needs nothing said about it at the call
+/// site, and a glyph that does not toggle is white for its whole life. Disabled
+/// and moused-over are PointerFeedback's, as everywhere else.
+class GlyphButton : public WidgetBase<juce::Button>
+{
+  public:
+    enum struct Glyph
+    {
+        FolderUp,
+        User,
+        JogPrevious,
+        JogNext,
+        /// \note Not in that row: this one is the editor's, beside the
+        /// sidechain source. \see BackgroundPainter::sideChainLockBounds().
+        Lock
+    };
+
+    /// \param toggles false for the three that are actions rather than states.
+    GlyphButton(juce::Component &parent, Glyph, bool toggles = false);
+
+  private: // juce::Component overrides
+    void paintButton(juce::Graphics &, bool isMouseOverButton, bool isButtonDown) override;
+
+  private:
+    Glyph const glyph_;
+}; // class GlyphButton
 
 /// \brief One of those with a caption beside it.
 class LEDTextButton : public CapsuleButton

--- a/src/gui/painters/backgroundPainter.cpp
+++ b/src/gui/painters/backgroundPainter.cpp
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 #include "gui/painters/backgroundPainter.hpp"
 
+#include "gui/painters/glyphPainter.hpp"
 #include "gui/resources.hpp"
 
 #include <cmath>
@@ -201,11 +202,35 @@ juce::Font regularFont(float const height)
 {
     return juce::Font(juce::FontOptions(regularTypeface()).withHeight(height));
 }
+
+/// \brief How wide \p text comes out in \p font, measured over the ink rather
+/// than over the advance -- which is what everything centred here is placed by.
+float inkWidth(juce::String const &text, juce::Font const &font)
+{
+    juce::GlyphArrangement glyphs;
+    glyphs.addLineOfText(font, text, 0, 0);
+    return glyphs.getBoundingBox(0, -1, false).getWidth();
+}
+
+/// \brief What the sidechain source label and the lock beside it take together,
+/// and where their left edge therefore falls.
+float sideChainLockLeft()
+{
+    auto const pair(GlyphStyle::lockWidth + sideChainLockGap +
+                    inkWidth(sideChainSourceLabel, boldFont(sideChainSourceLabelHeight)));
+    return rectangleOf(sideChainSourceBox).getCentreX() - pair / 2;
+}
 } // anonymous namespace
 
 juce::Colour BackgroundPainter::gutterColour()
 {
     return ColourMap::getColour(ColourMap::EditorSurround);
+}
+
+juce::Rectangle<float> BackgroundPainter::sideChainLockBounds()
+{
+    return {sideChainLockLeft(), sideChainSourceLabelY, GlyphStyle::lockWidth,
+            GlyphStyle::lockHeight};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -266,9 +291,12 @@ void BackgroundPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> c
 
     paintLabel(graphics, lfoLabel, boldFont(lfoLabelHeight), lfoLabelX, lfoLabelY, ColourMap::Text);
 
-    paintCentredLabel(graphics, sideChainSourceLabel, boldFont(sideChainSourceLabelHeight),
-                      rectangleOf(sideChainSourceBox).getCentreX(), sideChainSourceLabelY,
-                      ColourMap::Text);
+    /// \note Placed by its left edge rather than centred, because what is
+    /// centred over the box is the label *and* the lock in front of it.
+    /// \see sideChainLockBounds(), which is where the editor puts the widget.
+    paintLabel(graphics, sideChainSourceLabel, boldFont(sideChainSourceLabelHeight),
+               sideChainLockLeft() + GlyphStyle::lockWidth + sideChainLockGap,
+               sideChainSourceLabelY, ColourMap::Text);
 
     paintCentredLabel(graphics, productLabel, regularFont(productLabelHeight), productLabelCentreX,
                       productLabelY, ColourMap::Wordmark);

--- a/src/gui/painters/backgroundPainter.hpp
+++ b/src/gui/painters/backgroundPainter.hpp
@@ -255,6 +255,17 @@ float constexpr lfoLabelY{161.0f};
 float constexpr sideChainSourceLabelHeight{11.0f};
 float constexpr sideChainSourceLabelY{293.f};
 
+/// \brief What the padlock beside that label leaves between itself and it.
+///
+/// \note The lock and the words are centred over the box *as one*, so the label
+/// moves right by half of what the lock and this gap take. Issue #44 moves the
+/// preset browser's "Ignore external audio" toggle here: what it says is "this
+/// preset does not get to bring its own audio file with it", which is a
+/// statement about the sidechain source and belongs beside it rather than in a
+/// row of preset navigation.
+///                                       (19.08.2026.)
+float constexpr sideChainLockGap{4.0f};
+
 float constexpr productLabelHeight{12.f};
 float constexpr productLabelCentreX{40.f};
 float constexpr productLabelY{338.f};
@@ -280,6 +291,19 @@ class BackgroundPainter
   public:
     /// \brief Draws the whole chassis into \p bounds.
     static void paint(juce::Graphics &, juce::Rectangle<float> bounds);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Where the padlock beside the sidechain source label goes.
+    ///
+    ///   The editor places a widget there; this is what places it, because what
+    /// the pair is centred on is the label's *ink*, and how wide that is depends
+    /// on the copy and on the typeface. Asking here is what keeps the button and
+    /// the words that the button belongs to from drifting apart.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    static juce::Rectangle<float> sideChainLockBounds();
 
     /// \brief What fills the gutter an overlay panel opens beside itself.
     ///

--- a/src/gui/painters/glyphPainter.cpp
+++ b/src/gui/painters/glyphPainter.cpp
@@ -1,0 +1,154 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file glyphPainter.cpp
+/// ----------------------
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/painters/glyphPainter.hpp"
+
+namespace LE::SW::GUI
+{
+
+namespace
+{
+using namespace GlyphStyle;
+
+/// \brief \p ink centred in \p bounds, which is where every mark here is drawn.
+juce::Rectangle<float> centred(juce::Rectangle<float> const bounds, float const width,
+                               float const height)
+{
+    return juce::Rectangle<float>(width, height).withCentre(bounds.getCentre());
+}
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// GlyphPainter::paintFolderUp()
+// -----------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note One stroked path for the stem and the foot, with a curved joint where
+/// they meet, and a filled triangle on top of it. The stem's top end is butted
+/// rather than rounded because it does not end there -- the arrowhead's base
+/// sits on it, and a round cap would push a bulge out past that base.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void GlyphPainter::paintFolderUp(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
+                                 juce::Colour const colour)
+{
+    auto const ink(centred(bounds, upWidth, upHeight));
+
+    /// The stem is centred under the arrowhead, so the head's half width is
+    /// also how far in from the left the whole vertical run stands.
+    auto const stemX(ink.getX() + upHeadWidth / 2);
+    auto const headBase(ink.getY() + upHeadHeight);
+
+    juce::Path bend;
+    bend.startNewSubPath(ink.getRight(), ink.getBottom() - upStroke / 2);
+    bend.lineTo(stemX, ink.getBottom() - upStroke / 2);
+    bend.lineTo(stemX, headBase);
+
+    graphics.setColour(colour);
+    graphics.strokePath(bend, juce::PathStrokeType(upStroke, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::butt));
+
+    juce::Path head;
+    head.startNewSubPath(stemX, ink.getY());
+    head.lineTo(stemX + upHeadWidth / 2, headBase);
+    head.lineTo(stemX - upHeadWidth / 2, headBase);
+    head.closeSubPath();
+    graphics.fillPath(head);
+}
+
+void GlyphPainter::paintUser(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
+                             juce::Colour const colour)
+{
+    auto const ink(centred(bounds, userBodyWidth, userHeadDiameter + userGap + userBodyHeight));
+
+    graphics.setColour(colour);
+    graphics.fillEllipse(ink.getCentreX() - userHeadDiameter / 2, ink.getY(), userHeadDiameter,
+                         userHeadDiameter);
+    graphics.fillRoundedRectangle(ink.getX(), ink.getBottom() - userBodyHeight, userBodyWidth,
+                                  userBodyHeight, userBodyRadius);
+}
+
+void GlyphPainter::paintJog(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
+                            bool const pointsRight, juce::Colour const colour)
+{
+    auto const ink(centred(bounds, jogTriangle, jogTriangle));
+
+    auto const apex(pointsRight ? ink.getRight() : ink.getX());
+    auto const base(pointsRight ? ink.getX() : ink.getRight());
+
+    juce::Path triangle;
+    triangle.startNewSubPath(apex, ink.getCentreY());
+    triangle.lineTo(base, ink.getY());
+    triangle.lineTo(base, ink.getBottom());
+    triangle.closeSubPath();
+
+    graphics.setColour(colour);
+    graphics.fillPath(triangle);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// GlyphPainter::paintFolder()
+// ---------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Body and tab as one path rather than two overlapping rounded
+/// rectangles: they are drawn in one colour at one alpha, and two shapes sharing
+/// an edge antialias against the ground twice over -- which shows as a seam
+/// down a mark nine pixels tall.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void GlyphPainter::paintFolder(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
+                               juce::Colour const colour)
+{
+    auto const ink(centred(bounds, folderWidth, folderHeight));
+
+    juce::Path folder;
+    folder.addRoundedRectangle(ink.getX(), ink.getY(), folderTabWidth,
+                               folderTabRise + 2 * folderCornerRadius, folderCornerRadius,
+                               folderCornerRadius, true /*top left*/, true /*top right*/,
+                               false /*bottom left*/, false /*bottom right*/);
+    folder.addRoundedRectangle(ink.getX(), ink.getY() + folderTabRise, folderWidth,
+                               folderHeight - folderTabRise, folderCornerRadius);
+
+    graphics.setColour(colour);
+    graphics.fillPath(folder);
+}
+
+void GlyphPainter::paintLock(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
+                             juce::Colour const colour)
+{
+    auto const ink(centred(bounds, lockWidth, lockHeight));
+    auto const bodyTop(ink.getBottom() - lockBodyHeight);
+
+    /// The shackle's wire is stroked, so its path is the line down the middle of
+    /// it: half a stroke inside the ink at the top, and a radius that is half
+    /// the span between the two legs.
+    auto const radius(lockShackleWidth / 2);
+    auto const arcCentreY(ink.getY() + lockShackleStroke / 2 + radius);
+
+    juce::Path shackle;
+    shackle.startNewSubPath(ink.getCentreX() - radius, bodyTop);
+    shackle.lineTo(ink.getCentreX() - radius, arcCentreY);
+    shackle.addCentredArc(ink.getCentreX(), arcCentreY, radius, radius, 0.0f,
+                          -juce::MathConstants<float>::halfPi, juce::MathConstants<float>::halfPi);
+    shackle.lineTo(ink.getCentreX() + radius, bodyTop);
+
+    graphics.setColour(colour);
+    graphics.strokePath(shackle, juce::PathStrokeType(lockShackleStroke));
+    graphics.fillRoundedRectangle(ink.getX(), bodyTop, lockWidth, lockBodyHeight, lockCornerRadius);
+}
+
+} // namespace LE::SW::GUI

--- a/src/gui/painters/glyphPainter.hpp
+++ b/src/gui/painters/glyphPainter.hpp
@@ -1,0 +1,191 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file glyphPainter.hpp
+/// ----------------------
+///
+///   The small marks that stand for a word: the four in the preset browser's
+/// navigation row, and the folder in front of a directory in its list.
+///
+///   None of these came out of the skin -- there was no navigation row to draw
+/// them in. They are issue #44's mock-up, measured off it and divided by the
+/// 1.5 the editor is drawn at, so the numbers below are skin pixels and what
+/// lands on screen at the resting zoom is the mock-up's own: a nine pixel head
+/// on the user, a five pixel body under it.
+///
+/// \note Colour is the caller's, unlike every other painter here. A glyph in
+/// this row *is* its state -- white for off and the accent for on, which is
+/// what issue #44 asks for -- so there is nothing for the painter to look up.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef glyphPainter_hpp__5C1A8E37_49B2_4D6F_A0E3_2B7C4F91D6A8
+#define glyphPainter_hpp__5C1A8E37_49B2_4D6F_A0E3_2B7C4F91D6A8
+//------------------------------------------------------------------------------
+#include <juce_graphics/juce_graphics.h>
+
+namespace LE::SW::GUI
+{
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \namespace GlyphStyle
+///
+////////////////////////////////////////////////////////////////////////////////
+
+/// \brief Each mark's ink, in skin pixels, inside the widget that holds it.
+///
+/// \note The ink is centred in its widget rather than filling it: a glyph is a
+/// click target as well as a drawing, and sixteen pixels square is the smaller
+/// of those two jobs done. \see GlyphPainter, every entry point of which insets
+/// to the size below before drawing.
+namespace GlyphStyle
+{
+/// \name The widgets the marks are drawn in
+///
+/// \note All one height, which is the row's. The widths differ because the
+/// marks do: what they have in common is that each is a little wider than its
+/// ink, so that a pointer aimed at a five pixel arrowhead lands on something.
+///
+/// \note The row itself was already there -- twenty pixels between the bottom
+/// of the Save row's frame and the top of the list's -- and held the "Ignore
+/// external audio" toggle. \see PresetBrowser's constructor for the four x
+/// positions, which sit with every other placement in that panel.
+///@{
+int constexpr rowTop{58};
+int constexpr rowHeight{16};
+int constexpr upWidgetWidth{16};
+int constexpr userWidgetWidth{17};
+int constexpr jogWidgetWidth{11};
+///@}
+
+/// \brief The padlock, which is not in that row: it is the editor's, beside the
+/// sidechain source. \see BackgroundPainter::sideChainLockBounds().
+///@{
+int constexpr lockWidgetWidth{14};
+int constexpr lockWidgetHeight{16};
+///@}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \name Up one folder
+///
+///   A stem with an arrowhead on top of it and a foot turning right at the
+/// bottom, which is what the issue drew as
+///
+///     ^
+///     |
+///     +--
+///
+////////////////////////////////////////////////////////////////////////////////
+///@{
+float constexpr upWidth{10.0f};
+float constexpr upHeight{10.7f};
+/// The stem and the foot, which are one pen.
+float constexpr upStroke{2.4f};
+float constexpr upHeadWidth{5.4f};
+float constexpr upHeadHeight{4.7f};
+///@}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \name The user
+///
+///   A head over a pair of shoulders, and nothing else -- the issue asked for
+/// the simplified mark rather than the stylised one.
+////////////////////////////////////////////////////////////////////////////////
+///@{
+float constexpr userHeadDiameter{6.0f};
+float constexpr userBodyWidth{9.4f};
+float constexpr userBodyHeight{3.4f};
+/// \note Not half the height: at half, the shoulders come out a capsule. The
+/// mock-up rounds the top two corners hard and leaves the foot nearly square,
+/// which is the difference between shoulders and a pill.
+float constexpr userBodyRadius{1.4f};
+/// The neck, which is the whole of what makes the two shapes read as one.
+float constexpr userGap{1.3f};
+///@}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \name The jog
+///
+///   Two triangles pointing away from each other, one per button. Each is
+/// centred in its own widget and the widgets abut, so what separates them is
+/// the pair of insets and nothing else -- which is what makes the two read as
+/// one control rather than as two buttons that happen to be near each other.
+////////////////////////////////////////////////////////////////////////////////
+///@{
+float constexpr jogTriangle{9.4f}; ///< as wide as it is tall
+///@}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \name The folder in front of a directory's name in the list
+///
+/// \note juce::LookAndFeel::getDefaultFolderImage() until now, which JUCE 8
+/// answers with a Drawable, may answer with nothing at all, and draws in
+/// whatever its own look and feel says rather than in this skin's accent.
+////////////////////////////////////////////////////////////////////////////////
+///@{
+float constexpr folderWidth{11.0f};
+float constexpr folderHeight{9.0f};
+/// The tab along the back of it: how much of the width it takes and how far it
+/// stands above the body.
+///@{
+float constexpr folderTabWidth{4.6f};
+float constexpr folderTabRise{2.0f};
+///@}
+float constexpr folderCornerRadius{1.2f};
+///@}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \name The padlock that says a preset may not bring its own audio file
+///
+///   A body with a shackle standing on it. Shut and open are the same drawing
+/// -- what says which is the colour, as everywhere else in this row.
+////////////////////////////////////////////////////////////////////////////////
+///@{
+float constexpr lockWidth{9.4f};
+float constexpr lockHeight{10.7f};
+float constexpr lockBodyHeight{6.0f};
+/// The shackle, measured down the middle of its wire rather than around the
+/// outside of it, because that is what a stroked path is placed by.
+///@{
+float constexpr lockShackleWidth{5.3f};
+float constexpr lockShackleStroke{1.4f};
+///@}
+float constexpr lockCornerRadius{1.1f};
+///@}
+} // namespace GlyphStyle
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \class GlyphPainter
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class GlyphPainter
+{
+  public:
+    /// \brief Up one folder: draws GlyphStyle's arrow centred in \p bounds.
+    static void paintFolderUp(juce::Graphics &, juce::Rectangle<float> bounds, juce::Colour);
+
+    /// \brief A head and shoulders, centred in \p bounds.
+    static void paintUser(juce::Graphics &, juce::Rectangle<float> bounds, juce::Colour);
+
+    /// \brief One half of the jog, centred in \p bounds.
+    static void paintJog(juce::Graphics &, juce::Rectangle<float> bounds, bool pointsRight,
+                         juce::Colour);
+
+    /// \brief The mark in front of a directory in the preset list.
+    static void paintFolder(juce::Graphics &, juce::Rectangle<float> bounds, juce::Colour);
+
+    /// \brief A padlock, centred in \p bounds.
+    static void paintLock(juce::Graphics &, juce::Rectangle<float> bounds, juce::Colour);
+
+  public:
+    GlyphPainter() = delete; // a drawing, not an object
+}; // class GlyphPainter
+
+} // namespace LE::SW::GUI
+
+#endif // glyphPainter_hpp

--- a/src/gui/preset_browser/presetBrowser.cpp
+++ b/src/gui/preset_browser/presetBrowser.cpp
@@ -53,7 +53,10 @@ PresetBrowser::PresetBrowser()
       delete_(*this, "Delete", 54, 22, false),
       browseArrow_(*this, ArrowStyle::stepWidth, ArrowStyle::stepHeight, false,
                    ColourMap::MouseOverGlow),
-      ignoreExternalSamples_(*this, 15, 58, "Ignore external audio"), ignoreSelectionChange_(false),
+      upFolder_(*this, GlyphButton::Glyph::FolderUp),
+      userPresets_(*this, GlyphButton::Glyph::User, true /*toggles*/),
+      jogPrevious_(*this, GlyphButton::Glyph::JogPrevious),
+      jogNext_(*this, GlyphButton::Glyph::JogNext), ignoreSelectionChange_(false),
       addOneRow_(false), newPresetPending_(false), dirtyCommentPresetIndex_(-1)
 {
     listBox_.setModel(this);
@@ -61,10 +64,9 @@ PresetBrowser::PresetBrowser()
     setSizeFromPanel();
 
     /// \note All three start disabled and refresh() decides Save-As from there.
-    /// It used to be settled once, here, where location_ is still its default
-    /// Root -- so it was disabled before the browser had ever listed anything
-    /// and nothing re-enabled it. Save-As was unclickable for the life of the
-    /// plugin.
+    /// It used to be settled once, here, before the browser had ever listed
+    /// anything, and nothing re-enabled it: Save-As was unclickable for the
+    /// life of the plugin.
     ///                                       (01.08.2026.) (SW port)
     save_.setEnabled(false);
     saveAs_.setEnabled(false);
@@ -75,20 +77,35 @@ PresetBrowser::PresetBrowser()
 
     browseArrow_.addListener(this);
 
+    upFolder_.addListener(this);
+    userPresets_.addListener(this);
+    jogPrevious_.addListener(this);
+    jogNext_.addListener(this);
+
     /// \note Here rather than at the first save: an empty browser with no way
     /// to make a folder is not a usable answer to "you have no presets yet".
     GUI::createUserPresetsFolder();
 
-    /// \note Where it was last left, and the root -- "Factory" and "User" --
-    /// the first time, rather than the user's folder. A new installation's user
-    /// folder is empty, and a browser that opens on nothing while 303 presets
-    /// sit in the binary is the state this was reported in.
+    /// \note Where it was last left, and the list of factory banks the first
+    /// time, rather than the user's folder. A new installation's user folder is
+    /// empty, and a browser that opens on nothing while 303 presets sit in the
+    /// binary is the state this was reported in.
     restoreLastPlace();
 
     browseArrow_.setTopLeftPosition(174, 10);
     save_.setTopLeftPosition(14, 30);
     saveAs_.setTopLeftPosition(14 + 55, 30);
     delete_.setTopLeftPosition(14 + 55 + 55, 30);
+
+    /// \note The navigation row, in the gap the panel already had between the
+    /// Save buttons and the list. The four x positions are issue #44's mock-up
+    /// measured off it: up against the list's left frame, the user centred on
+    /// the panel, and the jog's two halves abutting against its right frame.
+    upFolder_.setTopLeftPosition(10, GlyphStyle::rowTop);
+    userPresets_.setTopLeftPosition(87, GlyphStyle::rowTop);
+    jogPrevious_.setTopLeftPosition(155, GlyphStyle::rowTop);
+    jogNext_.setTopLeftPosition(jogPrevious_.getRight() + 1, GlyphStyle::rowTop);
+
     listBox_.setBounds(11, 79, getWidth() - 22, 234);
     comment().setBounds(8, 322, getWidth() - 13, 29);
 
@@ -156,7 +173,8 @@ PresetBrowser::Place &PresetBrowser::lastPlace()
 /// \note Validated rather than trusted. A remembered folder is a path from a
 /// previous run of the host and the user may have moved or deleted it since, and
 /// a remembered bank is a name that a later build need not still ship. Either
-/// way the answer is the root, which is the one place that is always there.
+/// way the answer is the top of the factory tree, which is the one listing that
+/// is always there and never empty.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -166,9 +184,6 @@ void PresetBrowser::restoreLastPlace()
 
     switch (place.location)
     {
-    case Location::Root:
-        break;
-
     case Location::Factory:
         return setFactoryBank(place.factoryBank);
 
@@ -178,7 +193,7 @@ void PresetBrowser::restoreLastPlace()
         break;
     }
 
-    setRoot();
+    setFactoryBank({});
 }
 
 PresetBrowser::~PresetBrowser()
@@ -231,9 +246,9 @@ void PresetBrowser::presetSelectionChanged()
     delete_.setEnabled(enablePresetSaving);
 
     auto const presetData(selectedPresetData());
-    bool const succeeded(presetData && editor().loadPreset(presetData.get(),
-                                                           ignoreExternalSamples_.getToggleState(),
-                                                           originalComment_, item.name));
+    bool const succeeded(presetData &&
+                         editor().loadPreset(presetData.get(), editor().ignoreExternalSample(),
+                                             originalComment_, item.name));
 
     if (!succeeded)
     {
@@ -310,14 +325,6 @@ void PresetBrowser::listBoxItemDoubleClicked(int const row, juce::MouseEvent con
     Item const &item(this->item(row));
     switch (item.kind)
     {
-    case Item::Kind::Parent:
-        return goToParent();
-
-    case Item::Kind::Section:
-        if (item.name == "Factory")
-            return setFactoryBank({});
-        return setNewFolder(GUI::presetsFolder());
-
     case Item::Kind::Folder:
         if (inFactory())
             return setFactoryBank(factoryBank_.isEmpty() ? item.name
@@ -363,28 +370,16 @@ void PresetBrowser::paintListBoxItem(int const rowNumber, juce::Graphics &graphi
 
     unsigned int const x(isDirectory ? 16 : 4);
 
-    graphics.setColour(ColourMap::getColour(ColourMap::Ground));
-
+    /// \note Drawn rather than asked for. This was
+    /// `Theme::getDefaultFolderImage()`, which JUCE 8 answers with a Drawable,
+    /// may answer with nothing at all, and draws in its own look and feel's
+    /// colours rather than in this skin's -- so the one mark in the panel that
+    /// did not follow the palette was the folder. \see GlyphPainter.
     if (isDirectory)
-    {
-        //...mrmlj...
-        //paintImage
-        //(
-        //    graphics,
-        //    Theme::singleton().Theme::getDefaultFolderImage(),
-        //    2, 2
-        //);
-        /// \note JUCE 8's getDefaultFolderImage() returns a Drawable rather than
-        /// an Image, and may return nothing at all.
-        if (auto const *const pFolderImage = Theme::singleton().Theme::getDefaultFolderImage())
-            pFolderImage->drawWithin(
-                graphics,
-                juce::Rectangle<float>(2.0f, 2.0f, static_cast<float>(x) - 4.0f,
-                                       static_cast<float>(height) - 4.0f),
-                juce::RectanglePlacement::xLeft | juce::RectanglePlacement::xRight |
-                    juce::RectanglePlacement::onlyReduceInSize,
-                1.0f);
-    }
+        GlyphPainter::paintFolder(graphics,
+                                  juce::Rectangle<float>(2.0f, 0.0f, static_cast<float>(x) - 4.0f,
+                                                         static_cast<float>(height)),
+                                  ColourMap::getColour(ColourMap::Accent));
 
     graphics.setColour(Theme::singleton().Theme::findColour(
         juce::DirectoryContentsDisplayComponent::textColourId));
@@ -624,7 +619,7 @@ void PresetBrowser::saveCurrentPreset(juce::String const &presetName, fs::path c
     bool const shouldRefresh(!std::filesystem::exists(targetFile, error));
 
     originalComment_ = comment().getText();
-    editor().savePreset(targetFile, ignoreExternalSamples_.getToggleState(), originalComment_);
+    editor().savePreset(targetFile, editor().ignoreExternalSample(), originalComment_);
 
     if (shouldRefresh)
         refreshAndSelectPreset(presetName);
@@ -699,6 +694,28 @@ void PresetBrowser::buttonClicked(juce::Button *const pButton)
 
         showFilenameEditBox(newPreset, PresetBrowser::getNumRows());
         return;
+    }
+    else if (pButton == &upFolder_)
+    {
+        goToParent();
+    }
+    else if (pButton == &userPresets_)
+    {
+        /// \note The toggle state is already the new one -- juce::Button flips
+        /// it before it tells its listeners -- so this reads the answer rather
+        /// than deciding it, and updateNavigation() will agree with it.
+        if (userPresets_.getToggleState())
+            setNewFolder(GUI::presetsFolder());
+        else
+            setFactoryBank({});
+    }
+    else if (pButton == &jogPrevious_)
+    {
+        stepPreset(-1);
+    }
+    else if (pButton == &jogNext_)
+    {
+        stepPreset(+1);
     }
     else
     {
@@ -820,15 +837,6 @@ void PresetBrowser::setFactoryBank(juce::String const &bank)
     background().repaint();
 }
 
-void PresetBrowser::setRoot()
-{
-    location_ = Location::Root;
-    factoryBank_.clear();
-    deselectAllRows();
-    refresh();
-    background().repaint();
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 // PresetBrowser::goToParent()
@@ -842,32 +850,128 @@ void PresetBrowser::setRoot()
 /// a folder was the browse arrow and a native file dialog.
 ///                                           (31.07.2026.) (SW port)
 ///
+/// \note Up out of the top of a tree is *nowhere*, where it used to be the
+/// root's two-word listing. That listing is gone (\see Location) and the
+/// button that reaches this is disabled there, so the guard below is what
+/// makes those two statements one.
+///                                           (19.08.2026.) issue #44
+///
 ////////////////////////////////////////////////////////////////////////////////
 
 void PresetBrowser::goToParent()
 {
-    switch (location_)
-    {
-    case Location::Root:
+    if (atTopOfTree())
         return;
 
+    switch (location_)
+    {
     case Location::Factory:
     {
-        if (factoryBank_.isEmpty())
-            return setRoot();
         auto const separator(factoryBank_.lastIndexOfChar('/'));
         return setFactoryBank(separator < 0 ? juce::String()
                                             : factoryBank_.substring(0, separator));
     }
 
     case Location::User:
-        /// \note Up out of the user's own preset folder is the root rather than
-        /// the rest of the filesystem. Somewhere above `~/Documents` there is
-        /// nothing a preset browser should be showing.
-        if (currentDirectory_ == GUI::presetsFolder())
-            return setRoot();
         return setNewFolder(currentDirectory_.parent_path());
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// PresetBrowser::atTopOfTree()
+// ----------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The second `User` test is for the browse arrow, which can put
+/// `currentDirectory_` anywhere on the volume: from outside the preset root
+/// the walk up never reaches it, and without a second stop the user can climb
+/// out of their home directory a click at a time. `parent_path()` of a root is
+/// that root, which is what says there is no further to go.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+bool PresetBrowser::atTopOfTree() const
+{
+    if (location_ == Location::Factory)
+        return factoryBank_.isEmpty();
+
+    return (currentDirectory_ == GUI::presetsFolder()) ||
+           (currentDirectory_.parent_path() == currentDirectory_);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// PresetBrowser::stepPreset()
+// ---------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The presets are the tail of the listing, and that is not an assumption
+/// -- `Item::operator<` sorts by kind first and `Folder` sorts before `Preset`,
+/// so one index says where the folders stop.
+///
+/// \note Selecting the row is the whole of the action: `selectedRowsChanged()`
+/// is what loads a preset, and going through it is what makes a jog step and a
+/// click the same thing as far as everything downstream is concerned.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void PresetBrowser::stepPreset(int const direction)
+{
+    if (!canStep(direction))
+        return; // and the button that reaches this is disabled there
+
+    int const next(listBox_.getLastRowSelected() + direction);
+    listBox_.selectRow(next);
+    listBox_.scrollToEnsureRowIsOnscreen(next);
+}
+
+bool PresetBrowser::presetIsSelected() const
+{
+    int const selected(listBox_.getLastRowSelected());
+
+    /// \note The upper bound is not paranoia: addOneRow_ puts a row in the list
+    /// that `files_` has no entry for while the filename edit box is up.
+    return (selected >= 0) && (selected < files_.size()) &&
+           !files_.getReference(selected).isDirectory();
+}
+
+bool PresetBrowser::canStep(int const direction) const
+{
+    if (!presetIsSelected())
+        return false;
+
+    int const next(listBox_.getLastRowSelected() + direction);
+
+    /// \note Off the end of the listing, or onto a folder -- which, because the
+    /// folders sort first, is what stepping back past the first preset is.
+    return (next >= 0) && (next < files_.size()) && !files_.getReference(next).isDirectory();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// PresetBrowser::updateNavigation()
+// ---------------------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Reached from refresh(), which every move between folders comes through,
+/// and from selectedRowsChanged(), which every move within one does. The jog
+/// needs the second: where the browser is has not changed when a row is clicked,
+/// and whether the jog has anywhere to go has -- each half of it separately,
+/// because the first preset in a listing has a forward and no back.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void PresetBrowser::updateNavigation()
+{
+    upFolder_.setEnabled(!atTopOfTree());
+    userPresets_.setToggleState(location_ == Location::User, juce::dontSendNotification);
+
+    jogPrevious_.setEnabled(canStep(-1));
+    jogNext_.setEnabled(canStep(+1));
 }
 
 SpectrumWorxEditor &PresetBrowser::editor()
@@ -884,6 +988,12 @@ SpectrumWorxEditor const &PresetBrowser::editor() const
 void PresetBrowser::selectedRowsChanged(int const lastRowSelected)
 {
     saveDirtyComment();
+
+    /// \note Before the two early exits below, not after them: what the jog can
+    /// do depends on the selection whether or not this browser is the one that
+    /// asked for the change, and deselecting is exactly the case that turns it
+    /// off. \see updateNavigation().
+    updateNavigation();
 
     if (ignoreSelectionChange_ || (lastRowSelected == -1))
         return;
@@ -902,9 +1012,8 @@ int PresetBrowser::getNumRows() noexcept { return files_.size() + addOneRow_; }
 //
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note Three listings, because there are three things to list: two fixed
-/// entries at the root, a bank out of the binary, or a directory. Only the last
-/// is what this browser used to do.
+/// \note Two listings, because there are two things to list: a bank out of the
+/// binary, or a directory. Only the second is what this browser used to do.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -914,9 +1023,6 @@ void PresetBrowser::refresh()
 
     switch (location_)
     {
-    case Location::Root:
-        refreshRoot();
-        break;
     case Location::Factory:
         refreshFactory();
         break;
@@ -929,17 +1035,13 @@ void PresetBrowser::refresh()
 
     /// \note Save-As is the one button that depends on *where* the browser is
     /// rather than on what is selected in it, so this is where it belongs: the
-    /// three location setters all come through here, and so does
+    /// two location setters both come through here, and so does
     /// refreshAndSelectPreset(). save_ and delete_ stay with the selection.
     saveAs_.setEnabled(enablePresetSaving());
 
-    listBox_.updateContent();
-}
+    updateNavigation();
 
-void PresetBrowser::refreshRoot()
-{
-    files_.add(Item{"Factory", Item::Kind::Section});
-    files_.add(Item{"User", Item::Kind::Section});
+    listBox_.updateContent();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -963,8 +1065,6 @@ void PresetBrowser::refreshRoot()
 
 void PresetBrowser::refreshFactory()
 {
-    files_.add(Item{"..", Item::Kind::Parent});
-
     juce::String const prefix(factoryBank_.isEmpty() ? juce::String() : factoryBank_ + "/");
 
     for (auto const &bank : FactoryPresets::banks())
@@ -1014,8 +1114,6 @@ void PresetBrowser::refreshFactory()
 
 void PresetBrowser::refreshUserDirectory()
 {
-    files_.add(Item{"..", Item::Kind::Parent});
-
     std::error_code listingError;
     Item item;
     for (auto const &entry : std::filesystem::directory_iterator(currentDirectory_, listingError))
@@ -1099,9 +1197,6 @@ juce::String PresetBrowser::locationLabel() const
 {
     switch (location_)
     {
-    case Location::Root:
-        return _T( "Presets" );
-
     case Location::Factory:
         return factoryBank_.isEmpty() ? juce::String(_T( "Factory" ))
                                       : _T( "Factory/" ) + factoryBank_;

--- a/src/gui/preset_browser/presetBrowser.hpp
+++ b/src/gui/preset_browser/presetBrowser.hpp
@@ -88,31 +88,38 @@ class PresetBrowser final : public PanelBackground,
     ///
     /// \enum Location
     ///
-    /// \brief Which of the three things the list is showing.
+    /// \brief Which of the two trees the list is showing.
     ///
     /// \note The browser was a directory browser: one `juce::File` and
     /// `std::filesystem` over it. The factory banks are in the binary now (8.2)
     /// and have no directory to point it at, so where it is looking became a
-    /// small sum type rather than a path. `Root` is a list of two entries and
-    /// exists so that there is somewhere `..` can go from either tree.
+    /// small sum type rather than a path.
     ///                                       (31.07.2026.) (SW port)
+    ///
+    /// \note There was a third, `Root`, whose listing was the two words
+    /// "Factory" and "User" -- so opening the browser showed a plugin with 303
+    /// presets in it two rows and no preset names, and every session began with
+    /// two clicks that told the user nothing. The trees are a *toggle* now, in
+    /// the navigation row, and the browser opens inside one of them.
+    ///                                       (19.08.2026.) issue #44
     ///
     ////////////////////////////////////////////////////////////////////////////
 
     enum struct Location : std::uint8_t
     {
-        Root,    ///< "Factory" and "User"; no storage behind it
         Factory, ///< an embedded bank, addressed by factoryBank_. Read only.
         User     ///< a real directory, addressed by currentDirectory_
     };
 
     struct Item
     {
+        /// \note `Parent` -- the ".." row -- went with `Root`: the up button
+        /// owns going up now, and a list whose first row is punctuation is a
+        /// row of preset names lost to a control that has somewhere better to
+        /// be. \see issue #44.
         enum struct Kind : std::uint8_t
         {
-            Parent,  ///< the ".." row
-            Section, ///< "Factory" or "User", only at the Root
-            Folder,  ///< a bank or a sub-directory
+            Folder, ///< a bank or a sub-directory
             Preset
         };
 
@@ -133,12 +140,51 @@ class PresetBrowser final : public PanelBackground,
 
   private:
     void setNewFolder(fs::path const &);
-    void setRoot();
 
-    /// \brief Up one level, wherever "up" is from here.
+    /// \brief Up one level, wherever "up" is from here. Does nothing at the top
+    /// of either tree, which is also where the up button is disabled.
     void goToParent();
 
-    /// \brief What the header strip says, for whichever of the three it is
+    /// \brief Whether this is the top of the tree it is in -- the bank list, or
+    /// the user's own preset folder.
+    bool atTopOfTree() const;
+
+    /// \brief Whether the selected row is a preset, which is what the jog needs
+    /// to have somewhere to step *from*. A folder row, or no row at all, is not
+    /// one. \see canStep().
+    bool presetIsSelected() const;
+
+    /// \brief Whether stepPreset( \p direction ) would move: there is a preset
+    /// selected and another one that way.
+    ///
+    /// \note One predicate for the two questions the jog asks -- "may I be
+    /// pressed" and "is there anything to do" -- so that a lit button that does
+    /// nothing is not a state this can reach. \see updateNavigation().
+    bool canStep(int direction) const;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The previous or next preset in this listing, selected as though
+    /// the user had clicked it.
+    ///
+    /// \param direction -1 or +1.
+    ///
+    /// \note Clamped rather than wrapped, and folders are not stepped onto:
+    /// what a jog is for is hearing the presets in a bank one after another,
+    /// and both of those would interrupt that. Neither is a case this has to
+    /// handle gracefully, because canStep() has already disabled the button --
+    /// at the first preset in a listing the back arrow is dead and at the last
+    /// one the forward arrow is.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    void stepPreset(int direction);
+
+    /// \brief Points the navigation row at where the browser now is. Called by
+    /// refresh(), which every move comes through.
+    void updateNavigation();
+
+    /// \brief What the header strip says, for whichever of the two it is
     /// showing. Only `User` has a path to print.
     juce::String locationLabel() const;
 
@@ -153,7 +199,7 @@ class PresetBrowser final : public PanelBackground,
     /// has to outlive it. It used to be half remembered: the destructor wrote
     /// `currentDirectory_` into `GUI::presetsFolder()` and nothing recorded
     /// `location_`, which is a member initialiser, so the browser reopened at
-    /// `Root` whatever the user had been looking at. Writing the user's
+    /// the root whatever the user had been looking at. Writing the user's
     /// wanderings into `presetsFolder()` also moved the anchor `goToParent()`
     /// stops at and the folder `createUserPresetsFolder()` makes; that global
     /// means the preset root now and nothing writes to it.
@@ -163,7 +209,7 @@ class PresetBrowser final : public PanelBackground,
 
     struct Place
     {
-        Location location{Location::Root};
+        Location location{Location::Factory};
         juce::String factoryBank; ///< when location is Factory
         fs::path folder;          ///< when location is User
     };
@@ -172,7 +218,6 @@ class PresetBrowser final : public PanelBackground,
     void restoreLastPlace();
 
     void refresh();
-    void refreshRoot();
     void refreshFactory();
     void refreshUserDirectory();
 
@@ -228,7 +273,17 @@ class PresetBrowser final : public PanelBackground,
     PaintedButton saveAs_;
     PaintedButton delete_;
     ArrowButton browseArrow_;
-    LEDTextButton ignoreExternalSamples_;
+
+    /// \name The navigation row, between the Save buttons and the list
+    ///
+    /// \note Issue #44's. The row is where "Ignore external audio" was; that
+    /// toggle is the editor's lock beside the sidechain source now.
+    ///@{
+    GlyphButton upFolder_;
+    GlyphButton userPresets_;
+    GlyphButton jogPrevious_;
+    GlyphButton jogNext_;
+    ///@}
 
     bool ignoreSelectionChange_;
     bool addOneRow_;
@@ -236,7 +291,7 @@ class PresetBrowser final : public PanelBackground,
 
     int dirtyCommentPresetIndex_;
 
-    Location location_{Location::Root};
+    Location location_{Location::Factory};
 
     /// The bank, relative to the preset root, when location_ is Factory. Empty
     /// means the top of the factory tree.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ add_executable(sw-plugin-tests
         gui/overlayPanelTests.cpp
         gui/paletteTests.cpp
         gui/pathsTests.cpp
+        gui/presetNavigationTests.cpp
         gui/preferencesTests.cpp
         gui/sideChainSelectorTests.cpp
         gui/skinTests.cpp

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -69,8 +69,28 @@ class SilentNotifications final : public Plugin2HostInteropControler
 class Instance final : public GUI::EditorHost
 {
   public:
-    Instance()
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \param setUpEngine false for an engine that has never been given a
+    /// sample rate, which is what a plugin looks like before the host activates
+    /// it -- and the one state in which a case may *load a preset*.
+    ///
+    /// \note Loading reaches SpectrumWorxCore::engineSetup(), which asserts
+    /// unless the engine is already running at the FFT size the preset asks
+    /// for. Re-setting it up is the CLAP layer's job and there is no CLAP layer
+    /// here, so what makes the assertion legal is its third term: storage
+    /// factors that are not complete. \see spectrumWorxCore.cpp.
+    ///
+    /// \note show-ui's EditorPage takes the same argument as a sample rate of
+    /// zero, for the same reason.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    explicit Instance(bool const setUpEngine = true)
     {
+        if (!setUpEngine)
+            return;
+
         engine_.setNumberOfChannels(2, 2);
         engine_.setSampleRate(48000);
         engine_.setBlockSize(512);

--- a/tests/gui/presetNavigationTests.cpp
+++ b/tests/gui/presetNavigationTests.cpp
@@ -1,0 +1,351 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// presetNavigationTests.cpp
+/// -------------------------
+///
+///   The preset browser's navigation row, which issue #44 put where "Ignore
+/// external audio" used to be: up a folder, a User toggle, and a jog that steps
+/// between the presets in whatever is listed.
+///
+///   And the thing the row exists to make possible: the browser opens *inside*
+/// a tree rather than on a two-row listing of the word "Factory" and the word
+/// "User". That was the report -- a plugin with 303 presets in it showed two
+/// rows and no preset names, every time the window opened.
+///
+/// \note Through the list box and the buttons rather than through pixels, unlike
+/// overlayPanelTests.cpp beside it. What is being asked here is "which rows are
+/// there and which one is selected", and the model answers that exactly; a
+/// render would answer it by proxy and fail for a dozen reasons that are not
+/// this.
+///
+/// \note `mouseDown` and `mouseUp` rather than `triggerClick()`: JUCE 8 posts
+/// the latter through the message queue, and there is no loop running one in a
+/// test binary.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module, as overlayPanelTests.cpp does:
+/// the module chain downcasts a node to it.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "gui/gui.hpp"
+#include "le/spectrumworx/factoryPresets.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+using Editor = GUI::SpectrumWorxEditor;
+
+/// Every descendant of \p root that is a \p Widget, in child order.
+template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Component &root)
+{
+    std::vector<Widget *> found;
+    for (auto *const pChild : root.getChildren())
+    {
+        if (auto *const pWidget(dynamic_cast<Widget *>(pChild)); pWidget)
+            found.push_back(pWidget);
+        for (auto *const pDeeper : descendantsOfType<Widget>(*pChild))
+            found.push_back(pDeeper);
+    }
+    return found;
+}
+
+/// \brief The browser's list, which is the only one in the editor.
+juce::ListBox &listOf(Editor &editor)
+{
+    auto const lists(descendantsOfType<juce::ListBox>(editor));
+    REQUIRE(lists.size() == 1);
+    return *lists.front();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \enum Nav
+///
+/// \brief The navigation row, by position in it.
+///
+/// \note The order is the order the four are constructed in, which is also left
+/// to right. Both are asserted below rather than assumed: a fifth glyph, or a
+/// reordering, should fail here and not silently send the rest of a case at the
+/// wrong button.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+enum Nav
+{
+    Up,
+    User,
+    JogPrevious,
+    JogNext,
+    numberOfNavButtons
+};
+
+std::vector<GUI::GlyphButton *> navigationRow(Editor &editor)
+{
+    /// \note Told from the editor's own lock -- "ignore external audio", beside
+    /// the sidechain source, which is a GlyphButton too -- by its parent rather
+    /// than by its index: these four are on the browser panel and that one is
+    /// not.
+    auto *const pPanel(listOf(editor).getParentComponent());
+
+    std::vector<GUI::GlyphButton *> inBrowser;
+    for (auto *const pButton : descendantsOfType<GUI::GlyphButton>(editor))
+        if (pButton->getParentComponent() == pPanel)
+            inBrowser.push_back(pButton);
+
+    REQUIRE(inBrowser.size() == numberOfNavButtons);
+    for (unsigned int button(1); button < numberOfNavButtons; ++button)
+        REQUIRE(inBrowser[button - 1]->getX() < inBrowser[button]->getX());
+
+    return inBrowser;
+}
+
+/// \brief Presses \p button as a user does, synchronously.
+///
+/// \note Half a mouse, as tests/gui/moduleControlFocusTests.cpp explains at
+/// length: JUCE tracks a gesture in the MouseInputSource and nothing here
+/// touches that. Enough for a button, which acts on the release.
+void click(juce::Button &button)
+{
+    auto const centre(button.getLocalBounds().getCentre().toFloat());
+    juce::MouseEvent const press(juce::Desktop::getInstance().getMainMouseSource(), centre,
+                                 juce::ModifierKeys(juce::ModifierKeys::leftButtonModifier), 1.0f,
+                                 0.0f, 0.0f, 0.0f, 0.0f, &button, &button, juce::Time(), centre,
+                                 juce::Time(), 1, false);
+    /// \note Through the Component, because juce::Button narrows these two to
+    /// protected -- a button expects to be pressed by JUCE and not by its
+    /// neighbours. The base class's declaration is the public one.
+    auto &component(static_cast<juce::Component &>(button));
+    component.mouseDown(press);
+    component.mouseUp(press);
+}
+
+/// How many rows the browser is listing.
+int rowCount(Editor &editor) { return listOf(editor).getListBoxModel()->getNumRows(); }
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief How many banks the top of the factory tree has: the entries in
+/// FactoryPresets::banks() with no separator in them.
+///
+/// \note Counted here rather than written down, so that adding a bank to the
+/// binary does not fail these cases. What they are about is that the browser
+/// lists *the banks* rather than the word "Factory", and that is a comparison
+/// against this number and not against a literal.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+int topLevelBankCount()
+{
+    int banks(0);
+    for (auto const &bank : FactoryPresets::banks())
+        banks += (bank.find('/') == std::string::npos);
+    return banks;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The browser, opened on \p instance with the panels over the strips, at
+/// the top of the factory tree.
+///
+/// \note Put there rather than found there. Where the browser was last left is
+/// *process-wide* -- PresetBrowser::lastPlace(), which is what makes a second
+/// instance open where the first one was -- so in one test binary each case
+/// inherits wherever the previous one wandered to. Two cases here failed on
+/// that and neither was about it.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+Editor &browserEditor(SWTest::Instance &instance)
+{
+    instance.openEditor(Editor::PanelPlacement::overlay);
+    auto &editor(instance.editor());
+    editor.showFactoryBank({});
+    return editor;
+}
+
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// The reported bug: the browser opened on two words.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The preset browser opens inside the factory tree", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(browserEditor(instance));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Against the *banks*, which is the number this has to be: "more than
+    /// two" would pass on the root listing plus a `..` row, which is exactly the
+    /// state being fixed.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK(rowCount(editor) == topLevelBankCount());
+}
+
+TEST_CASE("Up is disabled at the top of a tree and enabled below it", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(browserEditor(instance));
+
+    auto const row(navigationRow(editor));
+
+    CHECK_FALSE(row[Up]->isEnabled());
+
+    editor.showFactoryBank("Echoes");
+    CHECK(row[Up]->isEnabled());
+
+    //   ...and it goes back up to the bank list rather than to a root listing.
+    click(*row[Up]);
+    CHECK_FALSE(row[Up]->isEnabled());
+    CHECK(rowCount(editor) == topLevelBankCount());
+}
+
+TEST_CASE("The User toggle swaps trees and says which one is showing", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(browserEditor(instance));
+
+    auto const row(navigationRow(editor));
+
+    CHECK_FALSE(row[User]->getToggleState());
+    auto const factoryRows(rowCount(editor));
+
+    click(*row[User]);
+    CHECK(row[User]->getToggleState());
+    //   A fresh user folder is empty, and that is the point: the toggle went
+    //   somewhere other than the factory banks.
+    CHECK(rowCount(editor) != factoryRows);
+
+    click(*row[User]);
+    CHECK_FALSE(row[User]->getToggleState());
+    CHECK(rowCount(editor) == factoryRows);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// The jog
+//
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// The jog
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note These select rows, and selecting a preset *loads* it -- so they take
+/// an Instance whose engine was never set up. \see the note on that argument in
+/// editorHarness.hpp; the short version is that re-setting the engine up for a
+/// preset's FFT size is the CLAP layer's job and there is no CLAP layer here.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The jog is dead until a preset is selected", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+    auto &editor(browserEditor(instance));
+
+    auto const row(navigationRow(editor));
+
+    REQUIRE(rowCount(editor) == topLevelBankCount()); // the banks, and nothing else
+    REQUIRE(listOf(editor).getLastRowSelected() == -1);
+
+    CHECK_FALSE(row[JogPrevious]->isEnabled());
+    CHECK_FALSE(row[JogNext]->isEnabled());
+
+    //   ...and inside a bank, where there *are* presets but none of them is the
+    // one being listened to yet.
+    editor.showFactoryBank("Echoes");
+
+    REQUIRE(rowCount(editor) > 0);
+    REQUIRE(listOf(editor).getLastRowSelected() == -1);
+
+    CHECK_FALSE(row[JogPrevious]->isEnabled());
+    CHECK_FALSE(row[JogNext]->isEnabled());
+}
+
+TEST_CASE("Each jog arrow is dead at its own end of the folder", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance(false /*an engine that was never set up*/);
+    auto &editor(browserEditor(instance));
+
+    editor.showFactoryBank("Echoes");
+    auto const row(navigationRow(editor));
+    auto &list(listOf(editor));
+
+    auto const presets(rowCount(editor)); // a bank holds no sub-folders
+    REQUIRE(presets > 2);
+
+    list.selectRow(0);
+    CHECK_FALSE(row[JogPrevious]->isEnabled()); // the first preset has no back
+    CHECK(row[JogNext]->isEnabled());
+
+    list.selectRow(presets - 1);
+    CHECK(row[JogPrevious]->isEnabled());
+    CHECK_FALSE(row[JogNext]->isEnabled()); // and the last one has no forward
+
+    list.selectRow(1);
+    CHECK(row[JogPrevious]->isEnabled());
+    CHECK(row[JogNext]->isEnabled());
+}
+
+TEST_CASE("The jog steps between the presets in a bank", "[gui][presets]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance(false /*an engine that was never set up*/);
+    auto &editor(browserEditor(instance));
+
+    editor.showFactoryBank("Echoes");
+    auto const row(navigationRow(editor));
+    auto &list(listOf(editor));
+
+    list.selectRow(0);
+
+    click(*row[JogNext]);
+    CHECK(list.getLastRowSelected() == 1);
+
+    click(*row[JogNext]);
+    CHECK(list.getLastRowSelected() == 2);
+
+    click(*row[JogPrevious]);
+    CHECK(list.getLastRowSelected() == 1);
+
+    click(*row[JogPrevious]);
+    CHECK(list.getLastRowSelected() == 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note Clamped rather than wrapped. The button is disabled here, so this
+    /// is belt and braces -- what it pins is that stepPreset() and the
+    /// enablement ask the same question, which is what canStep() is for.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    click(*row[JogPrevious]);
+    CHECK(list.getLastRowSelected() == 0);
+}


### PR DESCRIPTION
The browser opened on a listing of two words, "Factory" and "User", so a plugin with 303 presets in it showed no preset name until you had clicked twice -- and went back to showing none every time the window closed. It opens on the factory banks now, and the two trees are a toggle rather than a folder each.

The row between the Save buttons and the list holds three controls: up a folder, greyed at the top of either tree; the User toggle, white for the factory presets and the accent for your own; and a jog that steps through the presets in the current listing, each arrow dead at its own end of it and both dead until a preset is chosen.

The ".." row goes with the root it used to lead to, which gives the list back a row of preset names. The folder in front of a directory is drawn rather than taken from JUCE's look and feel, so it follows the palette like everything else in the panel.

"Ignore external audio" gave that row up and is the padlock beside Sidechain Source, which is what it has always been about. It belongs to the editor now, so it also outlives the browser being closed.

Closes #44

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>