### PR TITLE
Make BUILD_SHARED_LIBS=OFF actually hold (#186)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,9 @@ endif ()
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Never shared unless asked")
+# Not CACHE: without FORCE that loses to a -DBUILD_SHARED_LIBS=ON on the
+# configure line, and a shared pffft has no exported symbols (#186).
+set(BUILD_SHARED_LIBS OFF)
 
 # CI always passes one; a bare `cmake -B build` otherwise gets no optimisation
 # flags at all on single-config generators.


### PR DESCRIPTION
The line said "never shared unless asked" and set a cache entry without FORCE, which makes it a default rather than a decision: a -DBUILD_SHARED_LIBS=ON on the configure line creates the entry first, and the set() then does nothing at all. Fedora's RPM build passes one, so pffft -- the one target in the tree declared with a bare add_library() and no explicit type -- came out shared while every other library stayed an archive.

CMAKE_C_VISIBILITY_PRESET is hidden for the whole tree, so that .so exported nothing whatsoever: pffft_destroy_setup was a local symbol, and the VST3 link failed on an undefined reference to it from sw-dsp.

A normal variable shadows the cache entry through every subdirectory below it, and this one is set at line 96 against add_subdirectory(libs) at 139, so pffft reads OFF no matter what the command line asked for.

Shared builds are now unreachable rather than merely discouraged, which is what the comment should have said in the first place: visibility is hidden globally, so any of these libraries built shared would have failed exactly the way pffft did. The hatch was a trap, not a feature.

Addresses #186 

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>