### PR TITLE
Keep the selected control when the keyboard goes elsewhere

### DIFF
--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -133,25 +133,11 @@ ModuleControlBase &SharedModuleControls::controlForParameter(std::uint8_t const 
     }
 }
 
-/// \note Checked rather than asserted. Losing focus is something JUCE does to
-/// these controls on the way *out* -- a strip being dropped moves the focus, and
-/// the editor's record of what is selected is cleared before that -- so "there
-/// is a selected module" is exactly what does not hold here. In a shipped build
-/// the assertion was not there and the null was dereferenced.
-void SharedModuleControls::focusLost(FocusChangeType)
-{
-    /// \note Not while a menu is up. These two knobs each have a right button
-    /// menu with a type-in field in it, the field takes the keyboard, and
-    /// deactivating the module from here destroys *these controls* -- so the
-    /// knob the open menu belongs to would be freed under it.
-    /// \see the note on ModuleControlImpl::focusLost().
-    if (isCurrentlyBlockedByAnotherModalComponent())
-        return;
-
-    auto *const pModuleUI(editor().selectedModule());
-    if (pModuleUI && !pModuleUI->hasFocus())
-        pModuleUI->deactivate();
-}
+/// \note Deliberately nothing, and this is the reported case: Gain and Wet live
+/// on these controls, so learning one in a host's panel means clicking away from
+/// the plugin -- which used to deselect the module and destroy the very knob the
+/// user was reaching for. \see ModuleControlImpl::focusLost() and issue #139.
+void SharedModuleControls::focusLost(FocusChangeType) {}
 
 void SharedModuleControls::focusOfChildComponentChanged(FocusChangeType const type)
 {
@@ -278,10 +264,8 @@ void SharedModuleControls::FrequencyRange::focusGained(juce::Component::FocusCha
 {
     reportActiveControl();
 }
-void SharedModuleControls::FrequencyRange::focusLost(juce::Component::FocusChangeType)
-{
-    reportInactiveControl();
-}
+/// \note Nothing, for the reason the two knobs beside it give.
+void SharedModuleControls::FrequencyRange::focusLost(juce::Component::FocusChangeType) {}
 
 void SharedModuleControls::FrequencyRange::mouseEnter(juce::MouseEvent const &event) noexcept
 {
@@ -289,9 +273,11 @@ void SharedModuleControls::FrequencyRange::mouseEnter(juce::MouseEvent const &ev
     juce::Slider::mouseEnter(event);
 }
 
+/// \note Through mouseLeft(), for the reason its definition gives: a thumb the
+/// user clicked stays selected when the pointer wanders off it.
 void SharedModuleControls::FrequencyRange::mouseExit(juce::MouseEvent const &event) noexcept
 {
-    reportInactiveControl();
+    mouseLeft();
     juce::Slider::mouseExit(event);
 }
 

--- a/src/gui/editor/auxiliaryComponents.hpp
+++ b/src/gui/editor/auxiliaryComponents.hpp
@@ -79,6 +79,10 @@ class SharedModuleControls : public WidgetBase<>
       protected: // ModuleControlBase overrides
         void lfoStateChanged() override {}
 
+        /// \note This one is its own ModuleControlBase rather than a
+        /// ModuleControlImpl<>, so it answers for itself. \see issue #139.
+        void deselect() override { reportInactiveControl(); }
+
         void setValue(float value) override;
         float getValue() const override;
 

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1603,11 +1603,13 @@ void SpectrumWorxEditor::detachFrom(ModuleUI &region)
     /// through destroying them. Taking the keyboard to the editor, which wants
     /// it, stops the walk there.
     ///
-    /// \note After the LFO display and not before: taking the focus out of the
-    /// shared controls deselects the module, and `moduleDeactivated()` asserts
-    /// that the module's *control* was deselected first. This path skips that
-    /// deliberately (see the note on `pActiveControl_` above), so the strip has
-    /// to be retired by hand before anything can deselect the module.
+    /// \note And the selection cleared here rather than left to the focus walk.
+    /// Moving the keyboard out used to deselect the module for us -- that is what
+    /// `SharedModuleControls::focusLost()` did -- so `pSelectedModule_` came back
+    /// null on its own. It no longer does, and a strip left recorded as selected
+    /// while its shared controls are freed reaches `~ModuleUI`, which takes its
+    /// `if ( selected() )` branch into `moduleDeactivated()` and dereferences the
+    /// empty optional. \see issue #139.
     ///
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1617,6 +1619,26 @@ void SpectrumWorxEditor::detachFrom(ModuleUI &region)
             grabKeyboardFocus();
         sharedModuleControls_ = std::nullopt;
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note And last, the keyboard out of the strip itself and the editor's
+    /// record of it cleared -- the two things the focus walk used to do on the
+    /// way past.
+    ///
+    ///   `~ModuleUI` asserts that a strip it is destroying *unselected* is not
+    /// still holding the keyboard, which was true for free while a focus loss
+    /// deselected: whichever of the two happened first, the other followed. Now
+    /// neither happens on its own, and a strip whose knob had the focus reaches
+    /// the destructor both unselected and focused. \see issue #139.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    if (region.hasFocus())
+        grabKeyboardFocus();
+
+    if (pSelectedModule_ == &region)
+        pSelectedModule_ = nullptr;
 }
 
 void SpectrumWorxEditor::mainKnobDragStarted(std::uint8_t const index) const

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -71,11 +71,25 @@ bool ModuleControlBase::tryActivateControl() const
         return false;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **The outgoing control is told here.** Losing the keyboard no longer
+/// deselects, so the only thing that knows a control has stopped being the
+/// selected one is whatever became it. Leaving that out is not merely untidy
+/// bookkeeping: `ModuleKnob::moduleControlDeactivated()` is what turns the
+/// scroll wheel off, and a knob that keeps its wheel moves its value as the user
+/// scrolls the rack past it -- issue #124, back again. \see issue #139.
+///
+////////////////////////////////////////////////////////////////////////////////
+
 bool ModuleControlBase::reportActiveControl(double const minimum, double const maximum,
                                             double const interval)
 {
     if (tryActivateControl())
     {
+        if (auto *const pOutgoing = editor().activeControl())
+            pOutgoing->deselect();
+
         /// \note The control is marked as activated only after the editor
         /// has been informed (and the LFO GUI created) to avoid race condition
         /// crashes when a user activates a control that is being automated (and
@@ -237,6 +251,31 @@ void ModuleControlBase::endGesture()
 bool ModuleControlBase::needsOwnGesture() const
 {
     return !gestureOpen_ || (gestureID_.binaryValue != parameterMenuID().binaryValue);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **Only where the mouse is what selects.** This was
+/// `reportInactiveControl()` outright, and it could not reach a control the user
+/// had *clicked*: the guard inside answers no while the control holds the
+/// keyboard, and holding the keyboard was the only way to be selected.
+///
+///   It is not any more -- a control stays selected after the focus has gone to
+/// the preset pane or to another application -- so an unguarded exit would drop
+/// the LFO strip on the next sweep of the mouse across the rack, which is the
+/// thing issue #139 is about. Under the default reaction the pointer never
+/// selects a control, so it has no business deselecting one.
+///
+/// \note `deselect()` rather than `reportInactiveControl()`: the widget's own
+/// `moduleControlDeactivated()` has to run, and it resolves in ModuleControlImpl.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void ModuleControlBase::mouseLeft()
+{
+    if (preferences().moduleUIMouseOverReaction() == Preferences::Never)
+        return;
+    deselect();
 }
 
 void ModuleControlBase::configureControl(bool const mouseClickCanGrabFocus)

--- a/src/gui/modules/moduleControl.hpp
+++ b/src/gui/modules/moduleControl.hpp
@@ -156,6 +156,12 @@ class ModuleControlBase
 
     virtual void lfoStateChanged() = 0;
 
+    /// \brief Tells this control it is no longer the selected one.
+    ///
+    /// \note Asked of the control that is *losing* the selection, by the one
+    /// taking it. Losing the keyboard no longer does it. \see issue #139.
+    virtual void deselect() = 0;
+
     virtual void updateForEngineSetupChanges(Engine::Setup const &) {}
 
     // Implementation note:
@@ -207,6 +213,9 @@ class ModuleControlBase
     /// moduleParameterChanged() without the assertions that say the user has
     /// this control under the mouse right now. \see the definition.
     void publishValue();
+
+    /// \brief What a control does when the pointer leaves it. \see the definition.
+    void mouseLeft();
 
     ////////////////////////////////////////////////////////////////////////////
     ///
@@ -388,6 +397,12 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
             ImplWidget::moduleControlDeactivated();
     }
 
+    /// \note The same thing asked from outside. `moduleControlDeactivated()` is
+    /// the widget's own and resolves in this template, so the editor cannot reach
+    /// it through a ModuleControlBase -- and it has to, now that the control
+    /// losing the selection is told by the one taking it. \see issue #139.
+    void deselect() override { reportInactiveControl(); }
+
     using ModuleControlBase::isActive;
 
   private:
@@ -399,48 +414,31 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
     }
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note `|| !isEnabled()`. JUCE spells getWantsKeyboardFocus() as
-    /// `wantsKeyboardFocusFlag && !isDisabledFlag`, and
-    /// `Component::setEnabled( false )` sets that flag *before* handing the
-    /// focus to the parent -- so a control disabled while it holds the focus
-    /// arrives here reading "does not want focus", having never stopped wanting
-    /// it. `ModuleKnob::mouseDown` does exactly that to a knob whose LFO is on,
-    /// which is why clicking one fired this.
+    /// \note **The halo, and nothing else.** Losing the keyboard is not losing
+    /// the selection: this used to retire the LFO strip, on the assumption that
+    /// the focus was on its way to another module control. It goes to a preset
+    /// row, a settings box, a host's automation panel or another application at
+    /// least as often, and each of those wiped the strip the user had just set
+    /// up. The selection is handed over by whoever takes it instead.
+    /// \see reportActiveControl() and issue #139.
     ///
-    ////////////////////////////////////////////////////////////////////////////
-    ///
-    /// \note **The focus a menu borrows is not a focus loss.** A knob's own
-    /// right button menu contains a type-in field, the field takes the keyboard
-    /// when it opens, and the editor reads every focus loss as "this control is
-    /// no longer the one the user is on" -- which retires the LFO strip out from
-    /// under the menu that is offering to switch it, and, one level up, deselects
-    /// the module and destroys the shared controls the knob may itself be one of.
-    /// So the widget under the open menu could be freed while its menu was still
-    /// on screen, and choosing an item then did nothing at all.
-    ///
-    ///   `isCurrentlyBlockedByAnotherModalComponent()` is the question, and it is
-    /// exactly the right one: a menu is a modal component, so this is true for
-    /// every widget in the editor for as long as one is up, and false the moment
-    /// it closes. Nothing is lost by waiting -- a mouseExit or the next focus
-    /// change re-asks -- and the other two tear-downs guard on the same thing.
-    /// \see ModuleUI::focusLost(), SharedModuleControls::focusLost().
-    ///
-    /// \note The skin's own menus never reach here: they are desktop windows
-    /// carrying `ComponentPeer::windowIgnoresKeyPresses` and take no keyboard, so
-    /// no focus is lost when one opens. \see Knob::showParameterMenu().
+    /// \note Which retires three guards with it. There is no longer a tear-down
+    /// to keep away from an open menu -- the knob's own right button menu takes
+    /// the keyboard for its type-in field, and used to deselect the module and
+    /// destroy the shared controls the knob might itself be one of. Nor is there
+    /// a disabled-control case to excuse: `getWantsKeyboardFocus()` reads
+    /// `wantsKeyboardFocusFlag && !isDisabledFlag`, so a control disabled while
+    /// focused arrived here reading "does not want focus", and nothing asks any
+    /// more.
     ///
     ////////////////////////////////////////////////////////////////////////////
     virtual void focusLost(juce::Component::FocusChangeType) noexcept override
     {
-        LE_ASSERT(this->getWantsKeyboardFocus() || !this->isEnabled());
-        if (this->isCurrentlyBlockedByAnotherModalComponent())
-            return;
-        reportInactiveControl();
         ImplWidget::focusChanged();
     }
 
     virtual void mouseEnter(juce::MouseEvent const &) override { reportActiveControl(); }
-    virtual void mouseExit(juce::MouseEvent const &) noexcept override { reportInactiveControl(); }
+    virtual void mouseExit(juce::MouseEvent const &) noexcept override { mouseLeft(); }
 }; // class ModuleControlImpl
 
 #pragma warning(pop)

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -770,27 +770,13 @@ void ModuleUI::focusGained(FocusChangeType)
     LE_ASSERT(selected());
 }
 
-void ModuleUI::focusLost(FocusChangeType)
-{
-    // Implementation note:
-    //   If only transferring focus to a subcontrol or to the shared controls do
-    // not deactivate.
-    //                                        (14.11.2011.) (Domagoj Saric)
-    if (hasFocus() || editor().sharedModuleControlsActiveAndFocused())
-        return;
-
-    /// \note ...nor to a menu one of those subcontrols opened, which is a third
-    /// case of the same thing: deselecting the strip under an open menu destroys
-    /// the shared controls, and the menu may belong to one of them.
-    /// \see the note on ModuleControlImpl::focusLost().
-    if (isCurrentlyBlockedByAnotherModalComponent())
-        return;
-
-    //...mrmlj...rethink this focus changing logic and assumptions
-    //LE_ASSERT( selected() );
-    if (selected())
-        deactivate();
-}
+/// \note Deliberately nothing, for the reason ModuleControlImpl::focusLost()
+/// gives: a strip stops being the selected one when another is selected or when
+/// it is destroyed, and not because the keyboard went to the preset pane. The
+/// three guards this used to need -- focus moving to a subcontrol, to the shared
+/// controls, or to a menu one of those opened -- were all ways of saying "that is
+/// not really a loss", and there is no loss to qualify any more.
+void ModuleUI::focusLost(FocusChangeType) {}
 
 void ModuleUI::focusOfChildComponentChanged(FocusChangeType const changeType)
 {
@@ -805,6 +791,13 @@ void ModuleUI::activate()
     LE_ASSERT(hasFocus() || selectionTracksMouseMovements());
     if (this->selected())
         return;
+
+    /// \note A module change retires the control selection, where a control
+    /// change within one module does not. The LFO strip would otherwise name the
+    /// module the user has just left while the shared controls and the header
+    /// name the one they are on. \see issue #139.
+    if (auto *const pControl = editor().activeControl(); pControl && !pControl->pointsInto(*this))
+        pControl->deselect();
 
     // Implementation note:
     //   If the previously active module wasn't actually focused but the shared

--- a/tests/gui/moduleControlFocusTests.cpp
+++ b/tests/gui/moduleControlFocusTests.cpp
@@ -3,17 +3,18 @@
 /// moduleControlFocusTests.cpp
 /// ---------------------------
 ///
-///   What happens to a module control's keyboard focus when the control is
-/// disabled under it -- which is what clicking a knob whose LFO is on does.
+///   What the keyboard focus does to a module control: which one is selected,
+/// what an LFO takes away from the widget holding it, and what the host is told
+/// along the way.
 ///
-///   `ModuleKnob::mouseDown` calls `setEnabled( !isLFOEnabled() )` so that
-/// juce::Slider's own drag handling cannot move a value the LFO owns. JUCE's
-/// `Component::setEnabled( false )` sets the disabled flag *and then*, if the
-/// component has keyboard focus, hands that focus to the parent -- and
-/// `getWantsKeyboardFocus()` is `wantsKeyboardFocusFlag && !isDisabledFlag`
-/// (juce_Component.cpp), so by the time our `focusLost()` runs the answer is
-/// already false. There is no `--render` page for that: it needs a click, and a
-/// click needs focus, which needs a peer.
+///   None of it has a `--render` page. Selection needs a click, a click needs
+/// focus, and focus needs a peer -- so every case here puts the editor on the
+/// desktop and skips where the window server will not play along.
+///
+///   The rule the selection cases turn on: it moves when something *takes* it,
+/// or when the thing selected is destroyed, and never because the keyboard went
+/// somewhere else. \see issue #139, and issue #188 for the gestures that used to
+/// ride along with it.
 ///
 /// Copyright (c) 2026 the SpectrumWorx contributors.
 /// SPDX-License-Identifier: GPL-3.0-or-later
@@ -390,9 +391,16 @@ TEST_CASE("An LFO switches every gesture that would move the knob under it", "[g
 ///   The two are not the same the moment a control is deactivated: deactivation
 /// clears the editor's records and leaves the widgets alive, deliberately, so
 /// that moving between controls does not destroy and rebuild them. So a control
-/// that lost focus before its module was removed left both widgets behind,
-/// pointing into freed memory, still parented and still painted --
-/// `ModuleKnob::paint` reads `moduleUI().pModule_` straight through the hole.
+/// deselected before its module was removed left both widgets behind, pointing
+/// into freed memory, still parented and still painted -- `ModuleKnob::paint`
+/// reads `moduleUI().pModule_` straight through the hole.
+///
+/// \note **Selecting the other strip is what deselects here.** This read
+/// `editor.grabKeyboardFocus()` while a focus loss still deselected; it no longer
+/// does, and the state has to be reached the way a user reaches it. Selecting
+/// another *module* retires the LFO strip without re-pointing it -- the display
+/// is disabled and still holds the first strip's control -- which is exactly the
+/// mismatch this case is about. \see issue #139.
 ///
 ///   This is the 608f0773 bug class over again: a guard keyed on the wrong
 /// pointer. An `-fsanitize=address` build reports the paint below as a
@@ -434,14 +442,20 @@ TEST_CASE("A strip removed after its control was deactivated leaves nothing poin
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \note And then deselecting it, which is the step that made the old guards
-    /// answer no. The editor forgets which control was active and which module
-    /// was selected; the widgets pointing into the strip are only *disabled*,
-    /// their destruction deferred in case the user is on their way to another
-    /// control.
+    /// answer no. The editor forgets which control was active; the LFO display
+    /// pointing into this strip is only *disabled*, its destruction deferred in
+    /// case the user is on their way to another control.
     ///
     ////////////////////////////////////////////////////////////////////////////
-    editor.grabKeyboardFocus();
+    editor.regionInSlot(1)->grabKeyboardFocus();
     REQUIRE(editor.activeControl() == nullptr);
+    REQUIRE(editor.selectedModule() == editor.regionInSlot(1));
+
+    // ...and the state this case exists to test, asserted rather than assumed: a
+    // widget still pointing into the strip while the editor's records do not. It
+    // is what makes the removal below reach the guard at all.
+    REQUIRE(editor.lfoDisplay() != nullptr);
+    REQUIRE(editor.lfoDisplay()->pointsInto(*pFirstStrip));
 
     // The strip goes. detachFrom() runs from in here.
     editor.removeModule(*pFirstStrip);
@@ -982,4 +996,267 @@ TEST_CASE("A value typed into the menu is a whole gesture of its own",
     CHECK(instance.hostEdits()[2].kind == SWTest::HostEdit::Kind::GestureEnd);
     for (auto const &edit : instance.hostEdits())
         CHECK(edit.id == knobID);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Losing the keyboard is not losing the selection
+/// -----------------------------------------------
+///
+///   Selection moves when something *takes* it, or when the thing selected is
+/// destroyed. Nothing else. A focus loss used to retire the LFO strip on the
+/// assumption that the keyboard was on its way to another module control -- but
+/// the preset pane, a host's automation panel and another application are all
+/// places it goes instead, and each of them wiped the display the user had just
+/// set up. \see issue #139, and issue #188 for the half of this that reached the
+/// host.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+/// \brief Two strips of \p effectName, in slots 0 and 1.
+std::pair<GUI::ModuleUI *, GUI::ModuleUI *> twoStrips(GUI::SpectrumWorxEditor &editor,
+                                                      char const *const effectName)
+{
+    auto const effect(SWTest::effectByStreamingName(effectName));
+    editor.addUserAddedModule(static_cast<std::uint8_t>(effect));
+    editor.addUserAddedModule(static_cast<std::uint8_t>(effect));
+    editor.resyncModuleRack();
+    auto *const pFirst(editor.regionInSlot(0));
+    auto *const pSecond(editor.regionInSlot(1));
+    REQUIRE(pFirst != nullptr);
+    REQUIRE(pSecond != nullptr);
+    return {pFirst, pSecond};
+}
+
+/// \brief Whether the LFO strip is on screen for \p editor.
+///
+/// \note Enabled rather than present. Retiring one only disables it and posts a
+/// message to drop it, so that moving between controls does not destroy and
+/// rebuild -- and a test binary has no message loop to run that post. \see
+/// SpectrumWorxEditor::retireLFODisplay().
+bool lfoStripIsUp(GUI::SpectrumWorxEditor &editor)
+{
+    auto *const pDisplay(editor.lfoDisplay());
+    return (pDisplay != nullptr) && pDisplay->isEnabled();
+}
+
+TEST_CASE("A selected control keeps its LFO strip when the keyboard goes elsewhere",
+          "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(moduleUI));
+    REQUIRE(pControl != nullptr);
+
+    pControl->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+    REQUIRE(lfoStripIsUp(editor));
+
+    // Where the keyboard actually goes: the editor itself stands for every widget
+    // that is not a module control -- a preset row, a settings box, the window of
+    // another plugin entirely.
+    editor.grabKeyboardFocus();
+    REQUIRE(!pControl->widget().hasKeyboardFocus(false));
+
+    CHECK(editor.activeControl() == pControl);
+    CHECK(lfoStripIsUp(editor));
+}
+
+TEST_CASE("The shared controls survive the keyboard going elsewhere", "[gui][modules][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    moduleUI.grabKeyboardFocus();
+    REQUIRE(editor.selectedModule() == &moduleUI);
+    REQUIRE(editor.sharedModuleControlsActive());
+
+    // The reported case: Gain lives here, and learning it in a host's panel means
+    // clicking away from the plugin and back.
+    editor.grabKeyboardFocus();
+
+    CHECK(editor.selectedModule() == &moduleUI);
+    CHECK(editor.sharedModuleControlsActive());
+}
+
+TEST_CASE("Selecting a control in another module hands the selection over",
+          "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto const [pFirstStrip, pSecondStrip](twoStrips(editor, "Freeze"));
+
+    auto *const pFirst(firstKnob(*pFirstStrip));
+    auto *const pSecond(firstKnob(*pSecondStrip));
+    REQUIRE(pFirst != nullptr);
+    REQUIRE(pSecond != nullptr);
+    auto &firstKnobWidget(dynamic_cast<juce::Slider &>(pFirst->widget()));
+
+    pFirst->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pFirst);
+    REQUIRE(firstKnobWidget.isScrollWheelEnabled());
+
+    pSecond->widget().grabKeyboardFocus();
+
+    CHECK(editor.activeControl() == pSecond);
+    CHECK(lfoStripIsUp(editor));
+
+    // \note The half that is not bookkeeping. A control is told it was deselected
+    // so that it can turn its wheel off, and nothing else tells it any more --
+    // leave this out and scrolling the rack moves whatever it passes over, which
+    // is issue #124 back again.
+    CHECK(!firstKnobWidget.isScrollWheelEnabled());
+}
+
+TEST_CASE("Selecting another module retires the control selection",
+          "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto const [pFirstStrip, pSecondStrip](twoStrips(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(*pFirstStrip));
+    REQUIRE(pControl != nullptr);
+
+    pControl->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+
+    // \note The strip's own body rather than one of its controls. The LFO pane
+    // would otherwise name the first module while the shared controls and the
+    // header name the second.
+    pSecondStrip->grabKeyboardFocus();
+
+    CHECK(editor.selectedModule() == pSecondStrip);
+    CHECK(editor.activeControl() == nullptr);
+    CHECK(!lfoStripIsUp(editor));
+}
+
+/// \note What a preset load does to the rack, once per slot -- and the one path
+/// that still has to clear a selection, because the thing selected is going away.
+/// \see SpectrumWorxEditor::destroyChainGUIs().
+TEST_CASE("Dropping the selected module clears both selections", "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(moduleUI));
+    REQUIRE(pControl != nullptr);
+
+    pControl->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+    REQUIRE(editor.selectedModule() == &moduleUI);
+    REQUIRE(editor.sharedModuleControlsActive());
+
+    editor.destroyChainGUIs();
+
+    CHECK(editor.activeControl() == nullptr);
+    CHECK(editor.selectedModule() == nullptr);
+    CHECK(!editor.sharedModuleControlsActive());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The hole the change above opens if nothing is done about it. A control
+/// used to be selected only while it held the keyboard, so `mouseExit`'s
+/// `reportInactiveControl()` could not reach one the user had clicked -- the
+/// `hasDirectFocus()` guard inside answered no. Now a control stays selected
+/// after the keyboard has gone to the preset pane, and without a second guard the
+/// next sweep of the mouse across it would silently drop the LFO strip.
+///
+///   The preference is the right question: with the default reaction the mouse
+/// never *selects* a control, so it has no business deselecting one.
+/// \see Preferences::ModuleUIMouseOverReaction and issue #139.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("The mouse passing over a clicked control does not deselect it",
+          "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    // \note A folder of this case's own, and the reaction set in it rather than
+    // read. The suite points every case at one shared folder, and something in it
+    // writes there -- so what this would otherwise see is whatever ran last.
+    fs::path const folder(fs::path(SW_TEST_OUTPUT_DIR) / "preferences" / "mouseOverKeepsClicked");
+    fs::remove_all(folder);
+    GUI::setPreferencesFolder(folder);
+    GUI::preferences().setModuleUIMouseOverReaction(GUI::Preferences::Never);
+    REQUIRE(GUI::preferences().moduleUIMouseOverReaction() == GUI::Preferences::Never);
+
+    auto &editor(window.editor());
+    auto &moduleUI(stripFor(editor, "Freeze"));
+
+    auto *const pControl(firstKnob(moduleUI));
+    REQUIRE(pControl != nullptr);
+    auto &knob(pControl->widget());
+
+    knob.grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+
+    editor.grabKeyboardFocus(); // the preset pane, a host panel, another app
+    REQUIRE(editor.activeControl() == pControl);
+
+    // ...and the pointer wanders across the knob on its way somewhere else.
+    knob.mouseEnter(eventOver(knob, {}, false));
+    knob.mouseExit(eventOver(knob, {}, false));
+
+    CHECK(editor.activeControl() == pControl);
+    CHECK(lfoStripIsUp(editor));
 }


### PR DESCRIPTION
Losing the keyboard retired the LFO strip, on the assumption that the focus was on its way to another module control. It goes to a preset row, a settings box, a host's automation panel or another application at least as often, and each of those wiped the display the user had just set up -- so learning Gain in a host's remote controls was impossible, because clicking away destroyed the knob being reached for.

Selection now moves when something takes it, or when the thing selected is destroyed, and never because the keyboard went somewhere else. The four focus-loss handlers do nothing, and three guards retire with them: each was a way of saying "that is not really a loss", and there is no loss left to qualify.

Whoever takes the selection tells the control losing it. That is not bookkeeping -- a knob is told so that it can turn its scroll wheel off, and one that keeps its wheel moves its value as the user scrolls the rack past it. Selecting a different module retires the control selection, so that the LFO strip and the shared controls cannot name two different modules.

Two things the focus walk used to do on the way past, now done where they belong. detachFrom() takes the keyboard out of the strip it is about to drop and clears the editor's record of it, because ~ModuleUI asserts that a strip destroyed unselected is not still holding the keyboard -- true for free while either half implied the other. And the pointer leaving a control only deselects where the pointer is what selects: under the default mouse-over reaction a sweep across the rack would otherwise drop the strip that had just been clicked.

Closes #139.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W5yGpJjJXXuYYnE88Ers6U