### PR TITLE
Settings panel minor tweaks

### DIFF
--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -57,16 +57,6 @@ char const *const originalAuthors[]{
     "Direction: Danijel Domazet",   //
 };
 
-/// \note The first line is kept from the bitmap deliberately: the port is
-/// GPL-3.0-or-later over Little Endian's 2016 release, and a notice that was on
-/// screen for ten years is not something to drop as a side effect of retyping
-/// the panel. The second is the port's own, and says the same thing the source
-/// headers do -- who holds it is a question the log answers, not this page.
-char const *const copyright[]{
-    "©2006-2024 Little Endian",    //
-    "©2026-20xx Surge Synth Team", //
-};
-
 /// The manual is in the repository rather than on a documentation site; this is
 /// the folder it lives in. Point it somewhere better the moment there is one.
 char const *const manualURL{
@@ -97,7 +87,7 @@ int constexpr margin{32};
 /// One line of body text, ascent to next ascent.
 int constexpr lineHeight{21};
 
-int constexpr titleY{30};
+int constexpr titleY{41};
 int constexpr titleWidth{165};
 int constexpr titleHeight{30};
 
@@ -107,12 +97,9 @@ int constexpr versionLineCount{3};
 
 int constexpr linksY{versionY + versionLineCount * lineHeight + 12};
 int constexpr linksHeight{21};
-int constexpr linkGap{18};
+int constexpr linkGap{21};
 
-int constexpr copyrightY{linksY + linksHeight + lineHeight - 9};
-int constexpr copyrightLineCount{static_cast<int>(std::size(Content::copyright))};
-
-int constexpr authorsHeadingY{copyrightY + copyrightLineCount * lineHeight + 113};
+int constexpr authorsHeadingY{linksY + 177};
 int constexpr authorsY{authorsHeadingY + lineHeight + 6};
 } // namespace Layout
 
@@ -125,12 +112,6 @@ juce::Font headingFont() { return Theme::singleton().headingFont(); }
 juce::Font bodyFont() { return DrawableText::defaultFont(); }
 
 /// \brief One line of Content, as a juce::String.
-///
-/// \note And this is the only way any of it may become one. `juce::String(char
-/// const *)` is *ASCII*: it asserts on any byte over 127 and takes the rest as
-/// Latin-1, so four of the six credits and the copyright sign came out mangled
-/// and noisy. The literals above stay readable UTF-8 -- with `/utf-8` on MSVC
-/// keeping them that way through the compiler -- and this says so to JUCE.
 juce::String asText(char const *const utf8) { return juce::String(juce::CharPointer_UTF8(utf8)); }
 
 /// \brief Draws one line at \p y, shrinking it to fit rather than clipping it.
@@ -368,16 +349,6 @@ void AboutPage::paint(juce::Graphics &graphics)
         {
             drawLine(graphics, line, y, bodyFont(), ColourMap::getColour(ColourMap::TextDimmed),
                      width);
-            y += Layout::lineHeight;
-        }
-    }
-
-    {
-        auto y(Layout::copyrightY);
-        for (auto const *const line : Content::copyright)
-        {
-            drawLine(graphics, asText(line), y, bodyFont(),
-                     ColourMap::getColour(ColourMap::TextFaint), width + 8);
             y += Layout::lineHeight;
         }
     }

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -3061,9 +3061,11 @@ SpectrumWorxEditor &SpectrumWorxEditor::SampleArea::editor()
 SpectrumWorxEditor::Settings::Settings() /// \throws std::bad_alloc Out of memory
     : juce::TabbedComponent(juce::TabbedButtonBar::TabsAtTop),
 
-      fftSize_(enginePage_, xMargin, yMargin + yStep * 0, (Engine ::FFTSize *)(0)),
-      overlapFactor_(enginePage_, xMargin, yMargin + yStep * 1, (Engine ::OverlapFactor *)(0)),
-      windowFunction_(enginePage_, xMargin, yMargin + yStep * 2, (Engine ::WindowFunction *)(0))
+      fftSize_(enginePage_, xMargin, yMargin + yStep * 0 + yOffset, (Engine ::FFTSize *)(0)),
+      overlapFactor_(enginePage_, xMargin, yMargin + yStep * 1 + yOffset,
+                     (Engine ::OverlapFactor *)(0)),
+      windowFunction_(enginePage_, xMargin, yMargin + yStep * 2 + yOffset,
+                      (Engine ::WindowFunction *)(0))
 {
     // the sum of what it draws -- a 16 px tab bar over a 347 px page bitmap --
     // rather than the editor's height, so an overlay leaves no empty band
@@ -3248,8 +3250,6 @@ bool SpectrumWorxEditor::Settings::EnginePage::setEngineInformation(Engine::Setu
            (timeResolution_ != previousStep) || (latency_ != previousLatency);
 }
 
-/// \note Four strings and nothing computed; setEngineInformation() is what fills
-/// them and what decides when this page is repainted.
 void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 {
     PanelBackground::paint(g);
@@ -3257,22 +3257,27 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
     g.setFont(DrawableText::defaultFont());
 
     auto const line([&g](juce::String const &text, unsigned int const verticalOffset) {
-        g.drawFittedText(text, xMargin + 6, static_cast<int>(verticalOffset), 213, 18,
-                         juce::Justification::centred, 1);
+        g.drawFittedText(text, xMargin + 2, static_cast<int>(verticalOffset), 213, 18,
+                         juce::Justification::centredLeft, 1);
     });
 
-    line(engineQuality_, yMargin + yStep * 5);
-    line(frequencyResolution_, yMargin + yStep * 5 + 30);
-    line(timeResolution_, yMargin + yStep * 5 + 60);
-    line(latency_, yMargin + yStep * 5 + 90);
+    const auto infoTextY = yMargin + yStep * 5 + 67;
+    const auto lineHeight = 21;
+
+    line(engineQuality_, infoTextY + (lineHeight * 0));
+    line(frequencyResolution_, infoTextY + (lineHeight * 1));
+    line(timeResolution_, infoTextY + (lineHeight * 2));
+    line(latency_, infoTextY + (lineHeight * 3));
 }
 
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
-    : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep, "Zoom"),
-      palette_(*this, xMargin, yMargin + 1 * yStep, "Color Scheme"),
-      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 2 * yStep, "Mouse Over Reaction"),
-      lfoUpdateBehaviour_(*this, xMargin, yMargin + 3 * yStep, "LFO Update Behaviour"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 4 * yStep, "Hide cursor on knob drag")
+    : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep + yOffset, "Zoom"),
+      palette_(*this, xMargin, yMargin + 1 * yStep + yOffset, "Color Scheme"),
+      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 2 * yStep + yOffset,
+                                 "Mouse Over Reaction"),
+      lfoUpdateBehaviour_(*this, xMargin, yMargin + 3 * yStep + yOffset, "LFO Update Behaviour"),
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 4 * yStep + yOffset,
+                            "Hide cursor on knob drag")
 {
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1332,7 +1332,8 @@ class SpectrumWorxEditor final : private SkinLifetime,
       public:
         static std::uint16_t const xMargin = 30;
         static std::uint16_t const yMargin = 30;
-        static std::uint16_t const yStep = 68;
+        static std::uint16_t const yOffset = 7;
+        static std::uint16_t const yStep = 60;
     }; // class Settings
 
     /// Tab indices into Settings, in addTab() order.


### PR DESCRIPTION
Top margin for text is matching the left margin.
Reduced spacing between menus.
Left-aligned the engine info lines.
Matched spacing of engine info lines with original authors lines on About page.