### PR TITLE
Draw the LFO's waveform mark in every editor, not only the first

### DIFF
--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2191,7 +2191,7 @@ LE_NOINLINE double lfoValueToRangeSliderValue(juce::Slider const &slider,
 
 void fillLFOWaveformsMenu(PopupMenu &menu)
 {
-    static Artwork const *LE_RESTRICT const icons[] = {
+    Artwork const *LE_RESTRICT const icons[] = {
         &resourceArtwork<LFOSine>(),         &resourceArtwork<LFOTriangle>(),
         &resourceArtwork<LFOSawtooth>(),     &resourceArtwork<LFOReverseSaw>(),
         &resourceArtwork<LFOSquare>(),       &resourceArtwork<LFOExponent>(),

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1162,6 +1162,10 @@ class SpectrumWorxEditor final : private SkinLifetime,
             return pModuleControl_ && pModuleControl_->pointsInto(region);
         }
 
+        /// \brief The waveform popup, so that a headless case can ask which mark
+        /// the well is showing without painting one. \see issue #174.
+        PopupMenuWithSelection const &waveformMenu() const { return type_; }
+
       private:
         CapsuleButton switch_;
         TextButton quarter_;

--- a/tests/gui/lfoDisplayTests.cpp
+++ b/tests/gui/lfoDisplayTests.cpp
@@ -431,3 +431,37 @@ TEST_CASE("N, T and D are one choice rather than three toggles", "[gui][lfo]")
 /// drive. What guards it is that both go through the one
 /// `updateParameterAndNotifyHost<>`, which the two cases above exercise; a
 /// waveform case would need a real menu and would be measuring JUCE.
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note What issue #174 was, and the one thing about the mark worth a case.
+///
+///   `fillLFOWaveformsMenu()` held its eleven icons in a function-local static,
+/// and those are pointers into the artwork cache -- which `SkinLifetime` empties
+/// the moment the last editor closes. A second editor never re-ran the
+/// initialiser, so all eleven stayed invalid, `Artwork::draw()` returned without
+/// drawing, and the well was blank for the rest of the process. Picking another
+/// waveform did not help because every one of them was blank.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A second editor's LFO well has a mark in it", "[gui][lfo][skin]")
+{
+    SWTest::HostSideJuce const juce;
+    SWTest::Instance instance;
+
+    // an editor that raised an LFO panel and went away, which is what empties
+    // the cache the marks live in
+    {
+        PanelUnderTest const first(instance);
+    }
+    instance.closeEditor();
+
+    PanelUnderTest const panel(instance);
+    auto *const pDisplay(instance.editor().lfoDisplay());
+    REQUIRE(pDisplay != nullptr);
+
+    auto const *const pMark(pDisplay->waveformMenu().getSelectedItemIcon());
+    REQUIRE(pMark != nullptr);
+    CHECK(pMark->isValid());
+}


### PR DESCRIPTION
The eleven marks were fetched once per process, into a function-local static holding pointers into the artwork cache -- and that cache is emptied when the last editor closes, which resources.hpp says plainly. So the second editor of a session, and every one after it, painted an empty well: the initialiser never ran again, the slots stayed invalid and Artwork::draw() returned without drawing. Reaching for the popup and picking another waveform did not help, because all eleven were blank.

Nothing else in the skin can reach that state. Everything else asks resourceArtwork() at paint time and gets it reloaded on demand; those eleven numbers were the only ones nobody ever asked for twice.

The case guarding it asks the panel which mark it is showing, hence the one accessor. Painting the panel is not open to a headless test -- LFODisplay::paint asserts on an active control, and only real keyboard focus sets one.

Reported as #174.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>