### PR TITLE
Faster Mouse; and Shift Drag for Fine

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1408,13 +1408,6 @@ void Knob::mouseDown(juce::MouseEvent const &event)
         return passMousePressToParent(*this, event);
     }
 
-    /// \note Read here rather than in mouseDrag, so that a drag keeps the
-    /// sensitivity it started with. `handleAbsoluteDrag` works out the value as
-    /// `valueOnMouseDown + travelSoFar / sensitivity`, so changing the divisor
-    /// half way through recomputes the whole gesture at the new rate and the
-    /// knob jumps. Pressing the key first is the gesture; pressing it mid-drag
-    /// now does nothing, which is the quieter of the two answers.
-    ///
     /// The anchor every later event measures itself against. \see fineAdjusted().
     dragStartY_ = event.position.y;
     lastDragY_ = event.position.y;
@@ -1445,12 +1438,52 @@ void Knob::mouseDrag(juce::MouseEvent const &event)
     juce::Slider::mouseDrag(fineAdjusted(event));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The cursor goes back where it was pressed, and juce::Slider's own
+/// attempt at that is overwritten rather than prevented. `restoreMouseIfHidden`
+/// (juce_Slider.cpp:1187, reached from Slider::mouseUp) works out where the
+/// mouse would have travelled to for the value the knob ended on -- and then
+/// constrains that point to the knob's own screen bounds. A knob is some eighty
+/// pixels tall and a whole range is six hundred, so every drag long enough to be
+/// worth making overshoots and the cursor is left pinned to the top or bottom
+/// edge of the widget. It measures that travel at the coarse sensitivity too,
+/// which a drag that used shift did not happen at.
+///
+///   Where the press was is both simpler and what the gesture means: the mouse
+/// was taken away for the duration and is being handed back.
+///                                           (20.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
 void Knob::mouseUp(juce::MouseEvent const &event)
 {
     if (event.mods.isPopupMenu())
         return;
+
     juce::Slider::mouseUp(event);
+
+    if (hidesCursorWhileDragging())
+        juce::Desktop::getInstance().getMainMouseSource().setScreenPosition(
+            event.getMouseDownScreenPosition().toFloat());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Deliberately empty. juce::Slider::modifierKeysChanged calls
+/// `restoreMouseIfHidden()` for every modifier change that is not its own
+/// velocity swap (juce_Slider.cpp:1176) -- the guard above it exempts the
+/// `Rotary` style, which is a different value from the RotaryVerticalDrag these
+/// are. That puts the cursor back in the middle of the knob and ends the
+/// unbounded movement, which is precisely what pressing shift part way through a
+/// drag was doing: the gesture the key is there to refine was the gesture it
+/// broke. Nothing is lost by dropping it, because juce::Component's own only
+/// forwards to the parent and Slider does not call it either.
+///                                           (20.08.2026.)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void Knob::modifierKeysChanged(juce::ModifierKeys const &) {}
 
 void LE_NOINLINE Knob::setValue(param_type const newValue)
 {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1122,7 +1122,21 @@ Knob::Knob(juce::Component &parent, unsigned int const x, unsigned int const y,
     //setPopupDisplayEnabled ( true, 0               ); //...mrmlj...for testing...
     /// \note `setPopupMenuEnabled( true )` stood here. See the note over the
     /// menu interface in the header: the right button raises ours now.
-    setMouseDragSensitivity(1200);
+    setMouseDragSensitivity(coarseDragPixels());
+
+    /// \note The trailing false is `userCanPressKeyToSwapMode`, and it is off so
+    /// that every drag is the plain linear one fineAdjusted() can reason about.
+    /// JUCE's default swaps command, control and alt into a *velocity* based
+    /// drag (juce_Slider.cpp, `isAbsoluteDragMode`) whose response is a sine of
+    /// the mouse's speed rather than of its distance. Shift is not one of those
+    /// three, so leaving this alone would not have broken the fine drag -- it
+    /// would have left the other three keys turning a knob by a rule nothing
+    /// tells the user about, and moving it barely at all at the speed someone
+    /// uses when they mean to be precise. The first three arguments are JUCE's
+    /// own defaults, restated because there is no setter for the fourth alone.
+    ///                                       (20.08.2026.)
+    setVelocityModeParameters(1.0, 1, 0.0, false);
+
     addToParentAndShow(parent, *this);
 }
 
@@ -1393,14 +1407,42 @@ void Knob::mouseDown(juce::MouseEvent const &event)
             return showParameterMenu(event);
         return passMousePressToParent(*this, event);
     }
+
+    /// \note Read here rather than in mouseDrag, so that a drag keeps the
+    /// sensitivity it started with. `handleAbsoluteDrag` works out the value as
+    /// `valueOnMouseDown + travelSoFar / sensitivity`, so changing the divisor
+    /// half way through recomputes the whole gesture at the new rate and the
+    /// knob jumps. Pressing the key first is the gesture; pressing it mid-drag
+    /// now does nothing, which is the quieter of the two answers.
+    ///
+    /// The anchor every later event measures itself against. \see fineAdjusted().
+    dragStartY_ = event.position.y;
+    lastDragY_ = event.position.y;
+    travel_ = 0;
+
     juce::Slider::mouseDown(event);
+}
+
+juce::MouseEvent Knob::fineAdjusted(juce::MouseEvent const &event)
+{
+    /// \note Shift, which is what the rest of the Surge Synth Team's plugins use
+    /// for this -- sst-jucegui, ContinuousParamEditor::mouseDrag(). Command is
+    /// not free there: it quantizes a drag to the parameter's step, so borrowing
+    /// it here would have taught two different things about one key. Shift is
+    /// also the same key on all three platforms, which command is not.
+    auto const ratio(event.mods.isShiftDown() ? fineDragRatio : 1.0f);
+
+    travel_ += (lastDragY_ - event.position.y) / ratio;
+    lastDragY_ = event.position.y;
+
+    return event.withNewPosition(juce::Point<float>(event.position.x, dragStartY_ - travel_));
 }
 
 void Knob::mouseDrag(juce::MouseEvent const &event)
 {
     if (event.mods.isPopupMenu())
         return;
-    juce::Slider::mouseDrag(event);
+    juce::Slider::mouseDrag(fineAdjusted(event));
 }
 
 void Knob::mouseUp(juce::MouseEvent const &event)

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -1072,6 +1072,48 @@ class Knob : public WidgetBase<juce::Slider>
     typedef double value_type;
     typedef float param_type;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \name How fast a knob follows the mouse
+    ///
+    /// \note One number to turn, and it is deliberately not a preference: the
+    /// question these answer is whether the plugin tracks the mouse the way the
+    /// rest of the platform does, which is not something to ask a user. If a
+    /// platform wants a different answer, this is where it says so.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///@{
+    /// \brief The pixels of vertical travel a knob asked for, in 2012, before it
+    /// had moved through its whole range.
+    ///
+    /// Kept as the reference rather than edited away so that the sensitivity
+    /// below reads as a multiple of the feel this plugin shipped with.
+    static constexpr float referenceDragPixels{1200};
+
+    /// \brief The multiple of that travel a knob covers now.
+    ///
+    /// One is the 2012 feel, and a 16" laptop screen is not tall enough to drag
+    /// a knob through its range at it.
+    static constexpr float dragSensitivity{2.5f};
+
+    /// \brief What holding shift divides the travel by.
+    ///
+    /// \note The same linear drag, only finer -- not JUCE's velocity mode, which
+    /// the constructor switches off. \see Knob::fineAdjusted().
+    ///
+    /// \note Four rather than the ten sst-jucegui uses, because this is dividing
+    /// an already brisk 480 px. Ten would put a fine sweep back past the 1200
+    /// this is getting away from.
+    static constexpr float fineDragRatio{4};
+
+    /// \brief The travel a whole range takes, as JUCE counts it: 480 px, and
+    /// four times that with shift held.
+    static constexpr int coarseDragPixels()
+    {
+        return static_cast<int>(referenceDragPixels / dragSensitivity);
+    }
+    ///@}
+
     value_type getValue() const { return static_cast<value_type>(juce::Slider::getValue()); }
     void setValue(param_type);
 
@@ -1221,6 +1263,36 @@ class Knob : public WidgetBase<juce::Slider>
     /// it costs nothing to exist: LE_ASSERT compiles away on its own.
     ///                                       (28.07.2026.) (SW port)
     void stoppedDragging() noexcept override;
+
+  private:
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief \p event with its vertical position replaced by the one that
+    /// makes juce::Slider arrive at the value shift has earned so far.
+    ///
+    /// \note This exists because shift has to be allowed to go down and come
+    /// back up in the middle of a drag. juce::Slider works the value out afresh
+    /// on every event, as `valueOnMouseDown + travelSinceMouseDown /
+    /// sensitivity`, so simply changing the sensitivity when the key changes
+    /// rescales the travel already made and the knob jumps. Leaving the
+    /// sensitivity alone and handing it a position it would have reached is the
+    /// same arithmetic without the jump: each segment of the drag is divided by
+    /// the ratio that was in force while the mouse was covering it, and the
+    /// running total is what the slider is shown.
+    ///
+    /// \note Vertical only, because the style is RotaryVerticalDrag and
+    /// `handleAbsoluteDrag` reads nothing else.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    juce::MouseEvent fineAdjusted(juce::MouseEvent const &event);
+
+  private:
+    /// Where the press landed: what juce::Slider measures its travel from.
+    float dragStartY_{0};
+    /// Where the previous drag event was, so that a segment can be measured.
+    float lastDragY_{0};
+    /// Those segments, each divided by the ratio it was covered at.
+    float travel_{0};
 
   private:
     using juce::Slider::getMaxValueObject;

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -1094,7 +1094,7 @@ class Knob : public WidgetBase<juce::Slider>
     ///
     /// One is the 2012 feel, and a 16" laptop screen is not tall enough to drag
     /// a knob through its range at it.
-    static constexpr float dragSensitivity{2.5f};
+    static constexpr float dragSensitivity{2};
 
     /// \brief What holding shift divides the travel by.
     ///
@@ -1102,11 +1102,11 @@ class Knob : public WidgetBase<juce::Slider>
     /// the constructor switches off. \see Knob::fineAdjusted().
     ///
     /// \note Four rather than the ten sst-jucegui uses, because this is dividing
-    /// an already brisk 480 px. Ten would put a fine sweep back past the 1200
+    /// an already brisk 600 px. Ten would put a fine sweep well past the 1200
     /// this is getting away from.
     static constexpr float fineDragRatio{4};
 
-    /// \brief The travel a whole range takes, as JUCE counts it: 480 px, and
+    /// \brief The travel a whole range takes, as JUCE counts it: 600 px, and
     /// four times that with shift held.
     static constexpr int coarseDragPixels()
     {
@@ -1255,6 +1255,12 @@ class Knob : public WidgetBase<juce::Slider>
     void mouseDown(juce::MouseEvent const &) override;
     void mouseDrag(juce::MouseEvent const &) override;
     void mouseUp(juce::MouseEvent const &) override;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// \note Swallowed rather than forwarded, so that shift may be pressed in
+    /// the middle of a drag. \see fineAdjusted().
+    ////////////////////////////////////////////////////////////////////////////
+    void modifierKeysChanged(juce::ModifierKeys const &) override;
 
     void startedDragging() noexcept override;
     /// \note Was declared and defined only under !NDEBUG, but


### PR DESCRIPTION
A knob asked for 1200 pixels of vertical travel before it had moved through its whole range, which is taller than the screen it is being dragged on: with cursor hiding turned off a user could not reach either end without letting go. It takes 480 now, and holding shift makes the drag four times finer for the part of a move that wants care.

Shift rather than command because that is the key the rest of the Surge Synth Team's plugins use for this, and because command is not free there -- it quantizes a drag to the parameter's step. It can also go down and come back up in the middle of a drag without the value jumping.

How fast a knob follows the mouse is one constant on Knob now, so a platform that wants a different answer has somewhere to say so.

Closes #147.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>