### PR TITLE
Show LFO Phase in ° instead of %

### DIFF
--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -315,7 +315,7 @@ void SharedModuleControls::FrequencyRange::paint(juce::Graphics &g)
     juce::Slider::paint(g);
     g.setFont(DrawableText::defaultFont());
     g.setColour(ColourMap::getColour(ColourMap::Text));
-    g.drawSingleLineText("Frequency Range", 23, 48);
+    g.drawSingleLineText("Frequency Range", 17, 48);
 }
 
 void SharedModuleControls::FrequencyRange::valueChanged() noexcept

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2653,7 +2653,7 @@ SpectrumWorxEditor::LFODisplay::LFODisplay()
     //period_.setVelocityBasedMode( true );
     addToParentAndShow(*this, period_);
 
-    phase_.setBounds(59, 177, 63, 18);
+    phase_.setBounds(59, 177, 60, 18);
     phase_.setSliderStyle(juce::Slider::LinearHorizontal);
     phase_.setTextBoxStyle(juce::Slider::NoTextBox, true, 15, 18);
     phase_.setRange(-0.5, +0.5);
@@ -2820,12 +2820,7 @@ juce::String periodMillisecondsString(SpectrumWorxEditor::LFODisplay const &pare
 juce::String phaseString(SpectrumWorxEditor::LFODisplay const & /*parent*/,
                          double const &periodScale)
 {
-    constexpr char suffix[]{"%"};
-    std::array<char, 32> buffer;
-    auto const numberOfCharactersWritten(Utility::lexical_cast(
-        periodScale * 100, 1, std::span(buffer).first(buffer.size() - sizeof(suffix))));
-    std::strcpy(&buffer[numberOfCharactersWritten], suffix);
-    return juce::String(&buffer[0]);
+    return juce::String(periodScale * 360, 1) + "°";
 }
 
 juce::String rangeValueString(SpectrumWorxEditor::LFODisplay const &parent,

--- a/src/gui/painters/backgroundPainter.hpp
+++ b/src/gui/painters/backgroundPainter.hpp
@@ -108,8 +108,8 @@ Ramp constexpr moduleRackRamp{-105.0f, 105.0f, 396.75f, -396.75f,
 /// \brief The two blocks that join them, which is why the gap between the
 /// columns is not a gap all the way down.
 ///@{
-Panel constexpr upperJoin{298.0f, 98.0f, 317.0f, 129.0f, 0.00f};
-Panel constexpr lowerJoin{298.0f, 459.0f, 317.0f, 491.0f, 0.00f};
+Panel constexpr upperJoin{298.0f, 98.0f, 317.0f, 130.0f, 0.00f};
+Panel constexpr lowerJoin{298.0f, 458.0f, 317.0f, 490.0f, 0.00f};
 ///@}
 ///@}
 


### PR DESCRIPTION
Also center the Frequency Range label properly.