### PR TITLE
Even more themes!

### DIFF
--- a/src/gui/colourMap.cpp
+++ b/src/gui/colourMap.cpp
@@ -18,7 +18,7 @@ namespace LE::SW::GUI
 
 namespace
 {
-ColourMap::Palette current_{ColourMap::Classic};
+ColourMap::Palette current_{ColourMap::ClassicBlue};
 std::uint32_t generation_{0};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -28,9 +28,9 @@ std::uint32_t generation_{0};
 //
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \brief Classic, with its hue moved somewhere else.
+/// \brief ClassicBlue, with its hue moved somewhere else.
 ///
-/// \note A colour Classic left neutral is returned untouched. That is not a
+/// \note A colour ClassicBlue left neutral is returned untouched. That is not a
 /// special case being handled, it is the whole reason this works: the skin's
 /// bevels, rules, ink and shadows have no hue to move, so turning the palette
 /// turns exactly the things that carry the accent -- the lit ring on a knob,
@@ -45,13 +45,6 @@ std::uint32_t generation_{0};
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-struct Rotation
-{
-    float hue;        ///< turns of the colour wheel, added
-    float saturation; ///< multiplied
-    float brightness; ///< multiplied, in full at full saturation and not at all at none
-}; // struct Rotation
-
 juce::Colour turned(juce::Colour const colour, Rotation const &rotation)
 {
     auto const saturation(colour.getSaturation());
@@ -63,7 +56,7 @@ juce::Colour turned(juce::Colour const colour, Rotation const &rotation)
         .withMultipliedBrightness(1 + saturation * (rotation.brightness - 1));
 }
 
-/// \brief Classic, with the colour taken out rather than moved.
+/// \brief ClassicBlue, with the colour taken out rather than moved.
 ///
 /// \note By perceived brightness rather than by HSB's: the point of a grey
 /// scale is that nothing changes weight, and HSB calls a saturated blue and a
@@ -91,6 +84,10 @@ Rotation constexpr redRotation{0.4645f, 0.65f, 1.10f};
 Rotation constexpr greenRotation{0.8339f, 0.80f, 0.80f};
 /// To 37 degrees, which is SCXT's accent_1a. \see ColourMap::sstDark().
 Rotation constexpr amberRotation{0.5615f, 0.78f, 1.05f};
+/// To 55 degrees: #CFC237, matched to amberRotation's actual brightness
+Rotation constexpr yellowRotation{0.6117f, 0.8000f, 0.9733f};
+/// To 280 degrees: #C68CE3, perceived 0.638.
+Rotation constexpr purpleRotation{0.2367f, 0.4200f, 0.9692f};
 ///@}
 } // anonymous namespace
 
@@ -172,6 +169,7 @@ juce::Colour ColourMap::classic(Name const name)
         return juce::Colour(0xFF1A171Bu);
     case PanelFrame:
         return juce::Colour(0xFFFFFFFFu);
+
     case CapsuleBodyLeft:
         return juce::Colour(0xFF2B2829u);
     case CapsuleBodyRight:
@@ -274,7 +272,7 @@ juce::Colour ColourMap::classic(Name const name)
 /// neutral.
 ///
 /// \note The one palette with a `default:`, and it is the difference between
-/// this and Reds. SST Dark is a statement about the *chassis* -- what the
+/// this and ClassicRed. SST Dark is a statement about the *chassis* -- what the
 /// editor's grounds and its ink are -- and it has nothing to say about the
 /// second highlight near the foot of a slider bead or the shade a knob's bevel
 /// turns over at. Those keep the artwork's own modelling, turned to amber. So
@@ -282,7 +280,7 @@ juce::Colour ColourMap::classic(Name const name)
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-juce::Colour ColourMap::sstDark(Name const name)
+juce::Colour ColourMap::sstDark(Name const name, Rotation const rotation)
 {
     switch (name)
     {
@@ -290,15 +288,17 @@ juce::Colour ColourMap::sstDark(Name const name)
     /// small marks; here the accent is also what every panel's gradient is
     /// lifted *towards*, and #FFB949 at 0.78 of perceived brightness turns that
     /// wash into the loudest thing on the page. This one sits at 0.62, which is
-    /// where Classic's blue sits, so the chassis keeps the weight it was drawn
+    /// where ClassicBlue's blue sits, so the chassis keeps the weight it was drawn
     /// with. \see BackgroundStyle::Ramp::lift.
     case Accent:
-        return juce::Colour(0xFFD09030u); // accent_1b
+        return turned(classic(Accent), rotation).withMultipliedBrightness(0.85); // accent_1b
 
-    ///   The chassis, inverted. Classic's surround is a light grey with dark
+    ///   The chassis, inverted. ClassicBlue's surround is a light grey with dark
     /// panels on it; every ground here is one of the three darks.
     case EditorGradientStart:
-        return juce::Colour(0x90D09030u); // accent_1b
+        return turned(classic(EditorGradientStart), rotation)
+            .withMultipliedBrightness(0.8263)
+            .withMultipliedAlpha(0.565f); // accent_1b
     case EditorSurround:
         return juce::Colour(0xFF1B1D20u); // bg_main
     case EditorPanel:
@@ -306,11 +306,11 @@ juce::Colour ColourMap::sstDark(Name const name)
     case EditorWell:
         return juce::Colour(0xFF1B1D20u); // bg_1
     case EditorWellFace:
-        return juce::Colour(0xFF141619u); // under bg_main, as Classic's is under its own
+        return juce::Colour(0xFF141619u); // under bg_main, as ClassicBlue's is under its own
     case PanelBackground:
         return juce::Colour(0xFF262A2fu);
     case ModuleBackground:
-        return juce::Colour(0xFF262A2Fu);
+        return juce::Colour(0xFF1B1D20u);
     case ComboBackground:
         return juce::Colour(0xFF1B1D20u);
     case MenuBackground:
@@ -322,11 +322,11 @@ juce::Colour ColourMap::sstDark(Name const name)
     /// thing on a ground this dark, so they go to the grey SCXT divides panels
     /// with.
     case EditorRule:
-        return juce::Colour(0xFF393939u); // grid_primary, opaque
+        return juce::Colour(0xFF777777u); // generic_content_low
     case PanelFrame:
         return juce::Colour(0xFF777777u); // generic_content_low
     case MenuOutline:
-        return juce::Colour(0xFF333333u); // bg_3
+        return juce::Colour(0xFF777777u); // generic_content_low
 
     /// The ink, in SCXT's four weights.
     case Text:
@@ -338,22 +338,16 @@ juce::Colour ColourMap::sstDark(Name const name)
     case Wordmark:
         return juce::Colour(0xFFFFFFFFu); // generic_content_medium
 
-    ///   A button. Classic's runs from white to black with dark ink on it,
+    ///   A button. ClassicBlue's runs from white to black with dark ink on it,
     /// which on this chassis would be a slab of daylight; SCXT's buttons are
     /// the mid grey against the panel behind them.
-    case ButtonFaceTop:
-        return juce::Colour(0xFFAFAFAFu);
     case ButtonFaceBottom:
-        return juce::Colour(0xFF262A2Fu);
-    case ButtonCaption:
-        return juce::Colour(0xFF1B1D20u);
-    case TabFaceTop:
-        return juce::Colour(0xFF777777u);
+        return juce::Colour(0xFF333333u);
     case TabFaceBottom:
-        return juce::Colour(0xFF262A2Fu);
+        return juce::Colour(0xFF333333u);
 
     default:
-        return turned(classic(name), amberRotation);
+        return turned(classic(name), rotation);
     }
 }
 
@@ -376,16 +370,34 @@ juce::Colour ColourMap::getColour(Name const name)
 {
     switch (current_)
     {
-    case Classic:
+    case ClassicBlue:
         return classic(name);
-    case SSTDark:
-        return sstDark(name);
-    case Grays:
-        return drained(classic(name));
-    case Reds:
+    case ClassicRed:
         return turned(classic(name), redRotation);
-    case Greens:
+    case ClassicGreen:
         return turned(classic(name), greenRotation);
+    case ClassicYellow:
+        return turned(classic(name), yellowRotation);
+    case ClassicAmber:
+        return turned(classic(name), amberRotation);
+    case ClassicPurple:
+        return turned(classic(name), purpleRotation);
+    case ClassicGray:
+        return drained(classic(name));
+    case DarkBlue:
+        return sstDark(name, Rotation());
+    case DarkRed:
+        return sstDark(name, redRotation);
+    case DarkGreen:
+        return sstDark(name, greenRotation);
+    case DarkYellow:
+        return sstDark(name, yellowRotation);
+    case DarkAmber:
+        return sstDark(name, amberRotation);
+    case DarkPurple:
+        return sstDark(name, purpleRotation);
+    case DarkGray:
+        return drained(sstDark(name, Rotation()));
 
     /// \note No `default:` here either, for the reason getColour()'s has none.
     case numberOfPalettes:
@@ -413,16 +425,34 @@ char const *ColourMap::nameOf(Palette const palette)
 {
     switch (palette)
     {
-    case Classic:
-        return "Classic";
-    case SSTDark:
-        return "SSTDark";
-    case Grays:
-        return "Grays";
-    case Reds:
-        return "Reds";
-    case Greens:
-        return "Greens";
+    case ClassicBlue:
+        return "ClassicBlue";
+    case ClassicRed:
+        return "ClassicRed";
+    case ClassicGreen:
+        return "ClassicGreen";
+    case ClassicYellow:
+        return "ClassicYellow";
+    case ClassicAmber:
+        return "ClassicAmber";
+    case ClassicPurple:
+        return "ClassicPurple";
+    case ClassicGray:
+        return "ClassicGray";
+    case DarkBlue:
+        return "DarkBlue";
+    case DarkRed:
+        return "DarkRed";
+    case DarkGreen:
+        return "DarkGreen";
+    case DarkYellow:
+        return "DarkYellow";
+    case DarkAmber:
+        return "DarkAmber";
+    case DarkPurple:
+        return "DarkPurple";
+    case DarkGray:
+        return "DarkGray";
     case numberOfPalettes:
         break;
     }

--- a/src/gui/colourMap.hpp
+++ b/src/gui/colourMap.hpp
@@ -17,10 +17,10 @@
 /// without every call site learning about it. Five palettes need that now, and
 /// not one of the two hundred call sites changed to get them.
 ///
-///   Only Classic is written out. It is traced from artwork and every tint in
-/// it leans on the accent's hue, so Reds and Greens are that hue turned -- and
+///   Only ClassicBlue is written out. It is traced from artwork and every tint in
+/// it leans on the accent's hue, so ClassicRed and ClassicGreen are that hue turned -- and
 /// a colour the artwork left neutral has no hue to turn, which is what keeps
-/// the greys grey without a list of exceptions. Grays is the same trick with
+/// the greys grey without a list of exceptions. ClassicGray is the same trick with
 /// the colour taken out rather than moved. SST Dark is the one that is not a
 /// recolour: it inverts the chassis, so it names what it changes and turns the
 /// rest.
@@ -42,6 +42,13 @@
 
 namespace LE::SW::GUI
 {
+
+struct Rotation
+{
+    float hue{0.0f};        ///< turns of the colour wheel, added
+    float saturation{1.0f}; ///< multiplied
+    float brightness{1.0f}; ///< multiplied, in full at full saturation and not at all at none
+}; // struct Rotation
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -103,7 +110,7 @@ class ColourMap
         ModuleKnobCap,        ///< the cap over the wedge's inside
         ///@}
 
-        /// The halo around whichever control has the keyboard focus.
+        /// The halo around whichever control has the focus.
         FocusHalo,
 
         ////////////////////////////////////////////////////////////////////////
@@ -278,11 +285,21 @@ class ColourMap
 
     enum Palette
     {
-        Classic, ///< the skin as it was drawn, and the only one written out
-        Reds,
-        Greens,
-        Grays,
-        SSTDark, ///< Shortcircuit XT's wireframe-dark, as near as this skin goes
+        ClassicBlue,
+        ClassicRed,
+        ClassicGreen,
+        ClassicYellow,
+        ClassicAmber,
+        ClassicPurple,
+        ClassicGray,
+        DarkBlue,
+        DarkRed,
+        DarkGreen,
+        DarkYellow,
+        DarkAmber,
+        DarkPurple,
+        DarkGray,
+
         numberOfPalettes
     }; // enum Palette
 
@@ -328,7 +345,7 @@ class ColourMap
     /// them can say `Accent` instead of `ColourMap::Accent` fifty-six times.
     ///@{
     static juce::Colour classic(Name);
-    static juce::Colour sstDark(Name);
+    static juce::Colour sstDark(Name, Rotation);
     ///@}
 
   public:

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -3350,12 +3350,21 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
 
     // spelled here rather than taken from ColourMap::nameOf(): what goes in the
     // preferences file has to be greppable and what goes in this list has to be
-    // readable, and "SSTDark" cannot be both
-    palette_.addItem(ColourMap::Classic, "Classic");
-    palette_.addItem(ColourMap::Reds, "Reds");
-    palette_.addItem(ColourMap::Greens, "Greens");
-    palette_.addItem(ColourMap::Grays, "Grayscale");
-    palette_.addItem(ColourMap::SSTDark, "Dark");
+    // readable, and "DarkAmber" cannot be both
+    palette_.addItem(ColourMap::ClassicBlue, "Classic Blue");
+    palette_.addItem(ColourMap::ClassicRed, "Classic Red");
+    palette_.addItem(ColourMap::ClassicGreen, "Classic Green");
+    palette_.addItem(ColourMap::ClassicYellow, "Classic Yellow");
+    palette_.addItem(ColourMap::ClassicAmber, "Classic Amber");
+    palette_.addItem(ColourMap::ClassicPurple, "Classic Purple");
+    palette_.addItem(ColourMap::ClassicGray, "Classic Gray");
+    palette_.addItem(ColourMap::DarkBlue, "Dark Blue");
+    palette_.addItem(ColourMap::DarkRed, "Dark Red");
+    palette_.addItem(ColourMap::DarkGreen, "Dark Green");
+    palette_.addItem(ColourMap::DarkYellow, "Dark Yellow");
+    palette_.addItem(ColourMap::DarkAmber, "Dark Amber");
+    palette_.addItem(ColourMap::DarkPurple, "Dark Purple");
+    palette_.addItem(ColourMap::DarkGray, "Dark Gray");
     palette_.setSelectedIndex(preferences().palette());
 
     moduleUIMouseOverReaction_.addItem(Preferences::Never, "Never");

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -146,7 +146,7 @@ class Preferences
 
     ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
     LFOUpdateBehaviour lfoUpdateBehaviour_{Always};
-    ColourMap::Palette palette_{ColourMap::Classic};
+    ColourMap::Palette palette_{ColourMap::ClassicBlue};
     bool hideCursorOnKnobDrag_{true};
     unsigned int zoomPercent_{defaultZoomPercent};
 }; // class Preferences

--- a/tests/gui/paletteTests.cpp
+++ b/tests/gui/paletteTests.cpp
@@ -10,9 +10,9 @@
 /// \note Nothing here asserts what any palette *looks like*. A case that pinned
 /// a colour would be a case that has to be edited every time one is retuned, and
 /// a palette is a thing to look at rather than a thing to assert. What is pinned
-/// is the mechanism -- that Grays drains, that every scheme moves the accent,
+/// is the mechanism -- that ClassicGray drains, that every scheme moves the accent,
 /// that a change reaches the screen -- and the skin's own blue is asked for at
-/// run time rather than spelled, so retuning Classic moves the tests with it.
+/// run time rather than spelled, so retuning ClassicBlue moves the tests with it.
 ///
 /// \note The last of those is the point of the file, and it is measured in
 /// pixels. "Does getColour() answer differently" is a question the broken build
@@ -86,7 +86,7 @@ class PaletteRestored
 juce::Colour skinBlue()
 {
     PaletteRestored const restored;
-    ColourMap::setPalette(ColourMap::Classic);
+    ColourMap::setPalette(ColourMap::ClassicBlue);
     return ColourMap::getColour(ColourMap::Accent);
 }
 
@@ -144,10 +144,10 @@ fs::path caseFolder(char const *const name)
 // The map
 ////////////////////////////////////////////////////////////////////////////////
 
-TEST_CASE("Grays answers in greys")
+TEST_CASE("ClassicGray answers in greys")
 {
     PaletteRestored const restored;
-    ColourMap::setPalette(ColourMap::Grays);
+    ColourMap::setPalette(ColourMap::ClassicGray);
 
     forEachColour([](ColourMap::Name const name) {
         auto const colour(ColourMap::getColour(name));
@@ -164,7 +164,7 @@ TEST_CASE("Every palette moves the accent")
     auto const blue(skinBlue());
 
     forEachPalette([&](ColourMap::Palette const palette) {
-        if (palette == ColourMap::Classic)
+        if (palette == ColourMap::ClassicBlue)
             return;
 
         ColourMap::setPalette(palette);
@@ -176,16 +176,16 @@ TEST_CASE("Every palette moves the accent")
 TEST_CASE("Changing the palette moves the generation")
 {
     PaletteRestored const restored;
-    ColourMap::setPalette(ColourMap::Classic);
+    ColourMap::setPalette(ColourMap::ClassicBlue);
 
     auto const before(ColourMap::generation());
 
-    ColourMap::setPalette(ColourMap::Classic);
+    ColourMap::setPalette(ColourMap::ClassicBlue);
     CHECK(ColourMap::generation() == before); // nothing changed, nothing to tell
 
-    ColourMap::setPalette(ColourMap::Reds);
+    ColourMap::setPalette(ColourMap::ClassicRed);
     CHECK(ColourMap::generation() != before);
-    CHECK(ColourMap::palette() == ColourMap::Reds);
+    CHECK(ColourMap::palette() == ColourMap::ClassicRed);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -207,7 +207,7 @@ TEST_CASE("The palette survives the preferences file")
     });
 }
 
-TEST_CASE("A palette this build does not have reads as Classic")
+TEST_CASE("A palette this build does not have reads as ClassicBlue")
 {
     auto const folder(caseFolder("unknown"));
     fs::create_directories(folder);
@@ -225,7 +225,7 @@ TEST_CASE("A palette this build does not have reads as Classic")
     }
 
     GUI::Preferences const read(folder);
-    CHECK(read.palette() == ColourMap::Classic);
+    CHECK(read.palette() == ColourMap::ClassicBlue);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -236,7 +236,7 @@ TEST_CASE("An editor opens in the palette the user chose")
 {
     PaletteRestored const restored;
     GUI::setPreferencesFolder(caseFolder("opens-in"));
-    GUI::preferences().setPalette(ColourMap::Reds);
+    GUI::preferences().setPalette(ColourMap::ClassicRed);
 
     SWTest::Instance instance;
     instance.openEditor();
@@ -262,7 +262,7 @@ TEST_CASE("Changing the palette reaches an editor that is already open")
     auto const wasInTheTheme(
         GUI::Theme::singleton().findColour(juce::CaretComponent::caretColourId));
 
-    instance.editor().setPalette(ColourMap::Greens);
+    instance.editor().setPalette(ColourMap::ClassicGreen);
 
     ////////////////////////////////////////////////////////////////////////////
     /// \note By hand, because this is what the editor's 30 Hz timer calls and
@@ -277,7 +277,7 @@ TEST_CASE("Changing the palette reaches an editor that is already open")
     /// are copied out of the map once and go stale in place.
     CHECK(GUI::Theme::singleton().findColour(juce::CaretComponent::caretColourId) != wasInTheTheme);
 
-    CHECK(GUI::preferences().palette() == ColourMap::Greens);
+    CHECK(GUI::preferences().palette() == ColourMap::ClassicGreen);
 }
 
 TEST_CASE("An editor left alone does not reload its colours")
@@ -321,7 +321,7 @@ TEST_CASE("A palette change reaches the widgets that hold their own colours")
     auto const before(pComment->findColour(juce::TextEditor::textColourId));
     REQUIRE(before == skinBlue()); // the comment box writes in the accent
 
-    instance.editor().setPalette(ColourMap::Reds);
+    instance.editor().setPalette(ColourMap::ClassicRed);
     instance.editor().applyPaletteIfChanged();
 
     CHECK(pComment->findColour(juce::TextEditor::textColourId) != before);

--- a/tools/show-ui/main.cpp
+++ b/tools/show-ui/main.cpp
@@ -329,7 +329,7 @@ int renderPage(juce::String const &pageName, juce::File const &output)
 /// GUI::Preferences::zoomPercentages.
 ///
 /// \note `SW_SHOW_UI_PALETTE` likewise, by ColourMap::nameOf() -- so
-/// `SW_SHOW_UI_PALETTE=Reds` renders any page in that palette. Both the
+/// `SW_SHOW_UI_PALETTE=ClassicRed` renders any page in that palette. Both the
 /// preference and the map are set: the map because a page that builds no editor
 /// has no SkinLifetime to read the preference, and the preference so that the
 /// settings page shows the palette it is being drawn in.


### PR DESCRIPTION
Added amber, yellow and purple for Classic themes. Tweaked certain aspects of dark theme for better contrast. Every Classic color now also has a Dark variant Needed to refactor a bit how two accent colors in sstDark() are calculated to match the current amber look, so that it can be turned() at will to any other hue we want.

NOTE: Changed the streaming names for themes for consistency, so any nightly user who picked a theme other than Classic (Blue) will be reverted to Classic Blue. Small price to pay for consistency.