### PR TITLE
Fix the crash on removing a module with a shared control selected

### DIFF
--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1879,8 +1879,45 @@ void SpectrumWorxEditor::detachFrom(ModuleUI &region)
         lfoDisplay_ = std::nullopt;
     }
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And the keyboard out of the shared controls before they are
+    /// destroyed, rather than leaving JUCE to move it for us.
+    ///
+    ///   JUCE answers a focused component going away by walking the focus to
+    /// the next thing that will take it, synchronously, from inside
+    /// `~Component`. These are parented to `mainArea_`, which does not want the
+    /// keyboard, so the walk goes up to it and back down its default focus
+    /// child -- **another strip**. That is `ModuleUI::focusGained` ->
+    /// `activate()` -> `moduleActivated()`, which reaches for the shared
+    /// controls -- and `std::optional::reset()` destroys the value *before* it
+    /// clears the engaged flag, so `sharedModuleControls_` still answers
+    /// `has_value()` at that moment. `updateForActiveModule()` then writes
+    /// `gain_`, whose `juce::Slider` destructor has already run and nulled its
+    /// Pimpl.
+    ///
+    ///   Reported as a crash on removing a module with the shared Gain knob
+    /// selected: two modules, a control in the second one, then Gain, then its
+    /// eject button. `grabKeyboardFocus()` is the same move
+    /// `moduleDeactivated()` makes for the same reason -- the editor wants the
+    /// keyboard, so the walk stops there -- and it leaves nothing focused inside
+    /// what is about to go.
+    ///
+    /// \note After the LFO display and not before: taking the focus out of the
+    /// shared controls deselects the module, and `moduleDeactivated()` asserts
+    /// that the module's *control* was deselected first. This path skips that
+    /// deliberately (see the note on `pActiveControl_` above), so the strip has
+    /// to be retired by hand before anything can deselect the module.
+    ///                                       (21.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
     if (sharedControlsAreRegions)
+    {
+        if (sharedModuleControls_->hasFocus())
+            grabKeyboardFocus();
         sharedModuleControls_ = std::nullopt;
+    }
 }
 
 void SpectrumWorxEditor::mainKnobDragStarted(std::uint8_t const index) const

--- a/tests/gui/moduleControlFocusTests.cpp
+++ b/tests/gui/moduleControlFocusTests.cpp
@@ -26,11 +26,14 @@
 /// node to it, and this is the header with the complete type.
 #include "core/modules/moduleDSPAndGUI.hpp"
 
+#include "gui/editor/auxiliaryComponents.hpp"
 #include "gui/modules/moduleControl.hpp"
 #include "gui/modules/moduleUI.hpp"
 #include "gui/preferences.hpp" // hideCursorOnKnobDrag, for the fourth LFO gesture
 
 #include "le/parameters/lfoImpl.hpp"
+#include "le/parameters/parametersUtilities.hpp"
+#include "le/spectrumworx/effects/baseParameters.hpp"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -249,6 +252,28 @@ void clickOnce(juce::Component &widget)
 {
     widget.mouseDown(eventOver(widget, {}, false));
     widget.mouseUp(eventOver(widget, {}, false));
+}
+
+/// \brief The Gain/Wet/frequency-range strip, found in the tree rather than
+/// asked for: the editor hands it out to ModuleUI alone.
+GUI::SharedModuleControls *sharedControlsUnder(juce::Component &component)
+{
+    for (auto *const pChild : component.getChildren())
+    {
+        if (auto *const pShared = dynamic_cast<GUI::SharedModuleControls *>(pChild))
+            return pShared;
+        if (auto *const pFound = sharedControlsUnder(*pChild))
+            return pFound;
+    }
+    return nullptr;
+}
+
+/// The shared Gain knob -- the one the report's focus was in.
+juce::Component &sharedGain(GUI::SharedModuleControls &shared)
+{
+    namespace Base = Effects::BaseParameters;
+    return shared.controlForParameter(LE::Parameters::IndexOf<Base::Parameters, Base::Gain>::value)
+        .widget();
 }
 } // anonymous namespace
 
@@ -473,6 +498,99 @@ TEST_CASE("A strip removed after its control was deactivated leaves nothing poin
     }
 
     CHECK(editor.regionInSlot(0) != nullptr);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The shared controls' own version of the case above, and it crashes
+/// rather than reads freed memory. `detachFrom()` destroys them while the
+/// keyboard focus is still *inside* them, and JUCE answers a focused component
+/// going away by handing the focus to the next thing that will take it -- which,
+/// two strips down from the editor, is another `ModuleUI`. That is a synchronous
+/// `focusGained` -> `activate()` -> `moduleActivated()`, from inside
+/// `std::optional::reset()`.
+///
+///   And `reset()` destroys the value *before* it clears the engaged flag
+/// (libc++ `__optional_destruct_base::reset`), so `sharedModuleControls_` still
+/// answers `has_value()` at that moment: `moduleActivated()` takes the else
+/// branch, calls `updateForActiveModule()`, and writes `gain_` -- whose
+/// `juce::Slider` destructor has already run and nulled its Pimpl.
+///
+///     0  juce::Slider::Pimpl::setValue
+///     1  SharedModuleControls::updateForActiveModule
+///     2  SpectrumWorxEditor::moduleActivated
+///     3  ModuleUI::focusGained
+///     ...
+///     8  juce::Component::removeChildComponent
+///     9  juce::Component::~Component
+///    10  SpectrumWorxEditor::detachFrom
+///    11  SpectrumWorxEditor::resyncModuleRack
+///
+/// \note Two strips, and the *second* one removed: with one strip there is no
+/// other `ModuleUI` for the focus to land on and nothing re-enters.
+///                                           (21.08.2026.) (SW port)
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Removing the strip the shared controls are focused in activates nothing",
+          "[gui][modules][lfo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!aWindowCanBeMade())
+        SKIP(noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+
+    editor.addUserAddedModule(0);
+    editor.addUserAddedModule(0);
+    editor.resyncModuleRack();
+    auto *const pSecondStrip(editor.regionInSlot(1));
+    REQUIRE(editor.regionInSlot(0) != nullptr);
+    REQUIRE(pSecondStrip != nullptr);
+
+    // Selecting a control in the second strip is what builds the shared controls
+    // and points them at it.
+    auto *const pControl(firstKnob(*pSecondStrip));
+    REQUIRE(pControl != nullptr);
+    pControl->widget().grabKeyboardFocus();
+    REQUIRE(editor.sharedModuleControlsActive());
+
+    // ...and then the click on Gain, which moves the focus out of the strip and
+    // into the shared controls while leaving the strip selected.
+    auto *const pShared(sharedControlsUnder(editor));
+    REQUIRE(pShared != nullptr);
+    auto &gain(sharedGain(*pShared));
+    gain.grabKeyboardFocus();
+    REQUIRE(gain.hasKeyboardFocus(false));
+    REQUIRE(editor.sharedModuleControlsActiveAndFocused());
+    REQUIRE(editor.selectedModule() == pSecondStrip);
+
+    // The eject button's path, and the crash.
+    editor.removeModule(*pSecondStrip);
+    editor.resyncModuleRack();
+
+    CHECK(editor.regionInSlot(1) == nullptr);
+    CHECK(editor.regionInSlot(0) != nullptr);
+
+    // Nothing was activated on the way out: the strip that was selected is gone
+    // and no other one was made selected in its place.
+    CHECK(editor.selectedModule() == nullptr);
+    CHECK(editor.activeControl() == nullptr);
+    CHECK(!editor.sharedModuleControlsActive());
+
+    /// \note And the rack still paints, which is what the case above pins for
+    /// the deactivated-first path.
+    juce::Image canvas(juce::Image::ARGB, editor.getWidth(), editor.getHeight(), true);
+    {
+        juce::Graphics graphics(canvas);
+        editor.paintEntireComponent(graphics, true);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Destroying the shared Gain/Wet/frequency controls while the keyboard focus was still inside them let JUCE walk that focus into another module strip, which selected it and read the controls back while they were being destroyed. The keyboard now goes to the editor first, which is where it already goes when a module is deselected.

Repro: two modules, a knob on the second, then Gain, then eject.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDo3csJrDywYzoHEutXRY9