### PR TITLE
Take the pixel nitpicks off the rescaled interface

### DIFF
--- a/src/gui/colourMap.cpp
+++ b/src/gui/colourMap.cpp
@@ -140,8 +140,12 @@ juce::Colour ColourMap::classic(Name const name)
         return juce::Colour(0xFFF2F2F2u);
     case EditorKnobRimOutline:
         return juce::Colour(0x9D000000u);
+    ///   The accent, where the artwork had #161616. A near-black bar over a
+    /// black cap and a ring that is nearly black at the bottom is a pointer
+    /// that disappears over most of its travel and reappears over the rest,
+    /// which is the one thing this mark exists not to do. \see issue #134.
     case EditorKnobPointer:
-        return juce::Colour(0xFF161616u);
+        return juce::Colour(0xFF13B5EAu);
 
     case ModuleKnobDomeCentre:
         return juce::Colour(0xFFB8B6B6u);

--- a/src/gui/colourMap.hpp
+++ b/src/gui/colourMap.hpp
@@ -94,7 +94,7 @@ class ColourMap
         EditorKnobTick,        ///< the eight fixed marks
         EditorKnobRim,         ///< the bright edge past the bevel
         EditorKnobRimOutline,  ///< and the dark line around it
-        EditorKnobPointer,     ///< the bar that turns
+        EditorKnobPointer,     ///< the bar that turns, in the accent
         ///@}
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2882,6 +2882,12 @@ void SpectrumWorxEditor::LFODisplay::paint(juce::Graphics &graphics)
                           text.height, text.justification, false);
     }
 
+    /// \note The well before the mark that goes in it, and both here rather
+    /// than in the chassis: this strip is on screen only while a control is
+    /// selected, and a pill sitting alone in an empty LFO box was what the
+    /// chassis drawing it looked like. \see issue #134.
+    BackgroundPainter::paintLFOWaveformWell(graphics, getPosition());
+
     // Null for an item with no icon; every LFO waveform has one.
     if (auto const *const icon(type_.getSelectedItemIcon()); icon != nullptr)
         paintImage(graphics, *icon, 119, 144);
@@ -3687,10 +3693,13 @@ void SpectrumWorxEditor::Settings::InterfacePage::paint(juce::Graphics &graphics
 class SettingsTab : public juce::TabBarButton
 {
   public:
+    /// \note `ownerBar.setTopLeftPosition( { 9, 9 } )` stood here and did
+    /// nothing: `TabbedComponent::resized()` runs after every `addTab()` and
+    /// puts the bar back in the corner. Where the bar goes is the panel's
+    /// question rather than a tab's -- \see Settings::resized().
     SettingsTab(juce::String const &tabName, juce::TabbedButtonBar &ownerBar)
         : TabBarButton(tabName, ownerBar)
     {
-        ownerBar.setTopLeftPosition({9, 9});
     }
 
   private:

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1226,24 +1226,41 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
       private: // JUCE component overrides.
         /// \note The strip the tabs stand in, and nothing else -- the pages are
-        /// children and paint themselves. It runs to the right edge of the last
-        /// tab, which is what makes the tabs read as sitting on the page rather
-        /// than as a bar across it. \see PanelPainter::paintTabStrip().
+        /// children and paint themselves. \see PanelPainter::paintTabStrip().
         void paint(juce::Graphics &graphics) override
         {
-            PanelPainter::paintTabStrip(graphics, {0.f, 0.f, static_cast<float>(tabStripWidth()),
-                                                   static_cast<float>(ButtonStyle::tabHeight)});
+            PanelPainter::paintTabStrip(graphics, getLocalBounds().toFloat());
         }
 
-        /// \brief Where the last tab ends, which is where the strip does.
-        int tabStripWidth()
+        ////////////////////////////////////////////////////////////////////////
+        ///
+        /// \brief TabbedComponent's, and then the tab bar put where the panel
+        /// wants it rather than in its corner.
+        ///
+        ///   A tab lines up with the frame below it -- PanelPainter::fieldInset
+        /// is the line both stand on -- and the row of them is centred in the
+        /// dark between the top of the panel and the top of that frame. JUCE
+        /// puts the bar flush against the top left, which is a pixel in from an
+        /// edge nothing else on either panel measures from. \see issue #134.
+        ///
+        /// \note And in front of the page, which it now overlaps: `changeCallback`
+        /// brings the page forward every time a tab is pressed, so this is the
+        /// only place the order can be settled.
+        ///
+        ////////////////////////////////////////////////////////////////////////
+        void resized() override
         {
+            juce::TabbedComponent::resized();
+
+            auto const strip(ButtonStyle::tabHeight + PanelPainter::settingsFrameTop);
+            auto const left(juce::roundToInt(PanelPainter::fieldInset - ButtonStyle::tabSideInset));
+            auto const top(juce::roundToInt((strip - ButtonStyle::tabHeight) / 2));
+
             auto &bar(getTabbedButtonBar());
-            auto const last(bar.getNumTabs() - 1);
-            if (auto const *const button = (last >= 0) ? bar.getTabButton(last) : nullptr)
-                return button->getRight();
-            return 0;
+            bar.setBounds(left, top, getWidth() - left, ButtonStyle::tabHeight);
+            bar.toFront(false);
         }
+
         juce::TabBarButton *createTabButton(juce::String const &tabName, int tabIndex) override;
 
       private: // JUCE ButtonListener overrides.

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1057,12 +1057,16 @@ LEDTextButton::LEDTextButton(juce::Component &parent, unsigned int const x, unsi
               ledHeight);
 }
 
+/// \note The caption sat at five and reads two low: seventeen pixels of line box
+/// in a twenty-one pixel widget centres at three, and where this button carries a
+/// frame -- ModuleLEDTextButton, which is what a TuneWorx semitone is -- it was
+/// two below the middle of that too. \see issue #134.
 void LEDTextButton::paintButton(juce::Graphics &g, bool const isMouseOverButton,
                                 bool const isButtonDown)
 {
     g.setColour(ColourMap::getColour(ColourMap::Text));
     g.setFont(DrawableText::defaultFont());
-    g.drawFittedText(getName(), ledWidth, 5, getWidth() - ledWidth, 17,
+    g.drawFittedText(getName(), ledWidth, 3, getWidth() - ledWidth, 17,
                      juce::Justification::horizontallyCentred, 1);
 
     paintCapsule(g, {0, 0, ledWidth, ledHeight}, isMouseOverButton, isButtonDown);

--- a/src/gui/painters/backgroundPainter.cpp
+++ b/src/gui/painters/backgroundPainter.cpp
@@ -233,6 +233,15 @@ juce::Rectangle<float> BackgroundPainter::sideChainLockBounds()
             GlyphStyle::lockHeight};
 }
 
+/// \note A rule and nothing else: what shows inside it is the LFO box it is cut
+/// into, which the chassis has already drawn.
+void BackgroundPainter::paintLFOWaveformWell(juce::Graphics &graphics,
+                                             juce::Point<int> const origin)
+{
+    paintRule(graphics, rectangleOf(lfoWaveformWell).translated(-origin.x, -origin.y),
+              lfoWaveformWell.cornerRadius, ColourMap::EditorRule);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // BackgroundPainter::paint()
@@ -268,12 +277,8 @@ void BackgroundPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> c
         graphics.setColour(ColourMap::getColour(ColourMap::EditorRule));
         graphics.strokePath(path, juce::PathStrokeType(ruleThickness));
     }
-    {
-        //   The waveform button's well is a rule and nothing else: what shows
-        // inside it is the LFO box it is cut into.
-        paintRule(graphics, rectangleOf(lfoWaveformWell), lfoWaveformWell.cornerRadius,
-                  ColourMap::EditorRule);
-    }
+    /// \note The waveform button's well is not here. \see
+    /// paintLFOWaveformWell(), which the LFO strip calls.
 
     paintPanel(graphics, sideChainSourceBox, sideChainSourceRamp);
     paintPanel(graphics, buttonRowBox, buttonRowRamp);

--- a/src/gui/painters/backgroundPainter.hpp
+++ b/src/gui/painters/backgroundPainter.hpp
@@ -142,7 +142,10 @@ float constexpr lfoNotchRadius{9.18f};
 Ramp constexpr lfoBoxRamp{45.0f,   -45.0f, -265.5f, 265.5f,
                           0.5145f, 2.0f,   0.213f,  ColourMap::EditorWell};
 
-/// The pill inside it that the waveform button sits in.
+/// \brief The pill inside it that the waveform button sits in.
+///
+/// \note Drawn by the LFO strip rather than with the box it is cut into. \see
+/// BackgroundPainter::paintLFOWaveformWell().
 Panel constexpr lfoWaveformWell{219.0f, 377.0f, 267.0f, 407.0f, 12.62f};
 
 /// What is feeding the side channel.
@@ -296,6 +299,25 @@ class BackgroundPainter
   public:
     /// \brief Draws the whole chassis into \p bounds.
     static void paint(juce::Graphics &, juce::Rectangle<float> bounds);
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief The pill the LFO's waveform button sits in, for a widget whose
+    /// top left is at \p origin in the chassis' own coordinates.
+    ///
+    ///   Not part of paint(), and that is the point: the LFO strip is only on
+    /// screen while a control is selected, and everything in that box comes and
+    /// goes with it. This one did not -- an empty LFO box with a lone pill in
+    /// the corner of it is what issue #134 reports -- because it was drawn with
+    /// the chassis rather than with what it holds.
+    ///
+    /// \note \p origin rather than the widget's bounds, so the rectangle stays
+    /// written where the artwork measured it. \see
+    /// BackgroundStyle::lfoWaveformWell.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    static void paintLFOWaveformWell(juce::Graphics &, juce::Point<int> origin);
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/src/gui/painters/buttonPainter.hpp
+++ b/src/gui/painters/buttonPainter.hpp
@@ -82,10 +82,11 @@ float constexpr glowOuterAlpha{0.0134f}; ///< and at the last one
 /// \name The tab
 ////////////////////////////////////////////////////////////////////////////////
 ///@{
-/// \note PanelPainter::sideInset, not the artwork's 0.5. It is what separates
-/// one tab's pill from the next, and also what keeps the first one from
-/// overhanging the strip it stands in -- which the page below that strip is
-/// inset by too, so all three now start on the same line.
+/// \note What separates one tab's pill from the next, and the artwork's 0.5 at
+/// the size the skin is drawn at now. It is also what the settings panel takes
+/// off PanelPainter::fieldInset when it places the bar, so that the leftmost
+/// pill's edge and the frame below it stand on one line. \see
+/// SpectrumWorxEditor::Settings::resized().
 float constexpr tabSideInset{1.125f};
 float constexpr tabTopInset{1.125f};
 float constexpr tabRadius{6.75f};

--- a/src/gui/painters/panelPainter.cpp
+++ b/src/gui/painters/panelPainter.cpp
@@ -66,16 +66,21 @@ void PanelPainter::paintPresetBrowser(juce::Graphics &graphics, juce::Rectangle<
     juce::Rectangle<float> const location{10.125f, 12.735f, 265.815f, 22.53f};
     outline(graphics, location, 11.265f);
     {
-        //   The divider: the same capsule stopping short, with everything but
-        // its right-hand end clipped away.
+        ///   The divider: the same capsule stopping short, with everything but
+        /// its right-hand end clipped away.
+        ///
+        /// \note Two pixels further left than the artwork had it. The arc and
+        /// the capsule's own end had 15.5 px between them and the arrow that
+        /// goes there is 13 wide, which reads as the arrow being wedged in
+        /// rather than sitting in a slot. \see issue #134.
         juce::Graphics::ScopedSaveState const clipped(graphics);
-        graphics.reduceClipRegion({249, 12, 12, 26});
-        outline(graphics, location.withRight(260.43f), 11.265f);
+        graphics.reduceClipRegion({247, 12, 12, 26});
+        outline(graphics, location.withRight(258.43f), 11.265f);
     }
 
-    outline(graphics, {9.f, 42.f, 267.f, 41.f}, cornerRadius);   // the button row
-    outline(graphics, {9.f, 114.f, 267.f, 360.f}, cornerRadius); // the list
-    outline(graphics, {9.f, 481.5f, 267.f, 48.f}, cornerRadius); // the comment box
+    outline(graphics, {fieldInset, 42.f, 267.f, 41.f}, cornerRadius);   // the button row
+    outline(graphics, {fieldInset, 114.f, 267.f, 360.f}, cornerRadius); // the list
+    outline(graphics, {fieldInset, 481.5f, 267.f, 48.f}, cornerRadius); // the comment box
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -110,10 +115,13 @@ void PanelPainter::paintPresetBrowser(juce::Graphics &graphics, juce::Rectangle<
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
+/// \note Deeper than the tab bar, so that it runs behind the top of the page
+/// rather than up against it: two rounded rectangles meeting on a line would
+/// show that line.
 void PanelPainter::paintTabStrip(juce::Graphics &graphics, juce::Rectangle<float> const bounds)
 {
     graphics.setColour(ColourMap::getColour(ColourMap::PanelBackground));
-    graphics.fillRoundedRectangle({0.f, 1.f, width, 32.f}, cornerRadius);
+    graphics.fillRoundedRectangle(bounds.withY(1.f).withHeight(32.f), cornerRadius);
 }
 
 void PanelPainter::paintSettingsPage(juce::Graphics &graphics, juce::Rectangle<float> const bounds)
@@ -130,7 +138,7 @@ void PanelPainter::paintSettingsPage(juce::Graphics &graphics, juce::Rectangle<f
     graphics.fillPath(page);
 
     graphics.setColour(ColourMap::getColour(ColourMap::PanelFrame));
-    outline(graphics, {9.f, 16.5f, 267.f, 489.f}, cornerRadius);
+    outline(graphics, {fieldInset, settingsFrameTop, 267.f, 489.f}, cornerRadius);
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/painters/panelPainter.hpp
+++ b/src/gui/painters/panelPainter.hpp
@@ -57,8 +57,7 @@ class PanelPainter
     /// \brief A settings page -- Engine, GUI or About, which were one file.
     static void paintSettingsPage(juce::Graphics &, juce::Rectangle<float> bounds);
 
-    /// \brief The strip the settings tabs stand in, which runs from the panel's
-    /// left edge to the right edge of the last tab and no further.
+    /// \brief The strip the settings tabs stand in, across the top of \p bounds.
     static void paintTabStrip(juce::Graphics &, juce::Rectangle<float> bounds);
 
     /// The corner the panels are rounded by.
@@ -69,6 +68,23 @@ class PanelPainter
     /// \note The artwork's, and shared so that the strip and the page below it
     /// line up: they were a pixel apart when only the page had it.
     static float constexpr sideInset{1.5f};
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Where a field goes on either panel: every frame below starts on
+    /// this line, and so does the leftmost settings tab.
+    ///
+    /// \note Which is what it is named for. The tabs used to stand in the
+    /// corner of the panel, a pixel in from an edge nothing else measures
+    /// from, so the row above the fields did not line up with them. \see
+    /// issue #134 and SpectrumWorxEditor::Settings::resized().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    static float constexpr fieldInset{9.f};
+
+    /// \brief The settings page's one frame, from the top of the *page* --
+    /// which is the tab bar's own depth below the top of the panel.
+    static float constexpr settingsFrameTop{16.5f};
 
     /// \brief The sizes the two are drawn at, which were their artwork's.
     ///

--- a/src/gui/preset_browser/presetBrowser.cpp
+++ b/src/gui/preset_browser/presetBrowser.cpp
@@ -1202,7 +1202,30 @@ juce::String PresetBrowser::locationLabel() const
                                       : _T( "Factory/" ) + factoryBank_;
 
     case Location::User:
-        return LE::IO::pathToJuceString(currentDirectory_);
+    {
+        ///   "User", and then whatever is under it: the same shape the Factory
+        /// arm has, and for the reason issue #134 gives. The strip is 250 px of
+        /// room and an absolute path spends all of it on a home directory, a
+        /// vendor folder and a Presets folder -- so the one part that says where
+        /// the user actually is fell off the right-hand end.
+        ///
+        /// \note `lexically_relative()`, which touches no disk: this is asked
+        /// from paint(). It answers "." for the root itself, and an empty path
+        /// or one starting in ".." for somewhere with no route down from it --
+        /// which the browse button can reach, and which is the one case with
+        /// nothing shorter to say than the path.
+        auto const under(currentDirectory_.lexically_relative(GUI::presetsFolder()));
+        if (under.empty() || (*under.begin() == _T( ".." )))
+            return LE::IO::pathToJuceString(currentDirectory_);
+        if (under == _T( "." ))
+            return _T( "User" );
+
+        /// \note Joined as a path rather than with a literal "User/", so that
+        /// the separator between the folders is the one the platform names them
+        /// with. Factory's is a slash because a bank is a name in the binary
+        /// rather than a directory on disk.
+        return LE::IO::pathToJuceString(fs::path(_T( "User" )) / under);
+    }
     }
     LE_UNREACHABLE_CODE();
 }

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -166,12 +166,16 @@ void Theme::drawScrollbar(juce::Graphics &graphics, juce::ScrollBar &scrollBar, 
         return;
 
     /// What the thumb keeps clear of the edges of the strip it runs in.
-    constexpr int inset{2};
+    ///
+    /// \note A pixel and a half, and taken off the *float* rectangle: the whole
+    /// point of the inset is the difference between the bar and the thumb, and
+    /// rounding it to a whole pixel would move that by a third.
+    constexpr float inset{1.5f};
 
     auto const bar(isScrollbarVertical
                        ? juce::Rectangle<int>(x, thumbStartPosition, width, thumbSize)
                        : juce::Rectangle<int>(thumbStartPosition, y, thumbSize, height));
-    auto const thumb(bar.reduced(inset).toFloat());
+    auto const thumb(bar.toFloat().reduced(inset));
 
     /// \note Translucent at rest and solid under the hand: a floating bar has no
     /// frame to separate it from the list it is over, so what keeps it from

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -182,9 +182,14 @@ class Theme final : public juce::LookAndFeel_V2
 
     /// \brief What a scroll bar takes out of the view it scrolls, in pixels.
     ///
-    /// \note Six, of which the thumb is four: the inset either side is what keeps
+    /// \note Nine, of which the thumb is six: the inset either side is what keeps
     /// it off the edge of the view. JUCE's own answer is eighteen.
-    static int constexpr scrollBarThickness{6};
+    ///
+    /// \note Six until 19.08.2026, which was this number drawn through the
+    /// skin's 1.5 transform. Drawing the editor at 1:1 left it at six *screen*
+    /// pixels -- a two pixel thumb, which is a bar too thin to aim at. \see
+    /// issue #134.
+    static int constexpr scrollBarThickness{9};
 
   private:
     juce::Font const headingFont_;


### PR DESCRIPTION
A scroll bar was nine screen pixels wide until the editor started drawing at 1:1, and six after -- of which the thumb was two, which is a bar too thin to aim at. It is nine again, carrying the six pixel thumb it always had.

And the six the report lists:

- The settings tabs stand on the line the frame below them does and are centred in the dark above it, rather than in the corner of the panel. The tab that tried to place the bar was writing a position TabbedComponent::resized() overwrote on its way past.
- The LFO's waveform well comes and goes with the rest of the LFO strip. It was drawn into the chassis, so what an unselected control left on screen was an empty box with one pill sitting in the corner of it.
- A capsule button's caption is centred in the widget instead of two pixels under it -- twelve of them are a TuneWorx semitone.
- The in, out and mix knobs point in the accent colour. A near-black bar over a black cap and a ring that is nearly black at the bottom disappeared over half its travel and came back over the rest.
- The preset browser's folder capsule gives the arrow at its end two more pixels than the arrow is wide.
- And the user tree is called "User", the way the factory tree is called "Factory". It was the absolute path to it, which spends a 250 px strip on a home directory and loses the part that says where the user is.

Closes #134.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>