### PR TITLE
Update how module joiners are painted

### DIFF
--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -102,8 +102,8 @@ unsigned int const textBoxWidth = 170;
 unsigned int const textBoxMargin = 6;
 
 unsigned int const moduleNameVerticalOffset = 20;
-unsigned int const controlNameVerticalOffset = 63;
-unsigned int const controlValueVerticalOffset = 78;
+unsigned int const controlNameVerticalOffset = 66;
+unsigned int const controlValueVerticalOffset = 79;
 unsigned int const sampleNameVerticalOffset = 458;
 } // namespace Constants::Layout
 

--- a/src/gui/painters/backgroundPainter.cpp
+++ b/src/gui/painters/backgroundPainter.cpp
@@ -256,15 +256,21 @@ void BackgroundPainter::paint(juce::Graphics &graphics, juce::Rectangle<float> c
 
     graphics.fillAll(ColourMap::getColour(ColourMap::EditorSurround));
 
-    //   The two joins go down before the panels, so that the panels' rules
-    // close over them rather than being crossed by them.
-    graphics.setColour(ColourMap::getColour(ColourMap::PanelBackground));
-    graphics.fillRect(rectangleOf(upperJoin));
-    graphics.fillRect(rectangleOf(lowerJoin));
-
     paintPanel(graphics, leftColumn, leftColumnRamp);
     paintPanel(graphics, moduleRack, moduleRackRamp);
     paintPanel(graphics, centreColumn, centreColumnRamp);
+
+    // module joiners
+    graphics.setColour(ColourMap::getColour(ColourMap::EditorPanel));
+    graphics.fillRect(rectangleOf(upperJoin));
+    graphics.fillRect(rectangleOf(lowerJoin));
+
+    // top and bottom strokes of the joiners
+    graphics.setColour(ColourMap::getColour(ColourMap::EditorRule));
+    graphics.fillRect(rectangleOf(upperJoin).withHeight(2.f));
+    graphics.fillRect(rectangleOf(upperJoin).withTrimmedTop(29.f));
+    graphics.fillRect(rectangleOf(lowerJoin).withHeight(2.f));
+    graphics.fillRect(rectangleOf(lowerJoin).withTrimmedTop(29.f));
 
     paintBox(graphics, moduleNameBox, ColourMap::EditorWell, ColourMap::EditorRule);
     paintBox(graphics, activeControlBox, ColourMap::EditorWell, ColourMap::EditorRule);

--- a/src/gui/painters/backgroundPainter.hpp
+++ b/src/gui/painters/backgroundPainter.hpp
@@ -108,8 +108,8 @@ Ramp constexpr moduleRackRamp{-105.0f, 105.0f, 396.75f, -396.75f,
 /// \brief The two blocks that join them, which is why the gap between the
 /// columns is not a gap all the way down.
 ///@{
-Panel constexpr upperJoin{296.0f, 98.0f, 317.0f, 129.0f, 0.00f};
-Panel constexpr lowerJoin{296.0f, 459.0f, 317.0f, 491.0f, 0.00f};
+Panel constexpr upperJoin{298.0f, 98.0f, 317.0f, 129.0f, 0.00f};
+Panel constexpr lowerJoin{298.0f, 459.0f, 317.0f, 491.0f, 0.00f};
 ///@}
 ///@}
 


### PR DESCRIPTION
They now look much more integrated, rather than tacked-below.