### PR TITLE
Ring the control whose LFO strip is showing

### DIFF
--- a/src/gui/editor/auxiliaryComponents.cpp
+++ b/src/gui/editor/auxiliaryComponents.cpp
@@ -425,7 +425,6 @@ void SharedModuleControls::FrequencyRange::reportInactiveControl()
         selectedThumb_ = Constants::noThumb;
         reassignTo(invalidIndex);
         parameterIndexForInternalWriteAccess_ = invalidIndex;
-        repaint();
     }
 }
 

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -3191,10 +3191,6 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
         preferences().setModuleUIMouseOverReaction(
             static_cast<Preferences::ModuleUIMouseOverReaction>(value));
     }
-    else if (&comboBox == &settings.interfacePage_.lfoUpdateComboBox())
-    {
-        preferences().setLFOUpdateBehaviour(static_cast<Preferences::LFOUpdateBehaviour>(value));
-    }
     else
     {
         LE_UNREACHABLE_CODE();
@@ -3331,8 +3327,7 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
       palette_(*this, xMargin, yMargin + 1 * yStep + yOffset, "Color Scheme"),
       moduleUIMouseOverReaction_(*this, xMargin, yMargin + 2 * yStep + yOffset,
                                  "Mouse Over Reaction"),
-      lfoUpdateBehaviour_(*this, xMargin, yMargin + 3 * yStep + yOffset, "LFO Update Behaviour"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 4 * yStep + yOffset,
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep + yOffset,
                             "Hide cursor on knob drag")
 {
     Settings &parent(
@@ -3371,12 +3366,6 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     moduleUIMouseOverReaction_.addItem(Preferences::WhenParentModuleSelected, "Module selected");
     moduleUIMouseOverReaction_.addItem(Preferences::WhenParentOrNothingSelected, "Always");
     moduleUIMouseOverReaction_.setSelectedIndex(preferences().moduleUIMouseOverReaction());
-
-    lfoUpdateBehaviour_.addItem(Preferences::NoUpdate, "Never");
-    lfoUpdateBehaviour_.addItem(Preferences::WhenControlSelected, "Control selected");
-    lfoUpdateBehaviour_.addItem(Preferences::WhenControlActive, "Control active");
-    lfoUpdateBehaviour_.addItem(Preferences::Always, "Always");
-    lfoUpdateBehaviour_.setSelectedIndex(preferences().lfoUpdateBehaviour());
 
     hideCursorOnKnobDrag_.setToggleState(preferences().hideCursorOnKnobDrag(),
                                          juce::dontSendNotification);

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1308,7 +1308,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
             TitledComboBox const &paletteComboBox() const { return palette_; }
             TitledComboBox const &mouseOverComboBox() const { return moduleUIMouseOverReaction_; }
-            TitledComboBox const &lfoUpdateComboBox() const { return lfoUpdateBehaviour_; }
 
           private: // JUCE component overrides.
             void paint(juce::Graphics &) override;
@@ -1324,7 +1323,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
             TitledComboBox zoom_;
             TitledComboBox palette_;
             TitledComboBox moduleUIMouseOverReaction_;
-            TitledComboBox lfoUpdateBehaviour_;
             LEDTextButton hideCursorOnKnobDrag_;
         }; // class InterfacePage
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -669,7 +669,7 @@ void ComboBox::paint(juce::Graphics &graphics)
         graphics,
         juce::Rectangle<float>(0, 0, static_cast<float>(getWidth()),
                                static_cast<float>(boxHeight_)),
-        frame_, ColourMap::getColour(hasDirectFocus() ? ColourMap::FocusHalo : ColourMap::Accent),
+        frame_, ColourMap::getColour(showsAsSelected() ? ColourMap::FocusHalo : ColourMap::Accent),
         ColourMap::getColour(ColourMap::ComboBackground), true /*halo*/);
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
@@ -1749,18 +1749,5 @@ void addEnumeratedParameterValueStringsToComboBox(LE::Utility::Span<char const *
     comboBox.setValue(0);
 }
 } // namespace Detail
-
-// The LFO update policy. Here rather than on Theme because these ask about a
-// ModuleControlBase and a ModuleUI, neither of which a LookAndFeel should know
-// exist.
-
-bool shouldUpdateLFOControl(ModuleControlBase const &control)
-{
-    Preferences::LFOUpdateBehaviour const lfoUpdateBehaviour(preferences().lfoUpdateBehaviour());
-    return (lfoUpdateBehaviour == Preferences::Always) ||
-           (lfoUpdateBehaviour == Preferences::WhenControlActive && control.isActive()) ||
-           (lfoUpdateBehaviour == Preferences::WhenControlSelected &&
-            Detail::hasDirectFocus(control.widget()));
-}
 
 } // namespace LE::SW::GUI

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -169,11 +169,6 @@ fs::path const &presetsFolder();
 /// \note Not done by presetsFolder(); see the note at the definition.
 bool createUserPresetsFolder();
 
-class ModuleControlBase;
-class ModuleUI;
-
-bool shouldUpdateLFOControl(ModuleControlBase const &);
-
 ////////////////////////////////////////////////////////////////////////////////
 /// \internal
 /// \class WidgetBase
@@ -711,6 +706,10 @@ class ComboBox : public WidgetBase<>, public PopupMenuWithSelection
     ////////////////////////////////////////////////////////////////////////////
 
     virtual void selectionScrolled() {}
+
+    /// \brief Whether the box draws as the selected one -- the keyboard, unless
+    /// whoever owns it has another answer. \see DiscreteParameter.
+    virtual bool showsAsSelected() const { return hasDirectFocus(); }
 
   protected: // juce::Component overrides
     void paint(juce::Graphics &) override;

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -98,17 +98,20 @@ bool ModuleControlBase::reportActiveControl(double const minimum, double const m
         ///                                   (25.04.2013.) (Domagoj Saric)
         editor().moduleControlActivated(*this, minimum, maximum, interval);
         editor().pActiveControl_ = this;
+        // the halo is drawn on the selection, so the selection has to repaint
+        widget().repaint();
         return true;
     }
     return false;
 }
 
-bool ModuleControlBase::reportInactiveControl() const
+bool ModuleControlBase::reportInactiveControl()
 {
     if (isActive() && !Detail::hasDirectFocus(widget()))
     {
         editor().moduleControlDectivated(*this);
         editor().pActiveControl_ = nullptr;
+        widget().repaint();
         return true;
     }
     else

--- a/src/gui/modules/moduleControl.hpp
+++ b/src/gui/modules/moduleControl.hpp
@@ -115,8 +115,6 @@ template <class ImplWidget> class ModuleControl : public ParameterMenu
   protected: // Default implementations for the module control interface callbacks
     static void lfoStateChanged() {};
 
-    static void focusChanged() {}
-
     static void moduleControlActivated() {}
     static void moduleControlDeactivated() {}
 
@@ -203,6 +201,8 @@ class ModuleControlBase
     //...mrmlj...excludes non-lfoable parameters (Bypass)...
     std::uint8_t moduleParameterIndex() const { return parameterIndex_; }
 
+    /// \brief Whether this is the selected control -- the one the LFO strip is
+    /// showing, and the one wearing the halo. Not the keyboard. \see issue #139.
     bool isActive() const;
 
     bool isLFOEnabled() const;
@@ -298,7 +298,7 @@ class ModuleControlBase
 
   protected:
     bool reportActiveControl(double minimum, double maximum, double interval);
-    bool reportInactiveControl() const;
+    bool reportInactiveControl();
 
     void configureControl(bool mouseClickCanGrabFocus);
 
@@ -410,17 +410,20 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
     {
         LE_ASSERT(this->getWantsKeyboardFocus());
         reportActiveControl();
-        ImplWidget::focusChanged();
     }
     ////////////////////////////////////////////////////////////////////////////
     ///
-    /// \note **The halo, and nothing else.** Losing the keyboard is not losing
-    /// the selection: this used to retire the LFO strip, on the assumption that
-    /// the focus was on its way to another module control. It goes to a preset
-    /// row, a settings box, a host's automation panel or another application at
-    /// least as often, and each of those wiped the strip the user had just set
-    /// up. The selection is handed over by whoever takes it instead.
+    /// \note **Deliberately nothing.** Losing the keyboard is not losing the
+    /// selection: this used to retire the LFO strip, on the assumption that the
+    /// focus was on its way to another module control. It goes to a preset row, a
+    /// settings box, a host's automation panel or another application at least as
+    /// often, and each of those wiped the strip the user had just set up. The
+    /// selection is handed over by whoever takes it instead.
     /// \see reportActiveControl() and issue #139.
+    ///
+    /// \note Which is why the halo is not drawn on the focus either -- it says
+    /// which control the LFO strip is showing, and a control keeps that when the
+    /// keyboard leaves. \see ModuleControlBase::isActive().
     ///
     /// \note Which retires three guards with it. There is no longer a tear-down
     /// to keep away from an open menu -- the knob's own right button menu takes
@@ -432,10 +435,7 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
     /// more.
     ///
     ////////////////////////////////////////////////////////////////////////////
-    virtual void focusLost(juce::Component::FocusChangeType) noexcept override
-    {
-        ImplWidget::focusChanged();
-    }
+    virtual void focusLost(juce::Component::FocusChangeType) noexcept override {}
 
     virtual void mouseEnter(juce::MouseEvent const &) override { reportActiveControl(); }
     virtual void mouseExit(juce::MouseEvent const &) noexcept override { mouseLeft(); }

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -92,10 +92,10 @@ void ModuleLEDTextButton::mouseDown(juce::MouseEvent const &event)
 void ModuleLEDTextButton::paintButton(juce::Graphics &g, bool const isMouseOverButton,
                                       bool const isButtonDown)
 {
-    /// \note A combo box's focused background, borrowed: this button stands
-    /// where one does and says it has the focus the same way. It was
+    /// \note A combo box's selected background, borrowed: this button stands
+    /// where one does and says it is the selected control the same way. It was
     /// `paintImage( ModuleComboOn )` while that was a file.
-    if (hasDirectFocus())
+    if (control().isActive())
         FramePainter::paint(g,
                             juce::Rectangle<float>(0, -1, static_cast<float>(moduleComboWidth),
                                                    static_cast<float>(moduleComboHeight)),
@@ -222,7 +222,7 @@ void TriggerButton::paintButton(juce::Graphics &graphics, bool const isMouseOver
     if (fade)
         graphics.endTransparencyLayer();
 
-    if (this->hasDirectFocus())
+    if (control().isActive())
         KnobPainter::paintFocusRing(graphics, face.getCentre().toFloat(),
                                     static_cast<float>(face.getWidth()) / 2);
 }
@@ -286,8 +286,7 @@ void ModuleKnob::paint(juce::Graphics &graphics)
         graphics,
         juce::Rectangle<float>(static_cast<float>(marginForGlow), static_cast<float>(marginForGlow),
                                static_cast<float>(diameter_), static_cast<float>(diameter_)),
-        value, polarity_ == Bipolar, !control().isLFOEnabled() || shouldUpdateLFOControl(control()),
-        this->hasDirectFocus());
+        value, polarity_ == Bipolar, control().isActive());
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
     {
@@ -543,8 +542,6 @@ void DiscreteParameter::addParameterValueEntries(juce::PopupMenu &menu)
 }
 
 void DiscreteParameter::selectionScrolled() { moduleParameterChanged(); }
-
-void DiscreteParameter::focusChanged() { repaint(); }
 
 #pragma warning(push)
 #pragma warning(disable : 4355) // 'this' used in base member initializer list.
@@ -837,10 +834,7 @@ auto const bypassIndex = LE::Parameters::IndexOf<Effects::BaseParameters::Parame
 void setParameterControl(ModuleControlBase &control, float const parameterValue,
                          ModuleUI::ParameterChangeSource const source)
 {
-    if ((source != ModuleUI::LFOValue) || shouldUpdateLFOControl(control))
-    {
-        control.setValue(parameterValue);
-    }
+    control.setValue(parameterValue);
     if ((source == ModuleUI::AutomationOrPreset) && control.isActive())
     {
         SpectrumWorxEditor::fromChild(control.widget()).updateActiveControlValue();

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -158,14 +158,6 @@ class ModuleKnob : public Knob, public ModuleControl<ModuleKnob>
   protected: // ModuleControl interface.
     void lfoStateChanged();
 
-    /// \brief The halo is drawn on the focus, so a change of focus is a repaint.
-    ///
-    /// \note This was the default do-nothing, and the halo therefore appeared
-    /// whenever something else happened to repaint the knob -- for a right press,
-    /// not until the menu closed again, which is the second half of issue #92.
-    /// The other two focusable module widgets have always had this.
-    void focusChanged() { repaint(); }
-
     void updateForEngineSetupChanges(Engine::Setup const &);
 
     void moduleControlActivated();
@@ -227,8 +219,6 @@ class ModuleLEDTextButton : public LEDTextButton, public ModuleControl<ModuleLED
     bool parameterAcceptsText() const override { return false; }
 
   protected: // ModuleControl interface.
-    void focusChanged() { repaint(); }
-
     // Implementation note:
     //   We allow a smooth LFO range control for boolean parameters.
     //                                        (21.07.2011.) (Domagoj Saric)
@@ -281,7 +271,6 @@ class TriggerButton : public WidgetBase<juce::Button>, public ModuleControl<Trig
 
   protected: // ModuleControl interface.
     void lfoStateChanged() { setValue(false); }
-    void focusChanged() { repaint(); }
 
     // Implementation note:
     //   We allow a smooth LFO range control for boolean parameters.
@@ -367,9 +356,12 @@ class DiscreteParameter : public ComboBox, public ModuleControl<DiscreteParamete
 
     void addParameterValueEntries(juce::PopupMenu &) override;
 
-  protected: // ModuleControl interface.
-    void focusChanged();
+  private: // ComboBox
+    /// \note The selection rather than the keyboard, as on every other module
+    /// control. \see ModuleControlBase::isActive() and issue #139.
+    bool showsAsSelected() const override { return control().isActive(); }
 
+  protected: // ModuleControl interface.
     juce::String const &getTextFromValue(value_type const valueIndex) const
     {
         return getItemText(valueIndex);

--- a/src/gui/painters/moduleKnobPainter.cpp
+++ b/src/gui/painters/moduleKnobPainter.cpp
@@ -28,8 +28,7 @@ namespace LE::SW::GUI
 ////////////////////////////////////////////////////////////////////////////////
 
 void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
-                     float const normalisedValue, bool const bipolar, bool const drawWedge,
-                     bool const selected)
+                     float const normalisedValue, bool const bipolar, bool const selected)
 {
     using namespace ModuleKnobStyle;
 
@@ -41,24 +40,19 @@ void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const boun
 
     KnobPainter::paintDome(graphics, bounds, innerGradientRadius);
 
-    /// \note How far the wedge has opened, which the cap's radius follows -- and
-    /// so zero when there is no wedge to follow. A cap sized off a value the
-    /// knob is not showing is the one thing the LFO state could still leak.
-    auto const openness(!drawWedge ? 0.0f : bipolar ? std::abs(2 * value - 1) : value);
+    /// \note How far the wedge has opened, which the cap's radius follows.
+    auto const openness(bipolar ? std::abs(2 * value - 1) : value);
 
-    if (drawWedge)
-    {
-        // The far edge is the value; the near one is the stop it opens from.
-        auto const to(KnobPainter::angleFor(value));
-        auto const from(bipolar ? 0.0f : -KnobPainter::halfSweepDegrees);
-        juce::Path pie;
-        pie.addPieSegment(
-            bounds.withSizeKeepingCentre(2 * radius * wedgeRadius, 2 * radius * wedgeRadius),
-            juce::degreesToRadians(std::min(from, to)), juce::degreesToRadians(std::max(from, to)),
-            0.0f);
-        graphics.setColour(ColourMap::getColour(ColourMap::Accent));
-        graphics.fillPath(pie);
-    }
+    // The far edge is the value; the near one is the stop it opens from.
+    auto const to(KnobPainter::angleFor(value));
+    auto const from(bipolar ? 0.0f : -KnobPainter::halfSweepDegrees);
+    juce::Path pie;
+    pie.addPieSegment(
+        bounds.withSizeKeepingCentre(2 * radius * wedgeRadius, 2 * radius * wedgeRadius),
+        juce::degreesToRadians(std::min(from, to)), juce::degreesToRadians(std::max(from, to)),
+        0.0f);
+    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
+    graphics.fillPath(pie);
 
     auto const cap(capRadiusClosed + (capRadiusOpen - capRadiusClosed) * openness);
     KnobPainter::paintCap(graphics, bounds, cap, cap /*a hard edge*/,

--- a/src/gui/painters/moduleKnobPainter.hpp
+++ b/src/gui/painters/moduleKnobPainter.hpp
@@ -109,11 +109,10 @@ void paintTriggerButton(juce::Graphics &, juce::Rectangle<float> bounds, bool on
 ///
 /// \param normalisedValue where the value sits in its range, 0 to 1; for a
 /// \p bipolar knob 0.5 is the centre the wedge opens from.
-/// \param drawWedge false while an LFO drives the parameter, when the knob's own
-/// value says nothing.
-/// \param selected whether it has the keyboard focus.
+/// \param selected whether this is the control the interface is showing -- which
+/// is not the keyboard focus. \see ModuleControlBase::isActive().
 void paintModuleKnob(juce::Graphics &, juce::Rectangle<float> bounds, float normalisedValue,
-                     bool bipolar, bool drawWedge, bool selected);
+                     bool bipolar, bool selected);
 
 } // namespace LE::SW::GUI
 

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -43,7 +43,6 @@ std::string defaultsFileName() { return std::string(productName) + "UserDefaults
 enum PreferenceKey
 {
     moduleUIMouseOverReactionKey,
-    lfoUpdateBehaviourKey,
     hideCursorOnKnobDragKey,
     zoomPercentKey,
     paletteKey,
@@ -59,8 +58,6 @@ std::string preferenceKeyName(PreferenceKey const key)
     {
     case moduleUIMouseOverReactionKey:
         return "moduleUIMouseOverReaction";
-    case lfoUpdateBehaviourKey:
-        return "lfoUpdateBehaviour";
     case hideCursorOnKnobDragKey:
         return "hideCursorOnKnobDrag";
     case zoomPercentKey:
@@ -93,12 +90,8 @@ void reportPreferencesError(std::string const &message, std::string const &title
 constexpr std::array<char const *, 3> mouseOverReactionNames{"Never", "WhenParentModuleSelected",
                                                              "WhenParentOrNothingSelected"};
 
-constexpr std::array<char const *, 4> lfoUpdateBehaviourNames{"NoUpdate", "WhenControlSelected",
-                                                              "WhenControlActive", "Always"};
-
-/// The tables are indexed by the enumerator, so they have to cover it.
+/// The table is indexed by the enumerator, so it has to cover it.
 static_assert(mouseOverReactionNames.size() == Preferences::WhenParentOrNothingSelected + 1);
-static_assert(lfoUpdateBehaviourNames.size() == Preferences::Always + 1);
 
 template <typename Enumeration, std::size_t count>
 std::string nameOf(Enumeration const value, std::array<char const *, count> const &names)
@@ -173,11 +166,6 @@ Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Sto
                                      nameOf(moduleUIMouseOverReaction_, mouseOverReactionNames)),
         mouseOverReactionNames, moduleUIMouseOverReaction_);
 
-    lfoUpdateBehaviour_ =
-        valueNamed(provider.getUserDefaultValue(
-                       lfoUpdateBehaviourKey, nameOf(lfoUpdateBehaviour_, lfoUpdateBehaviourNames)),
-                   lfoUpdateBehaviourNames, lfoUpdateBehaviour_);
-
     palette_ = paletteNamed(provider.getUserDefaultValue(paletteKey, ColourMap::nameOf(palette_)),
                             palette_);
 
@@ -207,13 +195,6 @@ void Preferences::setModuleUIMouseOverReaction(ModuleUIMouseOverReaction const v
     moduleUIMouseOverReaction_ = value;
     storage_->provider.updateUserDefaultValue(moduleUIMouseOverReactionKey,
                                               nameOf(value, mouseOverReactionNames));
-}
-
-void Preferences::setLFOUpdateBehaviour(LFOUpdateBehaviour const value)
-{
-    lfoUpdateBehaviour_ = value;
-    storage_->provider.updateUserDefaultValue(lfoUpdateBehaviourKey,
-                                              nameOf(value, lfoUpdateBehaviourNames));
 }
 
 void Preferences::setPalette(ColourMap::Palette const value)

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -70,14 +70,6 @@ class Preferences
         WhenParentOrNothingSelected
     };
 
-    enum LFOUpdateBehaviour
-    {
-        NoUpdate,
-        WhenControlSelected,
-        WhenControlActive,
-        Always
-    };
-
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \brief The zooms the Interface page offers, ascending, as percentages.
@@ -115,7 +107,6 @@ class Preferences
     {
         return moduleUIMouseOverReaction_;
     }
-    LFOUpdateBehaviour lfoUpdateBehaviour() const { return lfoUpdateBehaviour_; }
     ColourMap::Palette palette() const { return palette_; }
     bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
     /// Always one of zoomPercentages.
@@ -123,7 +114,6 @@ class Preferences
 
     /// Each of these writes the file. `[main-thread]`
     void setModuleUIMouseOverReaction(ModuleUIMouseOverReaction);
-    void setLFOUpdateBehaviour(LFOUpdateBehaviour);
     /// \note Stores it. Painting in it is ColourMap::setPalette()'s half, and
     /// the two are done together -- \see SpectrumWorxEditor::setPalette(),
     /// which is the only place a user changes this.
@@ -145,7 +135,6 @@ class Preferences
     std::unique_ptr<Storage> storage_;
 
     ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
-    LFOUpdateBehaviour lfoUpdateBehaviour_{Always};
     ColourMap::Palette palette_{ColourMap::ClassicBlue};
     bool hideCursorOnKnobDrag_{true};
     unsigned int zoomPercent_{defaultZoomPercent};

--- a/tests/gui/knobPaintingTests.cpp
+++ b/tests/gui/knobPaintingTests.cpp
@@ -8,7 +8,7 @@
 ///
 ///   How they *look* is checked by looking: `sw-show-ui knobs` is a contact
 /// sheet of both knobs across their whole travel, in both polarities, both
-/// sizes, focused and LFO-driven, and reading it takes a second. That is the
+/// sizes, selected and not, and reading it takes a second. That is the
 /// right instrument for a drawing, and it is the one to reach for when
 /// ModuleKnobStyle or EditorKnobStyle is touched.
 ///
@@ -25,9 +25,9 @@
 ///
 /// \note A fuller set lived here while the port was being verified: which
 /// 10-degree sectors the wedge grew into, that it opened from the left stop when
-/// unipolar and from twelve o'clock when bipolar, that the focus ring changed
-/// nothing inside the face, and the pointer's bearing recovered from the render
-/// by high-passing an angular profile. All of it passed, and all of it was
+/// unipolar and from twelve o'clock when bipolar, that the halo changed nothing
+/// inside the face, and the pointer's bearing recovered from the render by
+/// high-passing an angular profile. All of it passed, and all of it was
 /// scaffolding for one change -- measuring by machine what the contact sheet
 /// says at a glance. It is in the history if a knob ever needs re-fitting.
 ///
@@ -62,10 +62,10 @@ template <typename Painter> juce::Image render(Painter &&paint)
     return image;
 }
 
-juce::Image moduleKnob(float const value, bool const bipolar, bool const drawWedge = true)
+juce::Image moduleKnob(float const value, bool const bipolar)
 {
     return render([&](juce::Graphics &graphics, juce::Rectangle<float> const bounds) {
-        GUI::paintModuleKnob(graphics, bounds, value, bipolar, drawWedge, false /*focus*/);
+        GUI::paintModuleKnob(graphics, bounds, value, bipolar, false /*not selected*/);
     });
 }
 
@@ -103,26 +103,6 @@ TEST_CASE("Both knobs draw the value they are given", "[gui][knob]")
     // ...and the polarity is a parameter rather than a decoration: at the centre
     // of the range a unipolar wedge is half open and a bipolar one is shut.
     CHECK(differ(moduleKnob(0.5f, false), moduleKnob(0.5f, true)));
-}
-
-TEST_CASE("An LFO driven module knob shows no value at all", "[gui][knob]")
-{
-    juce::ScopedJuceInitialiser_GUI const juceInitialiser;
-
-    //   The knob's own value says nothing while an LFO drives the parameter, so
-    // no part of the drawing may depend on it. Not just the wedge: the cap
-    // follows how far the wedge has opened, and sizing it off a value the knob
-    // is not showing is the way this leaks -- which it did, until it was looked
-    // at on the contact sheet.
-    auto const driven(moduleKnob(0.0f, false, false /*no wedge*/));
-    for (float value(0.25f); value <= 1.0f; value += 0.25f)
-    {
-        INFO("value " << value);
-        CHECK_FALSE(differ(driven, moduleKnob(value, false, false)));
-    }
-
-    // And it is a real difference from the same knob showing that value.
-    CHECK(differ(driven, moduleKnob(1.0f, false, true)));
 }
 
 TEST_CASE("Both knobs sweep through the same arc", "[gui][knob]")

--- a/tests/gui/moduleControlFocusTests.cpp
+++ b/tests/gui/moduleControlFocusTests.cpp
@@ -1073,6 +1073,104 @@ TEST_CASE("A selected control keeps its LFO strip when the keyboard goes elsewhe
     CHECK(lfoStripIsUp(editor));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The halo is the same claim as the LFO strip, drawn on the control
+/// instead of over the rack: both say "this is the one you are editing". It was
+/// keyed on the keyboard focus, which stopped being the selection -- so clicking
+/// away left a strip on screen naming a knob that had gone plain, and the two
+/// halves of one statement disagreed.
+///
+/// \note Rendered rather than reasoned about, and pixel for pixel: what the
+/// widget *decides* is a boolean this file could read off the control, and what
+/// it *draws* is the thing that was wrong. \see knobPaintingTests.cpp, which
+/// compares two renders of a painter for the same reason.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+/// One widget, painted into an image of its own at its own size.
+juce::Image renderOf(juce::Component &widget)
+{
+    juce::Image image(juce::Image::ARGB, widget.getWidth(), widget.getHeight(), true,
+                      juce::SoftwareImageType{});
+    juce::Graphics graphics(image);
+    widget.paintEntireComponent(graphics, false);
+    return image;
+}
+
+/// \note Both sides are renders of the same widget, so there is no size to check.
+bool differ(juce::Image const &a, juce::Image const &b)
+{
+    for (int y(0); y < a.getHeight(); ++y)
+        for (int x(0); x < a.getWidth(); ++x)
+            if (a.getPixelAt(x, y) != b.getPixelAt(x, y))
+                return true;
+    return false;
+}
+} // anonymous namespace
+
+TEST_CASE("The halo stays on the control whose LFO strip is showing",
+          "[gui][modules][lfo][selection]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    if (!SWTest::aWindowCanBeMade())
+        SKIP(SWTest::noWindow);
+
+    SWTest::Instance instance;
+    DesktopEditor const window(instance);
+    if (!window.tookTheKeyboard())
+        SKIP(keyboardRefused);
+
+    // Every shape a module control comes in, because each draws its own halo:
+    // three of them ask the control and the fourth is a combo box, which has the
+    // question put to it. \see ComboBox::showsAsSelected().
+    char const *effect{"Freeze"};
+    GUI::ModuleControlBase *(*controlIn)(GUI::ModuleUI &){nullptr};
+
+    SECTION("a knob") { controlIn = firstControlOfType<GUI::ModuleKnob>; }
+    SECTION("an LED button")
+    {
+        effect = "TuneWorx";
+        controlIn = firstControlOfType<GUI::ModuleLEDTextButton>;
+    }
+    SECTION("a trigger") { controlIn = firstControlOfType<GUI::TriggerButton>; }
+    SECTION("a combo box")
+    {
+        effect = "Swappah";
+        controlIn = firstControlOfType<GUI::DiscreteParameter>;
+    }
+
+    auto &editor(window.editor());
+    auto const [pFirstStrip, pSecondStrip](twoStrips(editor, effect));
+
+    auto *const pControl(controlIn(*pFirstStrip));
+    auto *const pOther(controlIn(*pSecondStrip));
+    REQUIRE(pControl != nullptr);
+    REQUIRE(pOther != nullptr);
+
+    pControl->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pControl);
+    REQUIRE(lfoStripIsUp(editor));
+    auto const selected(renderOf(pControl->widget()));
+
+    // The reported case: the keyboard goes to a preset row or a host's panel, the
+    // strip stays up -- and so must the halo.
+    editor.grabKeyboardFocus();
+    REQUIRE(!pControl->widget().hasKeyboardFocus(false));
+    REQUIRE(editor.activeControl() == pControl);
+    REQUIRE(lfoStripIsUp(editor));
+    CHECK(!differ(selected, renderOf(pControl->widget())));
+
+    // ...and it goes when the selection does, which is what says there is a halo
+    // in the first render at all.
+    pOther->widget().grabKeyboardFocus();
+    REQUIRE(editor.activeControl() == pOther);
+    CHECK(differ(selected, renderOf(pControl->widget())));
+}
+
 TEST_CASE("The shared controls survive the keyboard going elsewhere", "[gui][modules][selection]")
 {
     SWTest::HostSideJuce const juceIsUp;

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -138,8 +138,8 @@ template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Compone
 /// box arrived as a fourth and this said so.
 GUI::TitledComboBox &comboBoxOffering(Editor &editor, std::size_t const choices)
 {
-    /// Zoom, colour scheme, mouse-over reaction and LFO update behaviour.
-    std::size_t constexpr onTheInterfacePage{4};
+    /// Zoom, colour scheme and mouse-over reaction.
+    std::size_t constexpr onTheInterfacePage{3};
 
     auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
     REQUIRE(comboBoxes.size() == onTheInterfacePage);
@@ -157,7 +157,6 @@ GUI::TitledComboBox &zoomComboBox(Editor &editor)
     return comboBoxOffering(editor, Preferences::zoomPercentages.size());
 }
 GUI::TitledComboBox &mouseOverComboBox(Editor &editor) { return comboBoxOffering(editor, 3); }
-GUI::TitledComboBox &lfoUpdateComboBox(Editor &editor) { return comboBoxOffering(editor, 4); }
 
 /// The one LED on the Interface page, found through the combo boxes so that the
 /// module strips' own LEDs cannot be picked up instead.
@@ -190,7 +189,6 @@ TEST_CASE("With no preferences file every value is at its default", "[gui][prefe
     Preferences const preferences(caseFolder("absent"));
 
     CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
-    CHECK(preferences.lfoUpdateBehaviour() == Preferences::Always);
     CHECK(preferences.hideCursorOnKnobDrag());
     CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
 
@@ -207,7 +205,7 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
     {
         Preferences written(folder);
         written.setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
-        written.setLFOUpdateBehaviour(Preferences::WhenControlActive);
+        written.setPalette(GUI::ColourMap::ClassicRed);
         written.setHideCursorOnKnobDrag(false);
         written.setZoomPercent(75);
 
@@ -216,7 +214,7 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
 
     Preferences const read(folder);
     CHECK(read.moduleUIMouseOverReaction() == Preferences::WhenParentModuleSelected);
-    CHECK(read.lfoUpdateBehaviour() == Preferences::WhenControlActive);
+    CHECK(read.palette() == GUI::ColourMap::ClassicRed);
     CHECK(!read.hideCursorOnKnobDrag());
     CHECK(read.zoomPercent() == 75);
 }
@@ -236,7 +234,6 @@ TEST_CASE("The file names its keys and its enumerated values", "[gui][preference
 
     Preferences preferences(folder);
     preferences.setModuleUIMouseOverReaction(Preferences::WhenParentOrNothingSelected);
-    preferences.setLFOUpdateBehaviour(Preferences::WhenControlSelected);
     preferences.setHideCursorOnKnobDrag(false);
     preferences.setZoomPercent(125);
 
@@ -244,8 +241,6 @@ TEST_CASE("The file names its keys and its enumerated values", "[gui][preference
     CAPTURE(file);
 
     CHECK(file.find("key=\"moduleUIMouseOverReaction\" value=\"WhenParentOrNothingSelected\"") !=
-          std::string::npos);
-    CHECK(file.find("key=\"lfoUpdateBehaviour\" value=\"WhenControlSelected\"") !=
           std::string::npos);
     CHECK(file.find("key=\"hideCursorOnKnobDrag\" value=\"0\"") != std::string::npos);
     CHECK(file.find("key=\"zoomPercent\" value=\"125\"") != std::string::npos);
@@ -260,7 +255,7 @@ TEST_CASE("A value this build does not recognise reads as the default", "[gui][p
           "<?xml version = \"1.0\" encoding = \"UTF-8\" ?>\n"
           "<defaults version=\"1\">\n"
           "  <default key=\"moduleUIMouseOverReaction\" value=\"Sideways\" type=\"1\"/>\n"
-          "  <default key=\"lfoUpdateBehaviour\" value=\"WhenControlActive\" type=\"1\"/>\n"
+          "  <default key=\"palette\" value=\"ClassicRed\" type=\"1\"/>\n"
           "  <default key=\"zoomPercent\" value=\"300\" type=\"2\"/>\n"
           "</defaults>\n");
 
@@ -276,7 +271,7 @@ TEST_CASE("A value this build does not recognise reads as the default", "[gui][p
     CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
 
     // ...and neither unreadable key cost it the one beside it.
-    CHECK(preferences.lfoUpdateBehaviour() == Preferences::WhenControlActive);
+    CHECK(preferences.palette() == GUI::ColourMap::ClassicRed);
 }
 
 TEST_CASE("Every offered zoom scales the skin by its own percentage", "[gui][preferences]")
@@ -316,7 +311,6 @@ TEST_CASE("The Interface page opens showing what is in the preferences", "[gui][
 {
     useCaseFolder("pageReads");
     GUI::preferences().setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
-    GUI::preferences().setLFOUpdateBehaviour(Preferences::NoUpdate);
     GUI::preferences().setHideCursorOnKnobDrag(false);
 
     SWTest::HostSideJuce const juce;
@@ -324,7 +318,6 @@ TEST_CASE("The Interface page opens showing what is in the preferences", "[gui][
     auto &editor(editorOnTheInterfacePage(instance));
 
     CHECK(mouseOverComboBox(editor).getSelectedID() == Preferences::WhenParentModuleSelected);
-    CHECK(lfoUpdateComboBox(editor).getSelectedID() == Preferences::NoUpdate);
     CHECK(!hideCursorButton(editor).getToggleState());
 }
 

--- a/tools/show-ui/pages/knobsPage.cpp
+++ b/tools/show-ui/pages/knobsPage.cpp
@@ -9,9 +9,7 @@
 /// replaced was five film strips of 127 frames each -- so the artwork was its
 /// own contact sheet and anyone could see the whole travel at once. This is that
 /// contact sheet for the paint code: the editor knob, then the module knob in
-/// both polarities and both sizes, and the two states that are not a value at
-/// all (focused, and LFO-driven, where the knob's own value says nothing and the
-/// wedge goes away).
+/// both polarities and both sizes, selected and not.
 ///
 ///   The editor pages cannot show this. A knob there sits wherever its
 /// parameter's default put it -- which for the symmetric ones is dead centre,
@@ -50,8 +48,8 @@ class KnobsPage final : public juce::Component
 
     void paint(juce::Graphics &graphics) override
     {
-        // The module panel's own background, so the rims and the focus halo are
-        // read against what they will actually sit on.
+        // The module panel's own background, so the rims and the halo are read
+        // against what they will actually sit on.
         graphics.fillAll(juce::Colour(0xFF232323));
 
         label(graphics, "The editor's knobs, painted", margin, margin, 22.5f, juce::Colours::white);
@@ -70,8 +68,7 @@ class KnobsPage final : public juce::Component
                 if (row.editor)
                     GUI::paintEditorKnob(graphics, face, value);
                 else
-                    GUI::paintModuleKnob(graphics, face, value, row.bipolar, row.drawWedge,
-                                         row.selected);
+                    GUI::paintModuleKnob(graphics, face, value, row.bipolar, row.selected);
             }
             y += cell;
         }
@@ -88,24 +85,18 @@ class KnobsPage final : public juce::Component
         char const *caption;
         unsigned int diameter;
         bool editor;  ///< an EditorKnob rather than a ModuleKnob
-        bool bipolar; ///< module knobs only, as are the two below
-        bool drawWedge;
+        bool bipolar; ///< module knobs only, as is the one below
         bool selected;
     }; // struct Row
 
     static constexpr Row rows_[]{
-        {"EditorKnob, 83 px (in, out and mix)", GUI::EditorKnob::diameter, true, false, false,
-         false},
-        {"ModuleKnob unipolar, 77 px", GUI::ModuleKnob::diameter, false, false, true, false},
-        {"ModuleKnob bipolar, 77 px", GUI::ModuleKnob::diameter, false, true, true, false},
-        {"ModuleKnob unipolar, 77 px, focused", GUI::ModuleKnob::diameter, false, false, true,
-         true},
-        {"LFO driven -- no wedge, whatever the value", GUI::ModuleKnob::diameter, false, false,
-         false, false},
+        {"EditorKnob, 83 px (in, out and mix)", GUI::EditorKnob::diameter, true, false, false},
+        {"ModuleKnob unipolar, 77 px", GUI::ModuleKnob::diameter, false, false, false},
+        {"ModuleKnob bipolar, 77 px", GUI::ModuleKnob::diameter, false, true, false},
+        {"ModuleKnob unipolar, 77 px, selected", GUI::ModuleKnob::diameter, false, false, true},
         {"ModuleKnob unipolar, 35 px (gain and wet)", GUI::ModuleKnob::smallDiameter, false, false,
-         true, false},
-        {"ModuleKnob bipolar, 35 px, focused", GUI::ModuleKnob::smallDiameter, false, true, true,
-         true},
+         false},
+        {"ModuleKnob bipolar, 35 px, selected", GUI::ModuleKnob::smallDiameter, false, true, true},
     };
     static constexpr int rows{int(std::size(rows_))};
 


### PR DESCRIPTION
Selection stopped following the keyboard, and the halo did not come with it: clicking away from a knob left the strip still showing that knob's LFO while the knob itself went plain, so the two halves of one statement disagreed. The focus goes to a preset row, a settings box or a host's panel without the selection moving, and the ring has to say which control the interface is on rather than where the keyboard landed.

All four shapes a module control comes in ask the selection now. Three of them ask it outright; a combo box is drawn by GUI::ComboBox, which is not a module control, so the box has the question put to it and a module's answers with its selection. The repaint moved with them, to the two places the selection moves, and the four focusChanged() hooks retire -- nothing about a module control's drawing depends on the keyboard any more.

The LFO update behaviour preference goes with it. It offered "control selected" and "control active" as separate policies for whether a modulated control follows its sweep, which was one thing said twice while selection was the focus; pulling those apart left one of them keyed on a state nothing on screen shows. What it chose between is not worth a setting -- a modulated control follows its LFO, always -- so the row, the file key and shouldUpdateLFOControl() are gone, and with them paintModuleKnob()'s drawWedge, which only that policy could ever set false.

Closes #139.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>