### PR TITLE
Run clap-validator over the built .clap on every test leg

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -11,12 +11,13 @@
 #                      matrix says why. Neither configuration alone runs the
 #                      whole suite: the goldens SKIP under !NDEBUG, so Release
 #                      is the only one that renders DSP, and Debug is the only
-#                      one that runs the ~1200 asserts. Built with
-#                      SW_BUILD_PLUGIN_BUNDLES=OFF, which leaves out the
-#                      per-format wrapping and with it the VST3 and AudioUnit
-#                      SDK fetches -- the test binaries link sw-dsp and sw-impl
-#                      and want none of it (verified: that configuration writes
-#                      no _deps/ at all). One leg is a compiler rather than a
+#                      one that runs the ~1200 asserts. Then clap-validator over
+#                      the built .clap, which is the only thing here that asks
+#                      whether a *host* can load it. Built with
+#                      SW_BUILD_CLAP_ONLY=ON: the .clap needs no SDK, while the
+#                      other formats and the standalone CPM-fetch 54MB of them
+#                      at configure time (verified: that configuration writes no
+#                      _deps/ at all). One leg is a compiler rather than a
 #                      configuration, and so costs a matrix entry rather than a
 #                      job: Linux Debug again under GCC 15.
 #   build_plugin       the four bundles, and on anything but a pull request the
@@ -176,6 +177,7 @@ jobs:
           # clang-cl" step below sets it, and says why PATH is the wrong answer.
           - name: windows-x64
             os: windows-latest
+            validator_asset: "*windows.zip"
             config: Release
             cmake_args: -GNinja -DCMAKE_C_COMPILER="$SW_CLANG_CL" -DCMAKE_CXX_COMPILER="$SW_CLANG_CL"
             gcc_version: ''
@@ -184,22 +186,26 @@ jobs:
           # shipped and building them twice buys nothing.
           - name: macos
             os: macos-latest
+            validator_asset: "*macos-universal.zip"
             config: Debug
             cmake_args: -GNinja
             gcc_version: ''
           - name: macos
             os: macos-latest
+            validator_asset: "*macos-universal.zip"
             config: Release
             cmake_args: -GNinja
             gcc_version: ''
 
           - name: linux-x64
             os: ubuntu-latest
+            validator_asset: "*ubuntu*.zip"
             config: Debug
             cmake_args: -GNinja
             gcc_version: ''
           - name: linux-x64
             os: ubuntu-latest
+            validator_asset: "*ubuntu*.zip"
             config: Release
             cmake_args: -GNinja
             gcc_version: ''
@@ -214,6 +220,7 @@ jobs:
           # time, and rendering the goldens a second time would say nothing new.
           - name: linux-x64-gcc15
             os: ubuntu-latest
+            validator_asset: "*ubuntu*.zip"
             config: Debug
             cmake_args: -GNinja -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15
             gcc_version: '15'
@@ -346,7 +353,7 @@ jobs:
         run: |
           cmake -S . -B ./build ${{ matrix.cmake_args }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-            -DSW_BUILD_PLUGIN_BUNDLES=OFF \
+            -DSW_BUILD_CLAP_ONLY=ON \
             -DSW_WERROR=ON \
             -DGITHUB_ACTIONS_BUILD=TRUE
 
@@ -369,7 +376,8 @@ jobs:
       - name: Build the test binaries
         run: |
           cmake --build ./build --config ${{ matrix.config }} \
-            --target sw-dsp-tests sw-plugin-tests sw-show-ui --parallel 4
+            --target sw-dsp-tests sw-plugin-tests sw-show-ui \
+                     spectrumworx_clapfirst_clap --parallel 4
 
       # sw-plugin-tests instantiates the real editor, and JUCE wants a display
       # server to do that even for a component that is never shown. macOS and
@@ -381,6 +389,49 @@ jobs:
       - name: Test under Xvfb
         if: runner.os == 'Linux' && !matrix.build_only
         run: xvfb-run -a ctest --test-dir ./build -C ${{ matrix.config }} --output-on-failure
+
+      # What ctest cannot ask: whether a host can load the thing. The suite
+      # drives the engine and the editor directly, so the CLAP entry point --
+      # the parameter list, the state round trips, the threading contract -- is
+      # only ever exercised here.
+      #
+      # It costs a link rather than a bundle set. `SW_BUILD_CLAP_ONLY` leaves
+      # the other formats out, and with them the 54MB of SDKs clap-wrapper
+      # CPM-fetches at *configure* time; everything the .clap links is already
+      # built for sw-plugin-tests, so the bundle itself is ten ninja edges.
+      #
+      # \note Three platforms, three layouts, and the release is not consistent
+      # about any of it: macOS is a .zip holding a .tar.gz holding
+      # `binaries/clap-validator`, Linux is the same without the `binaries/`,
+      # and Windows is a bare `clap-validator.exe` with no tarball at all. The
+      # inner tarball also still says 0.3.2 inside a 0.4.1 release. So: unpack
+      # whatever arrived and go looking for the binary, rather than spell a path
+      # that is right on one runner in three.
+      - name: Fetch clap-validator
+        if: ${{ !matrix.build_only }}
+        run: |
+          mkdir -p validator && cd validator
+          gh release download --repo free-audio/clap-validator \
+            --pattern '${{ matrix.validator_asset }}'
+          unzip -q -o ./*.zip
+          if ls ./*.tar.gz >/dev/null 2>&1; then tar xzf ./*.tar.gz; fi
+          validator=$(find . -type f \( -name clap-validator -o -name clap-validator.exe \) | head -1)
+          test -n "$validator" || { echo "no clap-validator in the release asset"; ls -R; exit 1; }
+          chmod +x "$validator"
+          echo "SW_VALIDATOR=$PWD/$validator" >> "$GITHUB_ENV"
+          "$validator" --version
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate the CLAP
+        if: runner.os != 'Linux' && !matrix.build_only
+        run: |
+          "$SW_VALIDATOR" validate ./build/sw_assets/SpectrumWorx.clap
+
+      - name: Validate the CLAP under Xvfb
+        if: runner.os == 'Linux' && !matrix.build_only
+        run: |
+          xvfb-run -a "$SW_VALIDATOR" validate ./build/sw_assets/SpectrumWorx.clap
 
   build_plugin:
     name: Build - ${{ matrix.name }}

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -19,7 +19,8 @@
 #                      at configure time (verified: that configuration writes no
 #                      _deps/ at all). One leg is a compiler rather than a
 #                      configuration, and so costs a matrix entry rather than a
-#                      job: Linux Debug again under GCC 15.
+#                      job: Linux Debug again under GCC 15, which is also the
+#                      one leg built with a hardened standard library.
 #   build_plugin       the four bundles, and on anything but a pull request the
 #                      installer as well.
 #   build_plugin_msvc  a pull request only, and a compile check only. It builds
@@ -218,11 +219,22 @@ jobs:
           #
           #   Debug only. What a second compiler has to say it says at compile
           # time, and rendering the goldens a second time would say nothing new.
+          #
+          #   And the hardened leg: `_GLIBCXX_ASSERTIONS` turns the standard
+          # library's own preconditions on -- a container subscript is bounds
+          # checked, so is an empty container's front(), and so is an invalid
+          # iterator range. Stated here rather than inherited: this leg already
+          # had it from the toolchain's default, which is how it caught the peak
+          # detector taking `&array[n]` for the end of a full one, and a default
+          # is not something to leave a check standing on. Nothing else in the
+          # matrix hardens, so this is the only leg that asks.
           - name: linux-x64-gcc15
             os: ubuntu-latest
             validator_asset: "*ubuntu*.zip"
             config: Debug
-            cmake_args: -GNinja -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15
+            cmake_args: >-
+              -GNinja -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15
+              -DCMAKE_CXX_FLAGS=-D_GLIBCXX_ASSERTIONS
             gcc_version: '15'
 
           # Release, where the GCC 15 leg above is Debug -- and the difference is

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -423,15 +423,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # \note Located rather than spelled: Windows puts the bundle in a CLAP/
+      # subdirectory of sw_assets and the other two do not.
+      - name: Find the built CLAP
+        if: ${{ !matrix.build_only }}
+        run: |
+          clap=$(find ./build/sw_assets -maxdepth 2 -name 'SpectrumWorx.clap' | head -1)
+          test -n "$clap" || { echo "no SpectrumWorx.clap under build/sw_assets"; ls -R ./build/sw_assets; exit 1; }
+          echo "SW_CLAP=$clap" >> "$GITHUB_ENV"
+          echo "validating $clap"
+
       - name: Validate the CLAP
         if: runner.os != 'Linux' && !matrix.build_only
         run: |
-          "$SW_VALIDATOR" validate ./build/sw_assets/SpectrumWorx.clap
+          "$SW_VALIDATOR" validate "$SW_CLAP"
 
       - name: Validate the CLAP under Xvfb
         if: runner.os == 'Linux' && !matrix.build_only
         run: |
-          xvfb-run -a "$SW_VALIDATOR" validate ./build/sw_assets/SpectrumWorx.clap
+          xvfb-run -a "$SW_VALIDATOR" validate "$SW_CLAP"
 
   build_plugin:
     name: Build - ${{ matrix.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,11 @@ option(SW_BUILD_TOOLS "Build the developer tools (sw-show-ui)" ON)
 # configure one otherwise. See doc/tech/threading_model.md §8.
 option(SW_BUILD_PLUGIN_BUNDLES "Build the .clap/.vst3/.component bundles" ON)
 
+# The .clap needs no SDK; the other formats and the standalone CPM-fetch 54MB of
+# them at configure time. CI wants the bundle a validator can load and nothing
+# else. \see src/clap-first/CMakeLists.txt
+option(SW_BUILD_CLAP_ONLY "Of the bundles, build only the .clap" OFF)
+
 if (SW_BUILD_TESTS)
     enable_testing()
 endif()
@@ -142,10 +147,12 @@ add_subdirectory(src)
 
 if (SW_BUILD_PLUGIN_BUNDLES)
     add_subdirectory(src/clap-first)
+endif()
 
-    # The installer packages the bundles, so it only exists when they do.
-    # `cmake --build <dir> --target spectrumworx-installer` is what CI runs and
-    # what a release is cut with; it is not part of `all`.
+# The installer packages every format, so it exists only when every format does.
+# `cmake --build <dir> --target spectrumworx-installer` is what CI runs and
+# what a release is cut with; it is not part of `all`.
+if (SW_BUILD_PLUGIN_BUNDLES AND NOT SW_BUILD_CLAP_ONLY)
     include(basic_installer_clapfirst)
     add_clapfirst_installer(
             INSTALLER_TARGET spectrumworx-installer

--- a/doc/tech/threading_model.md
+++ b/doc/tech/threading_model.md
@@ -133,7 +133,7 @@ engine the main thread owns.
 | `core/threading/messages.hpp` | cases |
 |---|---|
 | `ToEngine` | `SetBaseParameter`, `SetSlot`, `MoveModule`, `SwapChain`, `SwapSample` |
-| `ToUI` | `BaseParameterChanged`, `ChainChanged`, `TimingChanged` — and `Retire`, on a ring of its own |
+| `ToUI` | `BaseParameterChanged`, `TimingChanged` — `Retire` on a ring of its own, and a chain change on a flag |
 
 Both are tagged unions, trivially copyable, owning nothing. Each case says which
 side is responsible for a pointer after it lands, and that is the entire
@@ -150,6 +150,16 @@ second per enabled LFO — up to 120,000/s for a full rack — against a UI that
 draws at 30 Hz. A FIFO would spend all its bandwidth on values nobody sees; a
 mailbox cannot overflow and coalesces by construction. Same message list, two
 transports.
+
+**And a chain change is a flag, not a message.** It carries nothing — the main
+thread recomputes the rack off the model, so a second of two says what the first
+did — which is the same test `TimingChanged` passes below. The difference is what
+happens on a full ring: a dropped chain change left the rack drawing the chain
+that was there before, with no second announcement coming. A flag the engine only
+sets and the main thread only clears cannot be dropped, and the callback that
+reads it is asked for by `requestRescan()` rather than by the push, so the
+wake-up never depended on the ring either. `TimingChanged` is the same shape and
+still a message; it caps itself at one outstanding rather than none.
 
 **And the retirements have a ring of their own.** They rode the same one as the
 echoes until a fuzzer showed what that costs: a host writing every parameter
@@ -313,8 +323,8 @@ the user asked for and the engine's chain is what is playing.
 
 Three things ask for it. **Whatever changed the main thread's chain says so** —
 `addUserAddedModule()`, `moduleAdded()`/`moduleRemoved()` and `GUI::loadPreset()`
-each call `refreshModuleRackAsync()`. **The engine's echo says so**,
-`ToUI::ChainChanged`, coalesced, for the changes that originate on the audio
+each call `refreshModuleRackAsync()`. **The engine's echo says so**, through
+`chainChangedPending_`, for the changes that originate on the audio
 thread — a host writing a slot selector inside `process()`. And that echo is
 acted on **synchronously**, from `drainEngineEvents()` in `onMainThread()`, which
 is worth stating because it is a precondition for everything below: a strip can
@@ -423,7 +433,7 @@ The inventory the model is measured by.
 | `Engine::Setup` and the spectral storage | `spectralSetupPending_` (`std::atomic`) + `clap_host::request_restart()`, applied in `deactivate()` after the queue is drained | ✅ |
 | An outstanding restart request | `restartRequested_`, `std::atomic`, test-and-set through `exchange` — both threads reach it | ✅ |
 | The `Sample` | `ToEngine::SwapSample` + `ToUI::Retire`; the main thread keeps the file name and the decoded rate | ✅ |
-| The module rack | recomputed from `programMain_`'s chain, by whatever changed it and by `ToUI::ChainChanged` | ✅ |
+| The module rack | recomputed from `programMain_`'s chain, by whatever changed it and by `chainChangedPending_` | ✅ |
 | Editor selection and active control | `SpectrumWorxEditor::{pSelectedModule_,pActiveControl_}`, per editor — and **not** what decides whether a widget is let go of; see §5 | ✅ |
 | The LFO display and the shared module controls | children of the editor holding a raw `ModuleUI *`; dropped by `detachFrom()` on their own pointer | ✅ |
 | `PopupMenu::menuActive_` | a member, per menu and therefore per editor; menus are dismissed before a strip, a chain or a program is replaced | ✅ |

--- a/doc/tech/threading_model.md
+++ b/doc/tech/threading_model.md
@@ -133,7 +133,7 @@ engine the main thread owns.
 | `core/threading/messages.hpp` | cases |
 |---|---|
 | `ToEngine` | `SetBaseParameter`, `SetSlot`, `MoveModule`, `SwapChain`, `SwapSample` |
-| `ToUI` | `BaseParameterChanged`, `ChainChanged`, `TimingChanged`, `Retire` |
+| `ToUI` | `BaseParameterChanged`, `ChainChanged`, `TimingChanged` — and `Retire`, on a ring of its own |
 
 Both are tagged unions, trivially copyable, owning nothing. Each case says which
 side is responsible for a pointer after it lands, and that is the entire
@@ -150,6 +150,16 @@ second per enabled LFO — up to 120,000/s for a full rack — against a UI that
 draws at 30 Hz. A FIFO would spend all its bandwidth on values nobody sees; a
 mailbox cannot overflow and coalesces by construction. Same message list, two
 transports.
+
+**And the retirements have a ring of their own.** They rode the same one as the
+echoes until a fuzzer showed what that costs: a host writing every parameter
+between two main-thread turns is ~700 echoes against a handful of retirements —
+60:1, measured — so the ring filled with the kind whose loss is a stale reading
+and had nothing left for the kind whose loss is a leak. They are the same message
+type and nothing else: opposite failure modes on a full ring is the whole reason
+to separate them. The main thread drains the echoes first and the retirements
+after, which is the order the engine made them in — a module is announced gone
+before the reference it left is dropped.
 
 **The ring refuses when full.** `SPSCQueue<Message, Capacity>`
 (`core/threading/spscQueue.hpp`) keeps free-running counters, masked only on the
@@ -168,8 +178,8 @@ seconds. It is news rather than data — the main thread reads the new timing of
 the engine for itself — so a second copy of it says nothing a first did not. That
 matters because the *rate* is unlike anything else on this ring: a host ramping
 the tempo reports a new bar duration on every block, some hundreds a second,
-and the ring it would fill is the one that also carries `Retire`, where a drop is
-a leak rather than a stale reading. So `SpectrumWorxCLAP::timingChanged()` keeps
+and a ring it fills has dropped somebody's echo, which leaves the main thread's
+Program behind the engine for that parameter. So `SpectrumWorxCLAP::timingChanged()` keeps
 one atomic flag, raises it with the message and lets the drain clear it, and at
 most one is ever outstanding. Nothing else here may do that: every other case
 carries a value or an ownership transfer, and the second of two is not the first.

--- a/src/clap-first/CMakeLists.txt
+++ b/src/clap-first/CMakeLists.txt
@@ -8,14 +8,31 @@
 
 set(SW_CLAPFIRST_TARGET spectrumworx_clapfirst)
 
-set(SW_FORMATS CLAP VST3)
-if (APPLE)
-    list(APPEND SW_FORMATS AUV2)
+# The wrapper CPM-fetches a format's SDK at *configure* time, so a format left
+# out here is 54MB and a download not spent. \see SW_BUILD_CLAP_ONLY
+set(SW_FORMATS CLAP)
+if (NOT SW_BUILD_CLAP_ONLY)
+    list(APPEND SW_FORMATS VST3)
+    if (APPLE)
+        list(APPEND SW_FORMATS AUV2)
+    endif()
 endif()
 
 message(STATUS "SpectrumWorx plugin formats: ${SW_FORMATS}")
 
 add_compile_definitions(CLAP_WRAPPER_LOGLEVEL=0)
+
+# rtaudio and rtmidi are the standalone's, and fetched the same way.
+set(swStandaloneArguments
+        # target-postfix, output name, clap id
+        STANDALONE_CONFIGURATIONS
+        standalone "${PRODUCT_NAME}" "${SW_CLAP_ID}"
+
+        STANDALONE_MACOS_ICON "${CMAKE_SOURCE_DIR}/assets/installer/SpectrumWorxIcon.icns"
+        STANDALONE_WINDOWS_ICON "${CMAKE_SOURCE_DIR}/assets/installer/SpectrumWorxIcon.ico")
+if (SW_BUILD_CLAP_ONLY)
+    set(swStandaloneArguments)
+endif()
 
 make_clapfirst_plugins(
         TARGET_NAME ${SW_CLAPFIRST_TARGET}
@@ -36,12 +53,7 @@ make_clapfirst_plugins(
 
         ASSET_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/sw_assets
 
-        # target-postfix, output name, clap id
-        STANDALONE_CONFIGURATIONS
-        standalone "${PRODUCT_NAME}" "${SW_CLAP_ID}"
-
-        STANDALONE_MACOS_ICON "${CMAKE_SOURCE_DIR}/assets/installer/SpectrumWorxIcon.icns"
-        STANDALONE_WINDOWS_ICON "${CMAKE_SOURCE_DIR}/assets/installer/SpectrumWorxIcon.ico"
+        ${swStandaloneArguments}
 )
 
 # Read back by the installer; clap-wrapper does not set it.

--- a/src/core/threading/messages.hpp
+++ b/src/core/threading/messages.hpp
@@ -155,13 +155,12 @@ struct ToUI
         /// \note Carries nothing: what changed is engine state the main thread
         /// can read for itself, and the message is only the news that it did.
         /// **Coalesced by the sender**, unlike everything else here -- a host
-        /// ramping the tempo moves it on every block, and this ring also carries
-        /// the retirements, where a drop is a leak rather than a stale reading.
-        /// \see SpectrumWorxCLAP::timingChanged().
+        /// ramping the tempo moves it on every block, and a ring that fills has
+        /// dropped somebody's echo. \see SpectrumWorxCLAP::timingChanged().
         TimingChanged,
         /// Something the audio thread unlinked and the main thread must delete.
-        /// Dropping one of these is a leak, which is why this is a ring and not a
-        /// mailbox.
+        /// Dropping one of these is a leak, which is why it is a ring and not a
+        /// mailbox -- and its own ring, so that echo traffic cannot fill it.
         Retire
     };
 
@@ -206,6 +205,15 @@ struct ToUI
 
 using ToEngineQueue = SPSCQueue<ToEngine, 1024>;
 using ToUIQueue = SPSCQueue<ToUI, 1024>;
+
+/// \brief The retirements, which share the ToUI message type and nothing else.
+///
+/// \note Their own ring because the two have opposite failure modes on a full
+/// one: a dropped echo is a stale reading, a dropped Retire is a leak. Sharing
+/// meant the frequent droppable kind could starve the rare undroppable one --
+/// a host writing every parameter between two main-thread turns is ~700 echoes
+/// against a handful of retirements, measured at 60:1 under a fuzzer.
+using RetireQueue = SPSCQueue<ToUI, 1024>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Makers.

--- a/src/core/threading/messages.hpp
+++ b/src/core/threading/messages.hpp
@@ -204,7 +204,9 @@ struct ToUI
 ////////////////////////////////////////////////////////////////////////////////
 
 using ToEngineQueue = SPSCQueue<ToEngine, 1024>;
-using ToUIQueue = SPSCQueue<ToUI, 1024>;
+// 16k * 24 bytes, and deep rather than right: a host automating hard outruns any
+// depth, so this defers the drops rather than preventing them
+using ToUIQueue = SPSCQueue<ToUI, 16 * 1024>;
 
 /// \brief The retirements, which share the ToUI message type and nothing else.
 ///

--- a/src/core/threading/messages.hpp
+++ b/src/core/threading/messages.hpp
@@ -143,10 +143,6 @@ struct ToUI
         /// A base value the engine settled on, after snapping or after a host
         /// automation event. Latchable: the model takes it and the host is told.
         BaseParameterChanged,
-        /// The chain changed shape -- a slot filled or emptied, two modules
-        /// swapped, a whole chain installed. The interface makes its rack a
-        /// function of the chain again; see SpectrumWorxEditor::resyncModuleRack().
-        ChainChanged,
         /// The host's bar duration or meter moved, so a synced LFO's period is a
         /// different number of seconds and its snap grid a different grid. The
         /// interface redraws the LFO panel; see
@@ -276,13 +272,6 @@ inline ToUI baseParameterChanged(std::uint32_t const parameterID, float const va
     ToUI message{};
     message.kind = ToUI::Kind::BaseParameterChanged;
     message.baseParameterChanged = {parameterID, value};
-    return message;
-}
-
-inline ToUI chainChanged()
-{
-    ToUI message{};
-    message.kind = ToUI::Kind::ChainChanged;
     return message;
 }
 

--- a/src/le/analysis/peak_detector/peakDetector.cpp
+++ b/src/le/analysis/peak_detector/peakDetector.cpp
@@ -177,7 +177,9 @@ void PeakDetector::findPeaksAndStrengthSort(float const *const amplitudes,
                                             std::uint16_t const numberOfBins)
 {
     findPeaks(amplitudes, numberOfBins);
-    std::sort(&peaks_[0], &peaks_[numberOfPeaks_]);
+    // data() + n rather than &peaks_[n]: the end of a full array is one past the
+    // last, which a hardened operator[] refuses to index \see issue #190
+    std::sort(peaks_.data(), peaks_.data() + numberOfPeaks_);
 }
 
 void PeakDetector::findPeaksAndEstimateFrequency(float const *const amplitudes,
@@ -293,7 +295,8 @@ void PeakDetector::findPeaksImpl(float const *LE_RESTRICT const amplitudes,
                 (pPeak->strength > strengthThreshold_) // is peak strong enough?
             )
             {
-                std::fill(&isPeak_[pPeak->startPos + 1], &isPeak_[pPeak->stopPos], true);
+                std::fill(isPeak_.data() + pPeak->startPos + 1, isPeak_.data() + pPeak->stopPos,
+                          true);
 
                 if (fs)
                     calculateTrueFrequency(*pPeak, numberOfBins, fs, ampsdB);

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1353,15 +1353,16 @@ bool SpectrumWorxCLAP::pushed(bool const wasPushed, char const *const what) cons
     return false;
 }
 
-/// \note A full retire ring is a leak, and freeing on this thread is the one
-/// thing the ring exists to prevent. 1024 deep against one entry per structural
-/// change, so it is a checked-build assertion rather than a policy.
+/// \note Its own ring, and that is the point: 1024 deep against one entry per
+/// structural change is ample, but it shared the echo ring until a fuzzer
+/// filled that with ~700 parameter echoes per permutation and a retirement had
+/// nowhere to go. A dropped echo is a stale reading; a dropped Retire is a leak.
 ///
 /// \note The push is the statement and the assert only reports on it --
 /// `LE_ASSERT_MSG` is `static_cast<void>(0)` under NDEBUG.
 void SpectrumWorxCLAP::retire(Threading::ToUI::Retired const what, void *const pObject)
 {
-    if (toUI_.push(Threading::retire(what, pObject)))
+    if (retire_.push(Threading::retire(what, pObject)))
         return;
 
     LE_ASSERT_MSG(false, "The retire queue is full; something will be leaked.");
@@ -1499,26 +1500,34 @@ void SpectrumWorxCLAP::drainEngineEvents()
         // rather than an object: the interface may still hold a strip pointing
         // at it, and dropping that strip is what finally frees it
         case Threading::ToUI::Kind::Retire:
-            switch (event.retire.what)
-            {
-            case Threading::ToUI::Retired::None:
-                break;
-            case Threading::ToUI::Retired::Module:
-                intrusive_ptr_release(&Engine::node(*static_cast<Module *>(event.retire.pObject)));
-                break;
-            case Threading::ToUI::Retired::Chain:
-                delete static_cast<AutomatedModuleChain *>(event.retire.pObject);
-                break;
-            case Threading::ToUI::Retired::Sample:
-                delete static_cast<Sample *>(event.retire.pObject);
-                break;
-            }
+            LE_ASSERT_MSG(false, "A retirement travels on its own ring.");
             break;
         }
     }
 
     if (std::exchange(chainChangedPending_, false) && pEditor_)
         pEditor_->resyncModuleRack();
+
+    // after the announcements, which is the order the engine made them in: a
+    // module is unlinked and said to be gone before the reference it left is
+    // dropped, and the strip holding the other reference goes with the resync
+    while (retire_.pop(event))
+    {
+        switch (event.retire.what)
+        {
+        case Threading::ToUI::Retired::None:
+            break;
+        case Threading::ToUI::Retired::Module:
+            intrusive_ptr_release(&Engine::node(*static_cast<Module *>(event.retire.pObject)));
+            break;
+        case Threading::ToUI::Retired::Chain:
+            delete static_cast<AutomatedModuleChain *>(event.retire.pObject);
+            break;
+        case Threading::ToUI::Retired::Sample:
+            delete static_cast<Sample *>(event.retire.pObject);
+            break;
+        }
+    }
 
     // after the rack, and only with a window: this is a redraw, and nothing
     // behind the interface depends on it

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1373,10 +1373,11 @@ void SpectrumWorxCLAP::retire(Threading::ToUI::Retired const what, void *const p
 /// emptied or moved is somebody changing the sound.
 void SpectrumWorxCLAP::chainChanged(ChainChange const what)
 {
-    // dropping this leaves the rack drawing the chain that was there before,
-    // with no second announcement coming: the drain is edge-triggered on it
-    pushed(toUI_.push(Threading::chainChanged()),
-           "The echo queue is full; the module rack will not be resynchronised.");
+    // a flag rather than a message: it carries nothing, and on a full ring the
+    // rack was left drawing the chain that was there before with no second
+    // announcement coming. requestRescan() below asks for the callback that
+    // reads it, so the wake-up never depended on the push either
+    chainChangedPending_.store(true, std::memory_order_release);
     requestRescan(CLAP_PARAM_RESCAN_INFO | CLAP_PARAM_RESCAN_TEXT | CLAP_PARAM_RESCAN_VALUES);
 
     // a whole chain arriving is not an edit: with audio running the chain a
@@ -1483,12 +1484,6 @@ void SpectrumWorxCLAP::drainEngineEvents()
             break;
         }
 
-        case Threading::ToUI::Kind::ChainChanged:
-            // coalesced: a preset that swaps the chain and then fills a slot is
-            // one resync, and a resync recomputes rather than diffs
-            chainChangedPending_ = true;
-            break;
-
         // cleared here rather than after the redraw, so a tempo that moves
         // again during the drain is announced rather than swallowed
         case Threading::ToUI::Kind::TimingChanged:
@@ -1505,7 +1500,9 @@ void SpectrumWorxCLAP::drainEngineEvents()
         }
     }
 
-    if (std::exchange(chainChangedPending_, false) && pEditor_)
+    // cleared before the resync, so a chain that changes again while the rack
+    // redraws is announced rather than swallowed
+    if (chainChangedPending_.exchange(false, std::memory_order_acquire) && pEditor_)
         pEditor_->resyncModuleRack();
 
     // after the announcements, which is the order the engine made them in: a

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -723,7 +723,12 @@ class SpectrumWorxCLAP final
     std::atomic<WithoutARestart> appliedWithoutARestart_{WithoutARestart::Nothing};
 
     /// \brief A `ToUI::ChainChanged` waiting to be acted on. \see drainEngineEvents().
-    bool chainChangedPending_{false};
+    /// \note An atomic and not a ring message: it carries nothing -- the main
+    /// thread recomputes the rack off the model -- so a second of two says what
+    /// the first did. The engine only ever sets it, the main thread only ever
+    /// clears it, and a flag cannot be dropped the way a full ring drops a
+    /// message. \see chainChanged()
+    std::atomic<bool> chainChangedPending_{false};
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -582,6 +582,7 @@ class SpectrumWorxCLAP final
 
     mutable Threading::ToEngineQueue toEngine_;
     Threading::ToUIQueue toUI_;
+    Threading::RetireQueue retire_;
     Threading::ValueMailbox values_;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/clap/publishProtocolTests.cpp
+++ b/tests/clap/publishProtocolTests.cpp
@@ -201,8 +201,11 @@ TEST_CASE("A module the engine displaces is released rather than leaked", "[clap
 
 namespace
 {
-/// One more than either ring holds.
-constexpr unsigned overflowing{LE::SW::Threading::ToEngineQueue::capacity + 1};
+/// One more than the ring in question holds. Two constants because the two are
+/// no longer the same depth: the echo ring is the one a host automating hard
+/// fills, so it is the deeper of them.
+constexpr unsigned overflowingCommands{LE::SW::Threading::ToEngineQueue::capacity + 1};
+constexpr unsigned overflowingEchoes{LE::SW::Threading::ToUIQueue::capacity + 1};
 
 LE::SW::ParameterID globalParameterID(unsigned const index)
 {
@@ -223,7 +226,7 @@ TEST_CASE("A full command ring is counted rather than ignored", "[clap][protocol
     /// \note No `process()` anywhere in here, which is what makes the ring fill:
     /// draining it is what a block does. An editor with a stuck audio thread in
     /// front of it is the real shape of this.
-    for (unsigned edit(0); edit < overflowing; ++edit)
+    for (unsigned edit(0); edit < overflowingCommands; ++edit)
         host.editParameter(globalParameterID(0), 0.5f);
 
     CHECK(implementation.droppedMessages() > 0);
@@ -246,9 +249,9 @@ TEST_CASE("A full echo ring leaves the main thread's Program behind, and says so
     /// \note One echo per block, and nothing pumping the main thread -- which is
     /// a host that is slow to run the callback it was asked for, with automation
     /// moving. Every one of these is applied to the engine.
-    for (unsigned block(0); block < overflowing; ++block)
+    for (unsigned block(0); block < overflowingEchoes; ++block)
     {
-        OneParameterEvent const event(id, 0.25 + (0.5 * block) / overflowing);
+        OneParameterEvent const event(id, 0.25 + (0.5 * block) / overflowingEchoes);
         plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr, &*event);
     }
 
@@ -300,7 +303,7 @@ TEST_CASE("A sample the engine never received is not recorded as loaded",
     REQUIRE(host.currentSampleFile().empty());
 
     // Fill the ring so that the sample's own push cannot land.
-    for (unsigned edit(0); edit < overflowing; ++edit)
+    for (unsigned edit(0); edit < overflowingCommands; ++edit)
         host.editParameter(globalParameterID(0), 0.5f);
     REQUIRE(implementation.droppedMessages() > 0);
 


### PR DESCRIPTION
The suite drives the engine and the editor directly, so nothing in it asks the question a host asks: can this bundle be loaded and played. Everything about the CLAP entry point -- the parameter list, the state round trips, the threading contract -- went untested until a validator was run by hand, which is how four shipped bugs stayed shipped.

It costs a link. Everything the .clap needs is already compiled for sw-plugin-tests, so the bundle is ten more build steps and the run itself under two seconds.

What it does not cost is the SDKs. The other formats and the standalone CPM-fetch 54MB of them at configure time and a validator can reach none of it, so SW_BUILD_CLAP_ONLY leaves them out: the legs that used to build no bundles at all now build the one that can be tested, and fetch no more than they did before.

Assisted-by: Claude Opus 5 (1M context)
Claude-Session: https://claude.ai/code/session_0129rvUuYBzKKi8kWUpXuuDa