### PR TITLE
Report a chain change only when the slot actually moved

### DIFF
--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1053,6 +1053,26 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
     if (!liveRanges(parameterID, ranges, program()))
         return false;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **What the slot held before the write, so that the answer below can
+    /// mean that it changed.** \see the note on the return value.
+    ///
+    ///   Read from the chain rather than inferred from \p value, because the two
+    /// are not the same question. `AutomatedModuleChain::setParameter` declines a
+    /// slot change it cannot carry out -- a module it cannot build, or one that
+    /// fails to initialise -- and leaves the slot holding what it already had.
+    /// Comparing the value asked for against the value asked for last time would
+    /// call that a change; comparing the slot against itself does not.
+    ///                                       (22.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    bool const isSlotSelector(parameterID.type() == ParameterID::ModuleChainParameter);
+    auto const slot(parameterID.value._.moduleChain.moduleIndex);
+    auto const effectBefore(isSlotSelector ? moduleChain().getParameterForIndex(slot).getValue()
+                                           : noModule);
+
     auto const value(CLAPEdge::fromHost(parameterID, ranges, event->value));
     auto const applied(setParameter(parameterID, value));
 
@@ -1084,10 +1104,41 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
         pushed(toUI_.push(Threading::baseParameterChanged(parameterID.binaryValue, value)),
                "The echo queue is full; the main thread's Program is now behind the engine.");
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
     /// \note Only a module-chain parameter changes what the *other* parameters
     /// are: it decides which effect a slot holds, and so how many parameters
     /// that slot has and what they are called. Everything else is just a value.
-    return parameterID.type() == ParameterID::ModuleChainParameter;
+    ///
+    /// \note **And only when the slot actually moved.** This asked what type the
+    /// parameter was rather than whether anything had happened, so a host writing
+    /// a slot back to the value it already held was answered as a chain change --
+    /// which is not free: `chainChanged()` pushes a `ChainChanged` echo, asks for
+    /// a `CLAP_PARAM_RESCAN_INFO | _TEXT | _VALUES` and marks the program dirty.
+    ///
+    ///   In Ardour that closed a loop. A rescan carrying `INFO` reaches VST3 as
+    /// `restartComponent( kParamValuesChanged | kParamTitlesChanged )`, and
+    /// Ardour answers it by writing the whole parameter set back into the plugin
+    /// -- from inside `restartComponent` itself, every block, one event per
+    /// parameter. One of them is a slot, unchanged, and it asked for the next
+    /// rescan. Measured at some thirty turns a second for as long as the plugin
+    /// was loaded, each costing the wrapper a full `get_value` sweep and the host
+    /// a control-surface rebuild, all on the main thread.
+    ///
+    ///   A host is entitled to write those values back: that is what the flags
+    /// invite, and re-stating a value after being told the titles changed is not
+    /// a defect. Claiming a change that had not happened is, which is why the
+    /// guard belongs here and not behind a test for which host is running.
+    /// Nothing else needed one -- every other parameter type already answered
+    /// false. \see issue #172.
+    ///                                       (22.08.2026.) (SW port)
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto const effectAfter(isSlotSelector ? moduleChain().getParameterForIndex(slot).getValue()
+                                          : noModule);
+
+    return isSlotSelector && (effectBefore != effectAfter);
 }
 
 void SpectrumWorxCLAP::requestRescan(clap_param_rescan_flags const flags)

--- a/tests/clap/hostInteropTests.cpp
+++ b/tests/clap/hostInteropTests.cpp
@@ -606,3 +606,101 @@ TEST_CASE("Learning the host's tempo does not move the LFO periods", "[clap][hos
     CHECK(afterLearningTheTempo == beforeAnyBlock);
     CHECK(afterMoreBlocks == beforeAnyBlock);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// What counts as the chain having changed
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+/// \brief The slot selector for module \p slot, as the host is shown it.
+clap_param_info slotSelector(clap_plugin const &plugin, clap_plugin_params const &params,
+                             std::uint8_t const slot)
+{
+    for (auto const &info : allParameterInfo(plugin, params))
+    {
+        LE::SW::ParameterID parameterID;
+        parameterID.binaryValue = info.id;
+        if ((parameterID.type() == LE::SW::ParameterID::ModuleChainParameter) &&
+            (parameterID.value._.moduleChain.moduleIndex == slot))
+            return info;
+    }
+    FAIL("no slot selector for that module");
+    return {};
+}
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The regression this file exists to hold on to. `handleEvent()` decides
+/// whether a block changed the *shape* of the parameter list, and it used to
+/// answer that question by asking what type the parameter was rather than
+/// whether anything had happened -- so a host writing a slot back to the value
+/// it already held was answered as a chain change, and paid for with a full
+/// `CLAP_PARAM_RESCAN_INFO`.
+///
+///   In Ardour that closed a loop, because a rescan carrying `INFO` is what makes
+/// it write the parameter set back. \see issue #172 and the note on the return
+/// value in `handleEvent()`.
+///
+/// \note `rescanFlags` and not `mainThreadCallbacks`, which cannot tell these
+/// cases apart: `markCurrentProgramAsModified()` asks for a callback on the same
+/// path, so *any* parameter event arms one. What is being pinned is narrower --
+/// that the callback, when it runs, has no rescan to deliver.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A slot written back the value it already holds is not a chain change",
+          "[clap][host][parameters]")
+{
+    Entry const entry;
+    TestHost host{TestHost::everything()};
+    ActivePlugin plugin(48000, 512, host);
+
+    auto const &params(parameters(*plugin));
+    auto const selector(slotSelector(*plugin, params, 0));
+
+    std::vector<float> leftIn(512, 0.0f), rightIn(512, 0.0f);
+    std::vector<float> leftOut(512), rightOut(512);
+
+    /// Delivers \p value for the slot in one block, and runs the callback the
+    /// plugin asks for -- which is where a rescan, if there is one, is handed
+    /// over. Answers what the host was told to rescan.
+    auto const writeSlot([&](double const value) {
+        host.rescanFlags = 0;
+        OneParameterEvent const edit(selector.id, value);
+        plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr, &*edit);
+        plugin.pumpMainThread();
+        return host.rescanFlags.load();
+    });
+
+    // The slot starts empty; min_value is `noModule` and the next value up is the
+    // first effect, so this genuinely fills it.
+    auto const firstEffect(selector.min_value + 1);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Filling the slot is a change, and has to stay one.
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto const onTheChange(writeSlot(firstEffect));
+    CHECK((onTheChange & CLAP_PARAM_RESCAN_INFO) != 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Writing it again is not.
+    ////////////////////////////////////////////////////////////////////////////
+
+    CHECK(writeSlot(firstEffect) == 0);
+
+    // And not merely the second time: a host in the loop this comes from repeats
+    // the write on every block, so once quiet it has to stay quiet.
+    for (unsigned block(0); block < 8; ++block)
+        CHECK(writeSlot(firstEffect) == 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Moving it really does still speak up, which is what says the guard reports
+    // changes rather than merely says less.
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto const onEmptyingIt(writeSlot(selector.min_value));
+    CHECK((onEmptyingIt & CLAP_PARAM_RESCAN_INFO) != 0);
+}


### PR DESCRIPTION
handleEvent() answered "the chain changed" for every module chain parameter event, asking what type the parameter was rather than whether anything had happened. A host writing a slot back to the value it already held was therefore answered as a change, and that is not free: chainChanged() pushes a ChainChanged echo, asks for a CLAP_PARAM_RESCAN_INFO | _TEXT | _VALUES and marks the program dirty.

In Ardour it closed a loop. A rescan carrying INFO reaches VST3 as restartComponent( kParamValuesChanged | kParamTitlesChanged ), and Ardour answers that by writing the whole parameter set back into the plugin -- from inside restartComponent itself, every block, one event per parameter. One of them is a slot, unchanged, which asked for the next rescan. Loading a preset was enough to start it, and it then ran at some thirty turns a second for as long as the plugin was loaded, each turn costing the wrapper a full get_value sweep and the host a control surface rebuild, all on the main thread.

The host is entitled to write those values back: that is what the flags invite, and re-stating a value after being told the titles changed is not a defect. Claiming a change that had not happened is, so the guard is here rather than behind a test for which host is running, and hosts that never triggered it see no change. Nothing else needed one -- every other parameter type already answered false.

The slot is read from the chain before the write and compared with what it holds after, rather than the requested value being compared with the previous one. AutomatedModuleChain::setParameter declines a slot change it cannot carry out and leaves the slot on what it had, which the second form would report as a change.

The case in hostInteropTests.cpp watches what the host is asked to rescan rather than how often it is asked for a callback: any parameter event arms a callback, markCurrentProgramAsModified() being on the same path, so what is pinned is that the callback has no rescan to deliver. It fills a slot and expects INFO, writes the same value ten more times and expects silence, then empties the slot and expects INFO again -- the last so that a guard which merely said less would fail it too. Without the fix it fails nine of its assertions.

See issue #172.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>