### PR TITLE
Tell the host a parameter is being edited only when it is

### DIFF
--- a/src/core/host_interop/plugin2Host.cpp
+++ b/src/core/host_interop/plugin2Host.cpp
@@ -75,7 +75,8 @@ void Plugin2HostInteropControler::moduleChangedByUser(std::uint8_t const chainPa
 void Plugin2HostInteropControler::automatedParameterChanged(Module const &module,
                                                             std::uint8_t const moduleIndex,
                                                             std::uint8_t const moduleParameterIndex,
-                                                            float const parameterValue) const
+                                                            float const parameterValue,
+                                                            bool const asDiscreteGesture) const
 {
     //LE_ASSERT( moduleParameterID.moduleParameterIndex < Constants::maxNumberOfParametersPerModule ); //...mrmlj...TuneWorx...
     /// \todo Consider a smarter place to put this check (currently needed only
@@ -90,7 +91,11 @@ void Plugin2HostInteropControler::automatedParameterChanged(Module const &module
     Plugin2HostInteropControler::ParameterValueForAutomation const automationValue = {
         Automation::internal2AutomatedValue(moduleParameterIndex, parameterValue, false, module),
         Automation::internal2AutomatedValue(moduleParameterIndex, parameterValue, true, module)};
+    if (asDiscreteGesture)
+        automatedParameterBeginEdit(parameterID);
     automatedParameterChanged(parameterID, automationValue);
+    if (asDiscreteGesture)
+        automatedParameterEndEdit(parameterID);
 }
 
 void Plugin2HostInteropControler::automatedParameterChanged(ParameterID::LFO const lfoParameterID,

--- a/src/core/host_interop/plugin2Host.hpp
+++ b/src/core/host_interop/plugin2Host.hpp
@@ -90,8 +90,12 @@ class Plugin2HostInteropControler
     }
 
     void automatedParameterChanged(ParameterID::LFO, float value) const;
+    /// \param asDiscreteGesture wraps the change in a gesture of its own, for an
+    /// edit that is not part of a drag -- a wheel notch, a menu row, a typed
+    /// value. A drag brackets itself and passes false. \see issue #188.
     void automatedParameterChanged(Module const &, std::uint8_t moduleIndex,
-                                   std::uint8_t moduleParameterIndex, float parameterValue) const;
+                                   std::uint8_t moduleParameterIndex, float parameterValue,
+                                   bool asDiscreteGesture) const;
     void modulesChanged(AutomatedModuleChain const &, std::uint8_t firstModuleIndex,
                         std::uint8_t lastModuleIndex) const;
     void moduleChangedByUser(std::uint8_t chainParameterIndex, Module const *) const;

--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -322,6 +322,31 @@ void SharedModuleControls::FrequencyRange::mouseDrag(juce::MouseEvent const &eve
     juce::Slider::mouseDrag(refinedDrag(fine_, event));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Guarded on the LFO exactly as mouseDrag() above is, and on a thumb
+/// being selected for the same reason: with neither there is no parameter for a
+/// gesture to be about.
+///
+/// \note The end asks the control rather than repeating the test. Whether the
+/// LFO owns this parameter is a question that can change while the mouse is
+/// down -- the right button menu's switch is one way -- and what has to balance
+/// is the gesture that was actually opened.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SharedModuleControls::FrequencyRange::startedDragging() noexcept
+{
+    if ((selectedThumb_ != Constants::noThumb) && !lfo().enabled())
+        beginGesture();
+}
+
+void SharedModuleControls::FrequencyRange::stoppedDragging() noexcept
+{
+    if (gestureIsOpen())
+        endGesture();
+}
+
 void SharedModuleControls::FrequencyRange::mouseMove(juce::MouseEvent const &event) noexcept
 {
     updateSliderSelection(event);

--- a/src/gui/editor/auxiliaryComponents.hpp
+++ b/src/gui/editor/auxiliaryComponents.hpp
@@ -111,6 +111,13 @@ class SharedModuleControls : public WidgetBase<>
         void mouseDown(juce::MouseEvent const &) noexcept override;
         void mouseDrag(juce::MouseEvent const &) noexcept override;
 
+        /// \brief The press and the release, which is what a host gesture
+        /// brackets. \see issue #188.
+        ///@{
+        void startedDragging() noexcept override;
+        void stoppedDragging() noexcept override;
+        ///@}
+
         void mouseEnter(juce::MouseEvent const &) noexcept override;
         void mouseExit(juce::MouseEvent const &) noexcept override;
 

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1469,8 +1469,6 @@ void SpectrumWorxEditor::moduleControlActivated(ModuleControlBase &control, doub
     setActiveModuleName(control.moduleUI().getName());
     setActiveControlName(control.widget().getName());
     updateActiveControlValue();
-
-    host().automatedParameterBeginEdit(moduleControlID(control));
 }
 
 void SpectrumWorxEditor::moduleControlDectivated(ModuleControlBase const &control)
@@ -1484,8 +1482,39 @@ void SpectrumWorxEditor::moduleControlDectivated(ModuleControlBase const &contro
     setActiveControlValue(juce::String());
 
     retireLFODisplay();
+}
 
-    host().automatedParameterEndEdit(moduleControlID(control));
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The gesture a module control's drag is held in, opened on the press
+/// and closed on the release.
+///
+/// \note Which is all a gesture is for. Selecting a control used to open one --
+/// `moduleControlActivated()` did, and `focusGained` reaches that -- so merely
+/// clicking a knob and then reaching for another told the host two parameters
+/// were being edited, in the order `end( the first )`, `begin( the second )`. A
+/// host with MIDI learn armed takes the first parameter it hears about, so it
+/// learned the knob the user had walked away from. \see issue #188.
+///
+/// \note An edit that is not a drag -- a wheel notch, a menu row, a typed value
+/// -- brackets itself instead, through `asDiscreteGesture`. \see
+/// ModuleControlBase::publishValue().
+///
+/// \note The ID rather than the control, so that a begin and its end cannot name
+/// different parameters. The frequency range is one widget standing for two, and
+/// `FrequencyRange::valueChanged()` can move it from one thumb to the other while
+/// the mouse is still down. \see ModuleControlBase::beginGesture().
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::moduleControlGestureBegin(ParameterID const parameterID) const
+{
+    host().automatedParameterBeginEdit(parameterID);
+}
+
+void SpectrumWorxEditor::moduleControlGestureEnd(ParameterID const parameterID) const
+{
+    host().automatedParameterEndEdit(parameterID);
 }
 
 void SpectrumWorxEditor::retireLFODisplay()
@@ -1522,10 +1551,11 @@ void SpectrumWorxEditor::retireLFODisplay()
 /// control had it -- and that calls `moduleControlDectivated()`, which asserts
 /// that the LFO display for that control is still there.
 ///
-/// \note Deliberately **not** `moduleControlDectivated()`: that ends the host's
-/// automation gesture, and `moduleControlID()` walks the chain for the control's
-/// module -- which by the time a strip is dropped has left it. The gesture is
-/// ended on the path that removes the module, where the module is still there.
+/// \note Deliberately **not** `moduleControlDectivated()`: it asserts that the
+/// LFO display is still there, and clearing `pActiveControl_` first is what makes
+/// the focus loss a no-op. Deactivation used to end the host's automation
+/// gesture too, which a dropped strip could not name a parameter for; a gesture
+/// now lasts only as long as the mouse is down. \see issue #188.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2070,7 +2100,8 @@ void SpectrumWorxEditor::queueGlobalParameter(std::uint8_t const index, float co
 
 void SpectrumWorxEditor::updateModuleParameterAndNotifyHost(ModuleUI &moduleUI,
                                                             std::uint8_t const moduleParameterIndex,
-                                                            float const parameterValue) const
+                                                            float const parameterValue,
+                                                            bool const asDiscreteGesture) const
 {
     auto &module(moduleUI.module());
     std::uint8_t const moduleIndex(moduleChain().getIndexForModule(module));
@@ -2085,7 +2116,8 @@ void SpectrumWorxEditor::updateModuleParameterAndNotifyHost(ModuleUI &moduleUI,
     // automatedParameterChanged queues into the ring the host collects on its
     // next process() or flush(), and the requestParameterFlush() inside it is
     // what gets the command drained with the transport parked
-    host().automatedParameterChanged(module, moduleIndex, moduleParameterIndex, parameterValue);
+    host().automatedParameterChanged(module, moduleIndex, moduleParameterIndex, parameterValue,
+                                     asDiscreteGesture);
 }
 
 SpectrumWorxEditor::ModuleMenuButton::ModuleMenuButton(SpectrumWorxEditor &parent)

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -296,6 +296,13 @@ class SpectrumWorxEditor final : private SkinLifetime,
                                 double interval);
     void moduleControlDectivated(ModuleControlBase const &);
 
+    /// \brief The gesture a module control's drag is held in. \see the
+    /// definitions, and issue #188.
+    ///@{
+    void moduleControlGestureBegin(ParameterID) const;
+    void moduleControlGestureEnd(ParameterID) const;
+    ///@}
+
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \brief Which module strip is selected, and which of its controls the mouse
@@ -335,7 +342,7 @@ class SpectrumWorxEditor final : private SkinLifetime,
     }
 
     void updateModuleParameterAndNotifyHost(ModuleUI &, std::uint8_t moduleParameterIndex,
-                                            float parameterValue) const;
+                                            float parameterValue, bool asDiscreteGesture) const;
 
     void destroyChainGUIs();
 

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -194,6 +194,11 @@ void ModuleControlBase::moduleParameterChanged()
 /// control deactivates -- and `isActive()` is false by the time the user presses
 /// return on a value they are quite deliberately setting.
 ///
+/// \note **The gesture, where a drag has not already opened one.** A wheel notch,
+/// a menu row and a typed value are each one whole edit, so each is bracketed
+/// here; a drag opens its gesture on the press and closes it on the release, and
+/// the values in between belong to that one. \see beginGesture(), issue #188.
+///
 ////////////////////////////////////////////////////////////////////////////////
 
 void ModuleControlBase::publishValue()
@@ -203,8 +208,35 @@ void ModuleControlBase::publishValue()
     ///                                       (12.03.2013.) (Domagoj Saric)
     SpectrumWorxEditor &editor(this->editor());
     std::uint8_t const parameterIndex(moduleParameterIndex() + 1); // Bypass
-    editor.updateModuleParameterAndNotifyHost(moduleUI(), parameterIndex, getValue());
+    editor.updateModuleParameterAndNotifyHost(moduleUI(), parameterIndex, getValue(),
+                                              needsOwnGesture());
     editor.updateActiveControlValue();
+}
+
+/// \note Asserted rather than counted: JUCE pairs a slider's mouseDown with its
+/// mouseUp, and a gesture that could nest would be a widget opening one it never
+/// closes.
+void ModuleControlBase::beginGesture()
+{
+    LE_ASSERT(!gestureOpen_);
+    gestureOpen_ = true;
+    gestureID_ = parameterMenuID();
+    editor().moduleControlGestureBegin(gestureID_);
+}
+
+void ModuleControlBase::endGesture()
+{
+    LE_ASSERT(gestureOpen_);
+    gestureOpen_ = false;
+    editor().moduleControlGestureEnd(gestureID_);
+}
+
+/// \note The comparison and not the flag alone: a drag of the frequency range
+/// can cross to the other thumb, and the parameter it moves to is one nothing
+/// has opened a gesture for.
+bool ModuleControlBase::needsOwnGesture() const
+{
+    return !gestureOpen_ || (gestureID_.binaryValue != parameterMenuID().binaryValue);
 }
 
 void ModuleControlBase::configureControl(bool const mouseClickCanGrabFocus)

--- a/src/gui/modules/moduleControl.hpp
+++ b/src/gui/modules/moduleControl.hpp
@@ -100,6 +100,8 @@ template <class ImplWidget> class ModuleControl : public ParameterMenu
         return impl().ModuleControlBase::isLFOEnabled();
     } //...mrmlj...try to access the effect-specific lfo directly...
     void moduleParameterChanged() { impl().ModuleControlBase::moduleParameterChanged(); }
+    void beginGesture() { impl().ModuleControlBase::beginGesture(); }
+    void endGesture() { impl().ModuleControlBase::endGesture(); }
 
     ModuleControlBase &control()
     { /*LE_ASSERT( &ModuleControlBase::controlForWidget( impl() ) == &impl() );*/ return impl(); }
@@ -208,6 +210,25 @@ class ModuleControlBase
 
     ////////////////////////////////////////////////////////////////////////////
     ///
+    /// \brief The host's automation gesture for this parameter, held open across
+    /// a drag. \see issue #188 and SpectrumWorxEditor::moduleControlGestureBegin().
+    ///
+    /// \note Only a drag needs these. Every other edit is one value with nothing
+    /// either side of it, and `publishValue()` gives it a gesture of its own.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///@{
+    void beginGesture();
+    void endGesture();
+    bool gestureIsOpen() const { return gestureOpen_; }
+
+    /// \brief Whether this edit has to bracket itself -- true unless a drag has
+    /// already opened a gesture for this very parameter.
+    bool needsOwnGesture() const;
+    ///@}
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
     /// \name What the right button's menu asks of a module control
     ///
     ///   The three answers that are not one-liners over the getters above.
@@ -292,6 +313,16 @@ class ModuleControlBase
   private:
     std::uint8_t parameterIndex_;
     ModuleUI *LE_RESTRICT pModuleUI_;
+
+    /// \note The widget's, not the editor's: two controls can be mid-gesture at
+    /// once only if two mice are, but this says which *parameter* is held open
+    /// and that is this control's own. The ID is kept rather than recomputed
+    /// because the frequency range can change which of its two parameters it
+    /// stands for while the mouse is still down.
+    ///@{
+    bool gestureOpen_{false};
+    ParameterID gestureID_;
+    ///@}
 
     /// \note Which control is active is the *editor's* -- see
     /// SpectrumWorxEditor::pActiveControl_ -- so that two instances of the plugin

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -306,6 +306,33 @@ void ModuleKnob::valueChanged() noexcept
     moduleParameterChanged();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note juce::Slider calls these from mouseDown and mouseUp, which is exactly
+/// where the host's gesture belongs: the drag is one edit however many values it
+/// passes through. `EditorKnob` brackets the global knobs the same way.
+///
+/// \note Guarded on the LFO, as every other gesture on this widget is -- the
+/// wheel, the double click and mouseDrag() all stand aside when the LFO owns the
+/// value. A begin/end pair around an edit the widget refuses to make would be a
+/// parameter the host could learn but the mouse cannot move.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void ModuleKnob::startedDragging() noexcept
+{
+    Knob::startedDragging();
+    if (!isLFOEnabled())
+        beginGesture();
+}
+
+void ModuleKnob::stoppedDragging() noexcept
+{
+    if (control().gestureIsOpen())
+        endGesture();
+    Knob::stoppedDragging();
+}
+
 void ModuleKnob::lfoStateChanged()
 {
     /// \note JUCE 8 split the out-parameter off into isDoubleClickReturnEnabled();
@@ -888,7 +915,8 @@ void ModuleUI::buttonClicked(juce::Button *LE_RESTRICT const pButton)
     if (pButton == &bypass_)
     {
         float const value(Math::convert<float>(bypass_.getValue()));
-        editor().updateModuleParameterAndNotifyHost(*this, bypassIndex, value);
+        // a click, so a whole gesture of its own -- there is no drag to hold one
+        editor().updateModuleParameterAndNotifyHost(*this, bypassIndex, value, true);
     }
     else
     {

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -140,6 +140,13 @@ class ModuleKnob : public Knob, public ModuleControl<ModuleKnob>
 
     void valueChanged() noexcept override;
 
+    /// \brief The press and the release, which is what a host gesture brackets.
+    /// \see issue #188.
+    ///@{
+    void startedDragging() noexcept override;
+    void stoppedDragging() noexcept override;
+    ///@}
+
     void paint(juce::Graphics &) override;
 
   public:

--- a/tests/gui/editorHarness.hpp
+++ b/tests/gui/editorHarness.hpp
@@ -117,16 +117,46 @@ constexpr char noWindow[]{
     "No window manager: JUCE cannot put a component on the desktop here, and these cases need a "
     "real window to drive the keyboard with."};
 
+/// \brief One entry of what a host would have been told about a parameter.
+///
+/// \note Order across the three kinds is the point, so they share one log: a
+/// host arms MIDI learn and takes the *first* parameter it hears about, whichever
+/// kind it arrives as. \see issue #188.
+struct HostEdit
+{
+    enum class Kind
+    {
+        GestureBegin,
+        GestureEnd,
+        Value
+    };
+    Kind kind;
+    ParameterID::BinaryValue id;
+}; // struct HostEdit
+
 /// \note Every one of these is a notification travelling plugin -> host, and
-/// there is no host.
+/// there is no host -- so the parameter-facing three are recorded instead of
+/// sent, which is the only way a case can read what a host would have seen.
 class SilentNotifications final : public Plugin2HostInteropControler
 {
+  public:
+    mutable std::vector<HostEdit> edits;
+
   private:
-    void automatedParameterBeginEdit(ParameterID) const override {}
-    void automatedParameterEndEdit(ParameterID) const override {}
+    void automatedParameterBeginEdit(ParameterID const id) const override
+    {
+        edits.push_back({HostEdit::Kind::GestureBegin, id.binaryValue});
+    }
+    void automatedParameterEndEdit(ParameterID const id) const override
+    {
+        edits.push_back({HostEdit::Kind::GestureEnd, id.binaryValue});
+    }
     void gestureBegin(char const *) const override {}
     void gestureEnd() const override {}
-    void automatedParameterChanged(ParameterID, ParameterValueForAutomation) const override {}
+    void automatedParameterChanged(ParameterID const id, ParameterValueForAutomation) const override
+    {
+        edits.push_back({HostEdit::Kind::Value, id.binaryValue});
+    }
     void moduleChanged(std::uint8_t, Module const *) const override {}
     bool parameterListChanged() const override { return true; }
     void presetChangeBegin() const override {}
@@ -196,6 +226,9 @@ class Instance final : public GUI::EditorHost
 
     SpectrumWorxCore &core() override { return engine_; }
     Plugin2HostInteropControler &automation() override { return notifications_; }
+
+    /// \brief What the host was told about parameters, in order. \see HostEdit.
+    std::vector<HostEdit> &hostEdits() const { return notifications_.edits; }
 
     ////////////////////////////////////////////////////////////////////////////
     ///

--- a/tests/gui/moduleControlFocusTests.cpp
+++ b/tests/gui/moduleControlFocusTests.cpp
@@ -792,3 +792,194 @@ TEST_CASE("A wheel over a combo box the LFO owns moves nothing", "[gui][modules]
     scrollOnce(comboBox, -0.3f);
     CHECK(comboBox.getValue() == opened);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Selection is not a gesture
+/// --------------------------
+///
+///   `moduleControlActivated()` opens a host automation gesture and
+/// `moduleControlDectivated()` closes one, and both are reached from
+/// `ModuleControlImpl::focusGained`/`focusLost` -- so *selecting* a control,
+/// which is a local matter of which LFO the strip shows, tells the host a
+/// parameter is being edited. Nothing has to be dragged.
+///
+///   The cost is issue #188: a host with MIDI learn armed takes the first
+/// parameter it hears about, and moving the selection from one control to
+/// another emits the outgoing control's gesture end *before* the incoming one's
+/// begin. So the parameter learned is the one the user selected and walked away
+/// from, not the one they then dragged.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Selecting a control does not tell the host it is being edited",
+          "[gui][modules][automation]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    editor.addUserAddedModule(0);
+    editor.addUserAddedModule(0);
+    editor.resyncModuleRack();
+
+    auto *const pFirstStrip(editor.regionInSlot(0));
+    auto *const pSecondStrip(editor.regionInSlot(1));
+    REQUIRE(pFirstStrip != nullptr);
+    REQUIRE(pSecondStrip != nullptr);
+
+    auto *const pSelected(firstKnob(*pFirstStrip));
+    auto *const pDragged(firstKnob(*pSecondStrip));
+    REQUIRE(pSelected != nullptr);
+    REQUIRE(pDragged != nullptr);
+
+    auto const selectedID(editor.moduleControlID(*pSelected).binaryValue);
+    auto const draggedID(editor.moduleControlID(*pDragged).binaryValue);
+    REQUIRE(selectedID != draggedID);
+
+    // "Select a knob and dont edit it" -- the press's focus half, which is what
+    // makes a control the selected one. \see the note in the first case.
+    pSelected->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pSelected);
+
+    // Where the host's Learn is armed: everything before this the host has
+    // already heard and acted on, so only what follows can be learned.
+    instance.hostEdits().clear();
+
+    // "Drag another knob" -- the reaching for it, which is all the gestures are
+    // about: they come from the focus move and not from the drag, and no
+    // synthesised drag can move a value anyway. \see the note on eventOver().
+    pDragged->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pDragged);
+
+    // "Do we get an event for the first knob" -- the question the issue asks, and
+    // no is the only answer a host can use. A knob that was merely selected is
+    // not being edited.
+    for (auto const &edit : instance.hostEdits())
+        CHECK(edit.id != selectedID);
+
+    // ...and the sharper half: nothing at all was said. The mechanism was a
+    // gesture pair rather than a value change to self, and both ends of it have
+    // gone with the selection that raised them.
+    CHECK(instance.hostEdits().empty());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///   ...and the other half of #188, which is that the gestures are still there.
+/// One per edit, where the edit is: the press and the release around a drag, and
+/// a bracket of its own around each of the edits that are not one.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A knob's press and release bracket one host gesture", "[gui][modules][automation]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(moduleUI));
+    REQUIRE(pControl != nullptr);
+    auto &knob(pControl->widget());
+    auto const knobID(editor.moduleControlID(*pControl).binaryValue);
+
+    knob.grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+    instance.hostEdits().clear();
+
+    // \note The press and the release alone. A synthesised drag cannot move a
+    // value -- ModuleKnob::valueChanged() asserts isMouseOverOrDragging(), which
+    // no hand-built event sets -- and the gesture is not the drag's anyway: JUCE
+    // raises startedDragging() from mouseDown and stoppedDragging() from mouseUp.
+    clickOnce(knob);
+
+    REQUIRE(instance.hostEdits().size() == 2);
+    CHECK(instance.hostEdits()[0].kind == SWTest::HostEdit::Kind::GestureBegin);
+    CHECK(instance.hostEdits()[1].kind == SWTest::HostEdit::Kind::GestureEnd);
+    CHECK(instance.hostEdits()[0].id == knobID);
+    CHECK(instance.hostEdits()[1].id == knobID);
+}
+
+/// \note A combo box rather than a knob, because a wheel over a knob would need
+/// the value to move and no synthesised event can do that. The path is the same
+/// one either way -- publishValue() with no drag holding a gesture open.
+TEST_CASE("A wheel notch is a whole gesture of its own", "[gui][modules][automation][combo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Swappah"));
+
+    auto *const pControl(firstControlOfType<GUI::DiscreteParameter>(moduleUI));
+    REQUIRE(pControl != nullptr);
+    auto &comboBox(dynamic_cast<GUI::ComboBox &>(pControl->widget()));
+
+    comboBox.grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+
+    auto const before(comboBox.getValue());
+    auto const comboID(editor.moduleControlID(*pControl).binaryValue);
+    instance.hostEdits().clear();
+
+    scrollOnce(comboBox, -0.3f);
+    REQUIRE(comboBox.getValue() != before); // the notch has to have moved a row
+
+    REQUIRE(instance.hostEdits().size() == 3);
+    CHECK(instance.hostEdits()[0].kind == SWTest::HostEdit::Kind::GestureBegin);
+    CHECK(instance.hostEdits()[1].kind == SWTest::HostEdit::Kind::Value);
+    CHECK(instance.hostEdits()[2].kind == SWTest::HostEdit::Kind::GestureEnd);
+    for (auto const &edit : instance.hostEdits())
+        CHECK(edit.id == comboID);
+}
+
+/// \note No window and no mouse: a value typed into the right button menu is the
+/// one edit that reaches a control while the control is *not* selected -- the
+/// type-in field has the keyboard. \see ModuleControlBase::publishValue().
+TEST_CASE("A value typed into the menu is a whole gesture of its own",
+          "[gui][modules][automation][menu]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    instance.openEditor();
+    auto &editor(instance.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(moduleUI));
+    REQUIRE(pControl != nullptr);
+    auto const knobID(editor.moduleControlID(*pControl).binaryValue);
+
+    instance.hostEdits().clear();
+    REQUIRE(pControl->setValueFromText(pControl->getValueText()));
+
+    REQUIRE(instance.hostEdits().size() == 3);
+    CHECK(instance.hostEdits()[0].kind == SWTest::HostEdit::Kind::GestureBegin);
+    CHECK(instance.hostEdits()[1].kind == SWTest::HostEdit::Kind::Value);
+    CHECK(instance.hostEdits()[2].kind == SWTest::HostEdit::Kind::GestureEnd);
+    for (auto const &edit : instance.hostEdits())
+        CHECK(edit.id == knobID);
+}


### PR DESCRIPTION
Selecting a module control opened a host automation gesture and deselecting it closed one, so merely clicking a knob and then reaching for another said "these two parameters are being edited" -- in the order end( the first ), begin( the second ), because JUCE delivers the focus loss before the focus gain.

A host with MIDI learn armed takes the first parameter it hears about, so it learned the control the user had selected and walked away from rather than the one they went on to move. Bitwig's remote controls are where this shows.

A gesture now lasts as long as the mouse is down and no longer. A drag opens one on the press and closes it on the release; a wheel notch, a menu row, a typed value and a button click are each one whole edit and bracket themselves, through the asDiscreteGesture the global parameters already used. Selection goes back to being what it reads as -- which LFO the strip is showing.

The gesture keeps the ID it was opened with, because the frequency range is one widget standing for two parameters and can cross from one thumb to the other while the mouse is still down.

The editor harness records what the host is told, so the cases can read the order it hears it in.

Closes issue #188.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W5yGpJjJXXuYYnE88Ers6U