### PR TITLE
Stop a fuzzed parameter set corrupting the spectrum

### DIFF
--- a/src/le/math/math.cpp
+++ b/src/le/math/math.cpp
@@ -761,6 +761,10 @@ namespace
 ///                                       (05.10.2015.) (Domagoj Saric)
 template <typename T> T moduloOf(std::uint64_t const draw, T const maximum)
 {
+    // [0, 0) has one answer; Burrito's Target Range is Minimum<0>, so a knob
+    // reaches this, and a plain modulo is SIGFPE on x86 \see issue #190
+    if (!maximum)
+        return 0;
     return static_cast<T>(narrow(draw) % maximum);
 }
 } // anonymous namespace

--- a/src/le/math/vector.cpp
+++ b/src/le/math/vector.cpp
@@ -276,14 +276,20 @@ void movingAverage(InputOutputRange const &data, unsigned int const windowWidth)
     }
 }
 
+/// \note The window is narrowed here rather than by the caller: it is counted in
+/// bins and the working range is not, so no parameter range establishes the fit.
+/// Sharper never clamped at all. \see issue #190
 void symmetricMovingAverage(InputRange const &input, OutputRange const output,
                             unsigned int const windowWidth)
 {
-    LE_ASSERT_MSG(windowWidth, "Wrong parameters.");
     LE_ASSERT_MSG(input.size() == output.size(), "Input/output buffer sizes mismatched.");
-    LE_ASSERT_MSG(unsigned(input.size()) > windowWidth, "Window larger than data.");
 
-    unsigned int const halfWindowWidth(windowWidth / 2);
+    auto const dataSize(unsigned(input.size()));
+    if (!dataSize)
+        return;
+
+    // half a window either side of a centre sample; zero is the identity
+    unsigned int const halfWindowWidth(std::min(windowWidth / 2, (dataSize - 1) / 2));
     unsigned int const fullWindowWidth(halfWindowWidth + 1 + halfWindowWidth);
     InputRange window(&input[0], &input[halfWindowWidth + 1 - 1] + 1);
     float *pOutputSample(output.begin());

--- a/src/le/parameters/lfoImpl.cpp
+++ b/src/le/parameters/lfoImpl.cpp
@@ -382,15 +382,18 @@ LFOImpl::value_type LFOImpl::getValue(Timer const &timer) const
     value_type const currentTime(freeRunning ? timer.currentTimeInReferenceBars()
                                              : timer.currentTimeInBars());
 
-    //...mrmlj...
-#ifndef NDEBUG
-    value_type const periodOffset(Math::abs(periodScale * phase()));
-#else
+    // took Math::abs under #ifndef NDEBUG, so only the build with no assertions
+    // left could reach a negative phase. \see issue #190
     value_type const periodOffset(periodScale * phase());
-#endif // _DEBUG
 
-    auto const [periodIndex, currentPeriodNormalisedPosition](
+    auto [periodIndex, currentPeriodNormalisedPosition](
         Math::splitFloat((periodOffset + currentTime) / periodScale));
+    // a position is a place inside a period; the waveforms LE_ASSUME it
+    if (currentPeriodNormalisedPosition < 0)
+    {
+        currentPeriodNormalisedPosition += 1;
+        --periodIndex;
+    }
     LE_ASSERT(currentPeriodNormalisedPosition >= 0);
     LE_ASSERT(currentPeriodNormalisedPosition <= 1);
 

--- a/src/le/spectrumworx/effects/ah_ah/ahAhImpl.cpp
+++ b/src/le/spectrumworx/effects/ah_ah/ahAhImpl.cpp
@@ -51,9 +51,11 @@ void AhAhImpl::setup(IndexRange const &indexRange, Engine::Setup const &engineSe
     //   The angular frequency is calculated so that we get the first half
     // period of a sine across the width of the filter.
     //                                        (21.10.2011.) (Domagoj Saric)
+    // a width under one bin floors to zero, and pi/0 fed process() a NaN gain
+    // for every amplitude in range; no window means a gain of one \see issue #190
     using namespace Math::Constants;
-    omega_ = pi / convert<float>(halfWidth * 2);
-    LE_ASSERT(omega_ == twoPi / 2.0f / convert<float>(halfWidth * 2));
+    omega_ = halfWidth ? (pi / convert<float>(halfWidth * 2)) : 0.0f;
+    LE_ASSERT(!halfWidth || omega_ == twoPi / 2.0f / convert<float>(halfWidth * 2));
 
     IndexRange::signed_value_type userBeginBin(centre - halfWidth);
     IndexRange::value_type userEndBin(centre + halfWidth + 1);

--- a/src/le/spectrumworx/effects/freeze/freezeImpl.cpp
+++ b/src/le/spectrumworx/effects/freeze/freezeImpl.cpp
@@ -107,7 +107,8 @@ void FreezeImpl::process(ChannelState &cs, Engine::ChannelData_AmPh data,
     cs.previousFreezeFlag = freeze_;
     cs.previousMeltFlag = melt_;
 
-    LE_ASSERT_MSG(!(freeze && melt), "Freezing and melting at the same time?");
+    // a host may send both in one block; freezing clears freezeDone, which is
+    // what the melt below is gated on, so the freeze wins \see issue #190
     //LE_ASSERT_MSG( cs.frameCounter <= 1 / inverseTransitionTime_, "Frame counter overflow."                ); //...mrmlj...
 
     if (freeze)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(sw-dsp-tests
         effects/amplifyingEffectsTests.cpp
         effects/effectsListTests.cpp
         effects/freezeTests.cpp
+        effects/parameterFuzzTests.cpp
         effects/sideChainTests.cpp
         effects/silentDefaultsTests.cpp
         goldens/engineHarness.cpp

--- a/tests/effects/parameterFuzzTests.cpp
+++ b/tests/effects/parameterFuzzTests.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file parameterFuzzTests.cpp
+/// ----------------------------
+///
+///   Every effect at randomised parameter and LFO values, the way a host's
+/// fuzzer drives it. The goldens render every effect at its *defaults*, so a
+/// defect needing two parameters at unusual values is invisible to them --
+/// which is how the four in issue #190 shipped.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "goldens/engineHarness.hpp"
+
+#include "le/parameters/lfoImpl.hpp"
+#include "le/spectrumworx/effects/configuration/constants.hpp"
+#include "le/spectrumworx/effects/configuration/effectNames.hpp"
+#include "le/spectrumworx/engine/moduleParameters.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+
+using SWTest::Slot;
+
+constexpr std::uint8_t channels{2};
+constexpr std::uint32_t sampleRate{44100};
+
+// not the goldens' 512/4: the smallest FFT is where a working range clamps
+// hardest, which is where three of the four defects lived
+constexpr std::array<SWTest::RenderSetup, 3> setups{
+    SWTest::RenderSetup{128, 4, channels, sampleRate, 256},
+    SWTest::RenderSetup{512, 4, channels, sampleRate, 256},
+    SWTest::RenderSetup{2048, 8, channels, sampleRate, 256},
+};
+
+/// \brief Every parameter and LFO of a module, at values from its own ranges.
+void randomise(LE::SW::Engine::ModuleParameters &module, SWTest::Rng &rng)
+{
+    auto const value([&rng](LE::SW::ParameterInfo const &info) {
+        auto const position((rng.nextBipolar() + 1.0f) / 2.0f);
+        return info.minimum + position * (info.maximum - info.minimum);
+    });
+
+    for (std::uint8_t index(0); index < module.numberOfParameters(); ++index)
+    {
+        auto const &info(module.parameterInfo(index));
+        if (index < LE::SW::Engine::ModuleParameters::numberOfBaseParameters)
+            module.setBaseParameter(index, value(info));
+        else
+            module.setEffectParameter(
+                LE::SW::Engine::ModuleParameters::effectSpecificParameterIndex(index), value(info));
+    }
+
+    // and every LFO: it rewrites its parameter every frame, so it reaches values
+    // no single set of writes does. phase is drawn from a list rather than
+    // uniformly because it was the negative half that broke.
+    using LFO = LE::Parameters::LFOImpl;
+    constexpr std::array<float, 5> phases{-0.5f, -0.25f, -0.05f, 0.0f, 0.5f};
+
+    for (std::uint8_t index(0); index < module.numberOfLFOControledParameters(); ++index)
+    {
+        auto &lfo(module.lfo(index));
+        auto &parameters(lfo.parameters());
+        parameters.set<LFO::Enabled>(true);
+        parameters.set<LFO::Waveform>(static_cast<LE::Parameters::LFO::Waveform>(
+            rng.next() % LE::Parameters::LFO::NumberOfWaveforms));
+        parameters.set<LFO::Phase>(phases[rng.next() % phases.size()]);
+    }
+}
+
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+TEST_CASE("No effect reads out of bounds at randomised parameter values", "[fuzz]")
+{
+    // Bypass is put back after randomising: a bypassed module proves nothing
+    for (std::uint32_t seed(1); seed <= 8; ++seed)
+    {
+        for (auto const &setup : setups)
+        {
+            for (std::int8_t effect(0);
+                 effect < static_cast<std::int8_t>(LE::SW::Effects::Constants::numberOfEffects);
+                 ++effect)
+            {
+                SWTest::Rng rng(seed * 2654435761u + static_cast<std::uint32_t>(effect));
+
+                INFO("effect " << LE::SW::Effects::effectName(static_cast<std::uint8_t>(effect))
+                               << ", fft " << setup.fftSize << ", seed " << seed);
+
+                std::array<Slot, 1> const chain{
+                    Slot{effect, [&rng](LE::SW::Engine::ModuleParameters &module) {
+                             randomise(module, rng);
+                             module.setBaseParameter(0 /*Bypass*/, 0);
+                         }}};
+
+                auto const rendered(
+                    SWTest::renderChain(setup, chain, SWTest::Signal::PinkNoise, 4096));
+                CHECK(rendered.size() > 0);
+            }
+        }
+    }
+}

--- a/tests/math/scalarTests.cpp
+++ b/tests/math/scalarTests.cpp
@@ -183,3 +183,21 @@ TEST_CASE("The magnitude bound catches what the finiteness guards cannot", "[mat
     // 100 dB over unity, stated as the conversion rather than as a literal.
     CHECK(normalisedLinear2dB(hundredDecibels) == Approx(100.0f));
 }
+
+TEST_CASE("An empty random range is answered rather than divided by", "[math][scalar]")
+{
+    // an empty interval has one answer; it was a plain modulo, silent on arm64
+    // and SIGFPE on x86, and Burrito's Target Range is Minimum<0> \see issue #190
+    LE::Math::Rng rng;
+    rng.seed(1u);
+
+    CHECK(rng.ranged(std::uint32_t(0)) == 0u);
+    CHECK(rng.ranged(std::uint16_t(0)) == 0u);
+
+    // and the non-empty case still lands inside the interval
+    for (unsigned int draw(0); draw < 64; ++draw)
+    {
+        CHECK(rng.ranged(std::uint32_t(7)) < 7u);
+        CHECK(rng.ranged(std::uint16_t(3)) < 3u);
+    }
+}

--- a/tests/math/vectorTests.cpp
+++ b/tests/math/vectorTests.cpp
@@ -251,6 +251,29 @@ TEST_CASE("movingAverage slides a window", "[math][vector]")
         CHECK(data[index] == Approx(1.0f));
 }
 
+TEST_CASE("symmetricMovingAverage survives a window wider than the data", "[math][vector]")
+{
+    // a working range is as narrow as Start and Stop make it -- one bin, at the
+    // smallest FFT -- and the window is a parameter in bins that knows neither,
+    // so this was a precondition no caller could establish \see issue #190
+    for (unsigned int size(1); size <= 8; ++size)
+    {
+        AlignedFloats const input(size);
+        AlignedFloats const output(size);
+        input.fill(1);
+        output.fill(0);
+
+        for (unsigned int window(1); window <= 16; ++window)
+        {
+            INFO("size " << size << ", window " << window);
+            Math::symmetricMovingAverage(input, output, window);
+            // A constant signal averages to itself, whatever the window does.
+            for (unsigned int index(0); index < size; ++index)
+                CHECK(output[index] == Approx(1.0f));
+        }
+    }
+}
+
 TEST_CASE("interleave and deinterleave are inverses", "[math][vector]")
 {
     constexpr std::uint16_t frames{32};

--- a/tests/parameters/lfoTests.cpp
+++ b/tests/parameters/lfoTests.cpp
@@ -510,6 +510,36 @@ TEST_CASE("Every LFO waveform stays inside the unit interval", "[lfo]")
     }
 }
 
+TEST_CASE("Every LFO waveform stays inside the unit interval at any phase", "[lfo]")
+{
+    ScopedHostTiming const timing;
+
+    // the case above sweeps at the default phase, and zero is the one value of
+    // it that cannot put the position inside a period below zero
+    //
+    // green in a checked build and red in a release one until issue #190: the
+    // offset took Math::abs under #ifndef NDEBUG, so the assertions in
+    // getValue() were measuring arithmetic the shipped build does not do
+
+    for (float const phase : {-0.5f, -0.25f, -0.05f, 0.25f, 0.5f})
+    {
+        for (std::uint8_t waveform(0); waveform < LFO::NumberOfWaveforms; ++waveform)
+        {
+            LFOImpl lfo;
+            lfo.seed(0x5A5Au + waveform);
+            withWaveform(lfo, static_cast<LFO::Waveform>(waveform));
+            lfo.parameters().set<LFOImpl::Phase>(phase);
+
+            INFO(waveformNames[waveform] << " at phase " << phase);
+            for (auto const value : overTwoPeriods(lfo, 256))
+            {
+                CHECK(value >= 0.0f);
+                CHECK(value <= 1.0f);
+            }
+        }
+    }
+}
+
 TEST_CASE("A held random waveform holds and a sliding one slides", "[lfo]")
 {
     ScopedHostTiming const timing;


### PR DESCRIPTION
An LFO handed a negative phase read a position in front of its period, which the waveform functions LE_ASSUME they never see. Sample & Glide extrapolated backwards and answered outside its own range, that mapped onto a module's Start Frequency, and the negative frequency became a bin near 65535 -- so the working range inverted and every effect walking it read far off the end of the spectrum.

Only a shipped build could reach it: the line that computes the offset took Math::abs under #ifndef NDEBUG, so the assertions that would have caught it were measuring arithmetic a user never runs.

Three more the same fuzz found, each an invariant asserted in a checked build and unenforced in a shipped one: Sharper never clamped its smoothing window to the range it was smoothing, Ah-ah divided by a filter width that rounds to zero bins and multiplied the spectrum by the NaN, and Freeze asserted a host cannot send freeze and melt in one block, which it can and which the code already handles.

The new case drives every effect at randomised parameter and LFO values; the goldens render them at their defaults and cannot see any of this.

Closes #190

Assisted-by: Claude Opus 5 (1M context)
Claude-Session: https://claude.ai/code/session_0129rvUuYBzKKi8kWUpXuuDa