### PR TITLE
Apply a pending spectral setup when Ardour will not restart

### DIFF
--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -304,6 +304,10 @@ bool SpectrumWorxCLAP::init() noexcept
     /// need not offer. See core/threading/threadCheck.hpp.
     Threading::markMainThread();
 
+    /// \note The prefix: what reaches the plugin is Ardour's own name with
+    /// clap-wrapper's " (CLAP-as-VST3)" appended. \see isArdour().
+    isArdour_ = _host.host()->name && (std::strncmp(_host.host()->name, "Ardour", 6) == 0);
+
     // The host may ask for the parameter list before activate(), and does.
     rebuildParameterIDs();
     return true;
@@ -523,6 +527,9 @@ void SpectrumWorxCLAP::deactivate() noexcept
 
     drainCommands();
     drainEngineEvents();
+
+    // The restart arrived after all. \see the fallback in process().
+    blocksAwaitingRestart_ = 0;
 
     /// \note Before the setup is applied rather than after: this is the restart
     /// that was asked for, so anything asking again from here on is asking about
@@ -1234,6 +1241,48 @@ clap_process_status SpectrumWorxCLAP::process(clap_process const *const process)
     /// before the block started.
     drainCommands();
 
+    /// \note **The restart that never came.** Ardour answers
+    /// `restartComponent( kIoChanged | kLatencyChanged )` by re-reading the
+    /// latency with the plugin still *active* and never deactivates, and calls
+    /// `stop_processing` only at either end of a session -- so this thread is the
+    /// only one that can ever apply a pending setup.
+    ///
+    /// \note **It allocates**, hence both guards: Ardour only, and only with the
+    /// transport parked, where the click lands on monitoring rather than in a
+    /// take. Sizing the working set for `maximumFFTSize` at activate() would make
+    /// it repositioning instead, and neither guard would be needed. The latency
+    /// is announced from `onMainThread()` -- outside activate(), but
+    /// `kLatencyChanged` is the part of a restart Ardour honours.
+    /// \see issue #172 and tracker.ardour.org/view.php?id=10470.
+    ///                                       (22.08.2026.) (SW port)
+
+    /// \brief Parked blocks to wait first, so a host that would restart still can.
+    static constexpr std::uint32_t blocksBeforeGivingUpOnTheRestart{4};
+
+    bool const transportRolling(process->transport &&
+                                ((process->transport->flags & CLAP_TRANSPORT_IS_PLAYING) != 0));
+
+    if (isArdour() && !transportRolling && spectralSetupPending() &&
+        restartRequested_.load(std::memory_order_acquire))
+    {
+        if (++blocksAwaitingRestart_ >= blocksBeforeGivingUpOnTheRestart)
+        {
+            auto const applied(applyPendingSpectralSetup());
+
+            blocksAwaitingRestart_ = 0;
+            restartRequested_.store(false, std::memory_order_release);
+            appliedWithoutARestart_.store(applied ? WithoutARestart::Applied
+                                                  : WithoutARestart::Failed,
+                                          std::memory_order_release);
+
+            _host.requestCallback(); // `[thread-safe]`; the announcement is not.
+        }
+    }
+    else
+    {
+        blocksAwaitingRestart_ = 0;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \note **The block is rendered in pieces, and a parameter event takes
@@ -1629,6 +1678,31 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
 void SpectrumWorxCLAP::onMainThread() noexcept
 {
     drainEngineEvents();
+
+    /// \note The other half of the fallback in process(). The resync is for the
+    /// failure case, in the order deactivate() does it; the announcement is what
+    /// tells Ardour.
+    switch (appliedWithoutARestart_.exchange(WithoutARestart::Nothing, std::memory_order_acq_rel))
+    {
+    case WithoutARestart::Nothing:
+        break;
+
+    case WithoutARestart::Failed:
+        resyncSpectralParametersToEngine();
+        [[fallthrough]];
+
+    case WithoutARestart::Applied:
+    {
+        auto const previousLatency(
+            std::exchange(latencyInSamples_, uncheckedEngineSetup().latencyInSamples()));
+        if ((latencyInSamples_ != previousLatency) && _host.canUseLatency())
+            _host.latencyChanged();
+
+        if (pEditor_)
+            pEditor_->updateForEngineSetupChanges();
+        break;
+    }
+    }
 
     auto const flags(pendingRescan_.exchange(0));
     if (flags && _host.canUseParams())

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -354,6 +354,10 @@ class SpectrumWorxCLAP final
     bool implementsLatency() const noexcept override { return true; }
     std::uint32_t latencyGet() const noexcept override { return latencyInSamples_; }
 
+    /// \brief Whether the host is Ardour, which does not answer a restart.
+    /// \see the fallback in process() and issue #172.
+    bool isArdour() const noexcept { return isArdour_; }
+
     // clap_plugin_gui, entirely by way of the shim
     bool implementsGui() const noexcept override { return clapJuceShim_ != nullptr; }
     ADD_SHIM_IMPLEMENTATION(clapJuceShim_)
@@ -726,6 +730,24 @@ class SpectrumWorxCLAP final
     ////////////////////////////////////////////////////////////////////////////
 
     std::atomic<bool> restartRequested_{false};
+
+    /// \see isArdour(). Written in init(), read from process().
+    bool isArdour_{false};
+
+    /// \brief Blocks rendered with a restart outstanding and the transport
+    /// parked. `[audio-thread]`, reset by deactivate().
+    std::uint32_t blocksAwaitingRestart_{0};
+
+    /// \brief What the audio thread did about a restart that never came, for
+    /// onMainThread() to finish.
+    enum class WithoutARestart : int
+    {
+        Nothing,
+        Applied,
+        Failed
+    };
+
+    std::atomic<WithoutARestart> appliedWithoutARestart_{WithoutARestart::Nothing};
 
     /// \brief A `ToUI::ChainChanged` waiting to be acted on. \see drainEngineEvents().
     bool chainChangedPending_{false};


### PR DESCRIPTION
A new FFT size, overlap factor or window function reaches the engine by way of a restart: the plugin asks, the host deactivates, deactivate() applies the pending setup and activate() announces the latency that follows from it. Ardour does not perform one. It answers restartComponent( kIoChanged | kLatencyChanged ) by re-reading getLatencySamples() with the plugin still active and never calls setActive( false ) at all, so the pending setup sits there for the life of the session and the size the user asked for is never heard. 

Two guards, because the call allocates: it resizes the shared spectral storage and every module's own. Ardour only, so that no host honouring a restart can reach an allocation it does not need, and only with the transport parked, which is what makes the allocation survivable rather than merely unnoticed -- a stopped transport is still calling process(), Ardour monitoring through it, so the work is still done promptly, but the click it costs lands on a moment of monitoring rather than in a take or a bounce. It also waits several parked blocks, so a host that would have restarted is given the chance to; deactivate() clears the request long before the count runs out, and resets it.

isArdour() is a named accessor rather than the comparison spelled out where it is used: a check on which host is running has to be obvious when it is read back, and easy to find on the day it can be deleted. It matches on the prefix, what reaching the plugin being Ardour's own IHostApplication::getName() with clap-wrapper's " (CLAP-as-VST3)" appended.

Reported upstream as tracker.ardour.org/view.php?id=10470.

Closes #172.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>