### PR TITLE
Trade the mouse-over reaction for a hover display and a still LFO

### DIFF
--- a/doc/tech/streaming_format.md
+++ b/doc/tech/streaming_format.md
@@ -348,16 +348,17 @@ The settings panel's Interface page is *not* a candidate, and it is the case tha
 says where the line is — and note that it is the *page* rather than the *tab*:
 which tab was showing is a place this session was left, which is the block's, and
 what is on that page is how this user likes the editor to behave, which is not.
-Its four — zoom, mouse-over reaction, LFO update behaviour,
-hide-cursor-on-knob-drag — used to persist nowhere at all (issues #61 and #55). They are answers about how this user likes the editor to behave, not
+Its five — zoom, colour scheme, show-LFO-animation, preview-LFO-on-hover,
+hide-cursor-on-knob-drag — used to persist nowhere at all (issues #61 and #55).
+They are answers about how this user likes the editor to behave, not
 about this session, so they are the same in every instance and in every project,
 and they belong in the user's preferences file rather than in a host's state
 blob: `<user folder>/SpectrumWorxUserDefaults.xml`, through
 `sst::plugininfra::defaults::Provider`. \see `src/gui/preferences.hpp`. Its
-format is that library's; what this tree fixes about it is that both
-enumerations are streamed **by name**, so inserting a value cannot silently
-change what an existing file means. `tests/gui/preferencesTests.cpp` pins the
-names.
+format is that library's; what this tree fixes about it is that the one
+enumeration in it — the palette — is streamed **by name**, so inserting a value
+cannot silently change what an existing file means.
+`tests/gui/preferencesTests.cpp` pins the names.
 
 The zoom is a percentage and **100 means no transform at all**. It used to mean
 1.5: the skin was a 563 x 376 bitmap laid out for a 2010 screen and

--- a/src/gui/colourMap.cpp
+++ b/src/gui/colourMap.cpp
@@ -150,6 +150,8 @@ juce::Colour ColourMap::classic(Name const name)
         return juce::Colour(0xFF0A0909u);
     case ModuleKnobCap:
         return juce::Colour(0xFF000000u);
+    case ModuleKnobLFORange:
+        return juce::Colour(0x8013B5EAu);
 
     case FocusHalo:
         return juce::Colour(0xFFFFFFFFu);

--- a/src/gui/colourMap.hpp
+++ b/src/gui/colourMap.hpp
@@ -108,6 +108,15 @@ class ColourMap
         ModuleKnobDomeCentre, ///< the dome where the cap ends
         ModuleKnobDomeRim,    ///< the dome at its rim, and the hairline on it
         ModuleKnobCap,        ///< the cap over the wedge's inside
+
+        /// \brief The arc an LFO's bounds cover, drawn where the wedge is drawn
+        /// and under it.
+        ///
+        /// \note Translucent, and that is the whole of it: this says "the value
+        /// lives somewhere in here" against a wedge that says where it is now.
+        /// Only drawn with the animation turned off. \see
+        /// Preferences::showLFOAnimation() and issue #210.
+        ModuleKnobLFORange,
         ///@}
 
         /// The halo around whichever control has the focus.

--- a/src/gui/editor/auxiliaryComponents.hpp
+++ b/src/gui/editor/auxiliaryComponents.hpp
@@ -85,9 +85,21 @@ class SharedModuleControls : public WidgetBase<>
       protected: // ModuleControlBase overrides
         void lfoStateChanged() override {}
 
-        /// \note This one is its own ModuleControlBase rather than a
+        /// \note These are its own ModuleControlBase rather than a
         /// ModuleControlImpl<>, so it answers for itself. \see issue #139.
+        ///@{
         void deselect() override { reportInactiveControl(); }
+
+        /// \note And the selection here is a *thumb*, so this is the one control
+        /// select() cannot make up an answer for: it forwards to the same
+        /// reportActiveControl() a press does, which does nothing until a thumb
+        /// has been chosen.
+        void select() override { reportActiveControl(); }
+        ///@}
+
+        /// \note And this one is the base's outright: a two-thumbed slider has no
+        /// wheel and no ring of its own to re-key. \see issue #210.
+        void unhover() override { mouseLeft(); }
 
         void setValue(float value) override;
         float getValue() const override;

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -1466,8 +1466,8 @@ juce::String SpectrumWorxEditor::moduleParameterMenuName(Module const &module,
            parameterName;
 }
 
-void SpectrumWorxEditor::moduleControlActivated(ModuleControlBase &control, double const minimum,
-                                                double const maximum, double const interval)
+void SpectrumWorxEditor::showLFOFor(ModuleControlBase &control, double const minimum,
+                                    double const maximum, double const interval)
 {
     /// \note
     ///   In addition to the reason given for the SharedModuleControls instance
@@ -1488,6 +1488,17 @@ void SpectrumWorxEditor::moduleControlActivated(ModuleControlBase &control, doub
     updateActiveControlValue();
 }
 
+void SpectrumWorxEditor::moduleControlActivated(ModuleControlBase &control, double const minimum,
+                                                double const maximum, double const interval)
+{
+    // a selection replaces whatever a hover was flashing, and the strip is about
+    // to be laid out for the new control either way
+    pPreviewControl_ = nullptr;
+    activeControlRange_ = {minimum, maximum, interval};
+
+    showLFOFor(control, minimum, maximum, interval);
+}
+
 void SpectrumWorxEditor::moduleControlDectivated(ModuleControlBase const &control)
 {
     LE_ASSERT(lfoDisplay_);
@@ -1498,6 +1509,92 @@ void SpectrumWorxEditor::moduleControlDectivated(ModuleControlBase const &contro
     setActiveControlName(selectedModule() ? selectedModule()->description() : juce::String());
     setActiveControlValue(juce::String());
 
+    retireLFODisplay();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// What the pointer is on
+// ----------------------
+//
+////////////////////////////////////////////////////////////////////////////////
+///
+///   Four entry points and no coordinate arithmetic, which works because JUCE
+/// delivers the exit before the enter: moving from a strip onto one of its knobs
+/// clears the strip's hover and then the knob puts it straight back, and both
+/// happen before anything is painted.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void SpectrumWorxEditor::moduleHovered(ModuleUI &region)
+{
+    if (pHoveredModule_ == &region)
+        return;
+
+    if (auto *const pOutgoing = pHoveredModule_)
+    {
+        pHoveredModule_ = nullptr;
+        pOutgoing->repaint();
+    }
+    pHoveredModule_ = &region;
+    region.repaint();
+}
+
+void SpectrumWorxEditor::moduleUnhovered(ModuleUI &region)
+{
+    if (pHoveredModule_ != &region)
+        return;
+
+    pHoveredModule_ = nullptr;
+    region.repaint();
+}
+
+void SpectrumWorxEditor::moduleControlHovered(ModuleControlBase &control, double const minimum,
+                                              double const maximum, double const interval)
+{
+    pHoveredControl_ = &control;
+
+    if (auto *const pStrip = control.stripDrawnOn())
+        moduleHovered(*pStrip);
+    else if (pHoveredModule_)
+        moduleUnhovered(*pHoveredModule_); // the shared controls stand above the rack
+
+    /// \note Not for the selected control, which the strip is already showing --
+    /// and "previewing the selection" would then have to be undone on the way
+    /// out, which is exactly the state endLFOPreview() exists not to have.
+    if (preferences().previewLFOOnHover() && (&control != pActiveControl_))
+    {
+        pPreviewControl_ = &control;
+        showLFOFor(control, minimum, maximum, interval);
+    }
+}
+
+void SpectrumWorxEditor::moduleControlUnhovered(ModuleControlBase &control)
+{
+    if (pHoveredControl_ != &control)
+        return;
+
+    pHoveredControl_ = nullptr;
+
+    if (auto *const pStrip = control.stripDrawnOn())
+        moduleUnhovered(*pStrip);
+
+    endLFOPreview();
+}
+
+void SpectrumWorxEditor::endLFOPreview()
+{
+    if (!pPreviewControl_)
+        return;
+    pPreviewControl_ = nullptr;
+
+    if (pActiveControl_)
+        return showLFOFor(*pActiveControl_, activeControlRange_.minimum,
+                          activeControlRange_.maximum, activeControlRange_.interval);
+
+    setActiveModuleName(selectedModule() ? selectedModule()->getName() : juce::String());
+    setActiveControlName(selectedModule() ? selectedModule()->description() : juce::String());
+    setActiveControlValue(juce::String());
     retireLFODisplay();
 }
 
@@ -1595,6 +1692,16 @@ void SpectrumWorxEditor::detachFrom(ModuleUI &region)
     // and a cleared pActiveControl_ makes that re-entry a no-op
     if (activeControlIsRegions)
         pActiveControl_ = nullptr;
+
+    // and the three the pointer keeps, which point into the strip the same way
+    // and are read by every repaint. Cleared rather than handed over: the
+    // pointer is wherever it is, and whatever it lands on next will say so
+    if (pHoveredControl_ && pHoveredControl_->pointsInto(region))
+        pHoveredControl_ = nullptr;
+    if (pPreviewControl_ && pPreviewControl_->pointsInto(region))
+        pPreviewControl_ = nullptr;
+    if (pHoveredModule_ == &region)
+        pHoveredModule_ = nullptr;
 
     // both destroyed *now*, where retireLFODisplay() and moduleDeactivated()
     // only disable them and post a message to do it later. That deferral suits a
@@ -1835,6 +1942,23 @@ void SpectrumWorxEditor::updateLFO(ModuleUI &moduleUI, std::uint8_t const parame
          LE::Parameters::IndexOf<LFOImpl::Parameters, LFOImpl::Enabled>::value) &&
         (value == 0))
         showUnmodulatedValue(moduleUI, parameterIndex);
+
+    //   And the strip whole, where a *bound* moved: the knobs on it draw the
+    // bounds when the animation is off, and this index addresses a parameter the
+    // way an LFO does -- which only ModuleUI::setParameter() knows how to turn
+    // into a widget. Guarded on the two, because a host is as free to automate a
+    // phase every block as it is to move a bound once. \see issue #210.
+    using LFOImpl = LE::Parameters::LFOImpl;
+    if ((lfoParameterIndex ==
+         LE::Parameters::IndexOf<LFOImpl::Parameters, LFOImpl::LowerBound>::value) ||
+        (lfoParameterIndex ==
+         LE::Parameters::IndexOf<LFOImpl::Parameters, LFOImpl::UpperBound>::value))
+    {
+        moduleUI.repaint();
+        // the gain and wet pair stand above the rack rather than on the strip
+        if (sharedModuleControlsActive())
+            sharedModuleControls().repaint();
+    }
 
     if (lfoDisplay_ && lfoDisplay_->isEnabled())
         lfoDisplay_->updateForChangedParameters(moduleUI, parameterIndex, lfoParameterIndex, value);
@@ -2126,9 +2250,24 @@ void SpectrumWorxEditor::setPalette(ColourMap::Palette const palette)
     // rather than two that have to agree
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **The unmodulated value, where the user has asked not to see the
+/// sweep.** Skipping the write instead would be cheaper and would leave every
+/// knob frozen wherever its LFO happened to have it when the preference was
+/// turned off -- a value nobody chose, and the same complaint issue #204 was
+/// about. Writing what the parameter itself holds converges on the next tick,
+/// costs nothing after it (juce::Slider ignores a value it already has), and
+/// needs no answer to "which editors have to be told". \see
+/// Preferences::showLFOAnimation() and issue #210.
+///
+////////////////////////////////////////////////////////////////////////////////
+
 void SpectrumWorxEditor::pumpModulatedValues()
 {
     LE_ASSERT(isThisTheGUIThread());
+
+    bool const animate(preferences().showLFOAnimation());
 
     editorHost().modulatedValues().forEachChanged([&](std::size_t const index, float const value) {
         ParameterID const parameterID{Plugins::ParameterIndex{static_cast<std::uint16_t>(index)}};
@@ -2139,15 +2278,22 @@ void SpectrumWorxEditor::pumpModulatedValues()
         if (!pRegion)
             return;
 
-        // the slot's effect may have changed since the value was written, and
+        //   The slot's effect may have changed since the value was written, and
         // then this is an index the *previous* effect had: the mailbox is a
         // fixed array over the maximal layout and keeps its dirty bit until
-        // swept, so a preset leaves values for slots whose effects it replaced
-        if (parameterID.value._.module.moduleParameterIndex >=
-            pRegion->module().numberOfParameters())
+        // swept, so a preset leaves values for slots whose effects it replaced.
+        //
+        //   Zero is Bypass, which no LFO drives and which the mailbox therefore
+        // never carries -- and the `- 1` below would read past the start of the
+        // unmodulated values if it did: those are indexed as the LFOs are.
+        auto const parameterIndex(parameterID.value._.module.moduleParameterIndex);
+        if ((parameterIndex == 0) || (parameterIndex >= pRegion->module().numberOfParameters()))
             return;
 
-        pRegion->setParameter(parameterID.value._.module.moduleParameterIndex, value,
+        pRegion->setParameter(parameterIndex,
+                              animate ? value
+                                      : pRegion->module().unmodulatedParameter(
+                                            static_cast<std::uint8_t>(parameterIndex - 1)),
                               ModuleUI::LFOValue);
     });
 }
@@ -2486,7 +2632,7 @@ juce::String phaseString(SpectrumWorxEditor::LFODisplay const &parent, double co
 juce::String rangeValueString(SpectrumWorxEditor::LFODisplay const &parent,
                               double const &periodScale)
 {
-    LE_ASSERT(parent.control().isActive());
+    LE_ASSERT(parent.control().isDisplayed());
     return parent.control().getTextFromValue(static_cast<float>(periodScale));
 }
 
@@ -2548,9 +2694,8 @@ void SpectrumWorxEditor::LFODisplay::paint(juce::Graphics &graphics)
     //...mrmlj...ugh...2.6.x quick-fix workarounds...reinvestigate and clean this up...
     if (!this->isEnabled())
         return;
-    LE_ASSERT(editor().activeControl() != nullptr);
-    LE_ASSERT(editor().activeControl() == &control());
-    LE_ASSERT(control().isActive());
+    LE_ASSERT(editor().displayedControl() != nullptr);
+    LE_ASSERT(editor().displayedControl() == &control());
     LE_ASSERT(getParentComponent() == &editor().mainArea());
 
     {
@@ -2712,6 +2857,12 @@ void SpectrumWorxEditor::LFODisplay::sliderValueChanged(juce::Slider *const pSli
 
         updateParameterAndNotifyHost<LFO::LowerBound>(newLowerBound);
         updateParameterAndNotifyHost<LFO::UpperBound>(newUpperBound);
+
+        //   The knob draws the bounds too, where the animation is off, and
+        // nothing else would repaint it: with the sweep not moving the widget,
+        // there is no value change to carry a repaint along with it.
+        // \see ModuleKnob::lfoRangeToDraw() and issue #210.
+        control().widget().repaint();
     }
     else if (pSlider == &period_)
     {
@@ -3486,11 +3637,6 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
     {
         editor.setPalette(static_cast<ColourMap::Palette>(value));
     }
-    else if (&comboBox == &settings.interfacePage_.mouseOverComboBox())
-    {
-        preferences().setModuleUIMouseOverReaction(
-            static_cast<Preferences::ModuleUIMouseOverReaction>(value));
-    }
     else
     {
         LE_UNREACHABLE_CODE();
@@ -3625,9 +3771,10 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep + yOffset, "Zoom"),
       palette_(*this, xMargin, yMargin + 1 * yStep + yOffset, "Color Scheme"),
-      moduleUIMouseOverReaction_(*this, xMargin, yMargin + 2 * yStep + yOffset,
-                                 "Mouse Over Reaction"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep + yOffset,
+      showLFOAnimation_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset, "Show LFO animation"),
+      previewLFOOnHover_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + ledStep,
+                         "Preview LFO on hover"),
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + 2 * ledStep,
                             "Hide cursor on knob drag")
 {
     Settings &parent(
@@ -3662,10 +3809,12 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     palette_.addItem(ColourMap::DarkGray, "Dark Gray");
     palette_.setSelectedIndex(preferences().palette());
 
-    moduleUIMouseOverReaction_.addItem(Preferences::Never, "Never");
-    moduleUIMouseOverReaction_.addItem(Preferences::WhenParentModuleSelected, "Module selected");
-    moduleUIMouseOverReaction_.addItem(Preferences::WhenParentOrNothingSelected, "Always");
-    moduleUIMouseOverReaction_.setSelectedIndex(preferences().moduleUIMouseOverReaction());
+    showLFOAnimation_.setToggleState(preferences().showLFOAnimation(), juce::dontSendNotification);
+    showLFOAnimation_.addListener(&parent);
+
+    previewLFOOnHover_.setToggleState(preferences().previewLFOOnHover(),
+                                      juce::dontSendNotification);
+    previewLFOOnHover_.addListener(&parent);
 
     hideCursorOnKnobDrag_.setToggleState(preferences().hideCursorOnKnobDrag(),
                                          juce::dontSendNotification);
@@ -3731,12 +3880,28 @@ SpectrumWorxEditor &SpectrumWorxEditor::Settings::editor()
                                              &SpectrumWorxEditor::settings_, false>()(*this);
 }
 
+/// \note The rack is repainted for the first of the three, and polling is why:
+/// what a knob under an LFO draws changes with that switch, and a knob is
+/// otherwise only repainted when the mailbox has a new value for it -- which,
+/// with the transport parked, is never.
 void SpectrumWorxEditor::Settings::buttonClicked(juce::Button *const pButton)
 {
-    LE_ASSERT(pButton == &interfacePage_.hideCursorOnKnobDrag_);
-    (void)pButton;
+    auto &page(interfacePage_);
 
-    preferences().setHideCursorOnKnobDrag(interfacePage_.hideCursorOnKnobDrag_.getToggleState());
+    if (pButton == &page.showLFOAnimation_)
+    {
+        preferences().setShowLFOAnimation(page.showLFOAnimation_.getToggleState());
+        editor().mainArea().repaint();
+    }
+    else if (pButton == &page.previewLFOOnHover_)
+    {
+        preferences().setPreviewLFOOnHover(page.previewLFOOnHover_.getToggleState());
+    }
+    else
+    {
+        LE_ASSERT(pButton == &page.hideCursorOnKnobDrag_);
+        preferences().setHideCursorOnKnobDrag(page.hideCursorOnKnobDrag_.getToggleState());
+    }
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -332,6 +332,45 @@ class SpectrumWorxEditor final : private SkinLifetime,
     ModuleUI *selectedModule() const { return pSelectedModule_; }
     ModuleControlBase *activeControl() const { return pActiveControl_; }
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief And what the *pointer* is on, which is a separate question with a
+    /// separate answer. \see issue #210.
+    ///
+    ///   A strip and one of its controls can both be hovered -- the pointer is
+    /// over both -- where selection is one strip and one control. Neither
+    /// hovering nor leaving moves a selection.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///@{
+    ModuleUI *hoveredModule() const { return pHoveredModule_; }
+    ModuleControlBase *hoveredControl() const { return pHoveredControl_; }
+
+    void moduleHovered(ModuleUI &);
+    void moduleUnhovered(ModuleUI &);
+    void moduleControlHovered(ModuleControlBase &, double minimum, double maximum, double interval);
+    void moduleControlUnhovered(ModuleControlBase &);
+    ///@}
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Which control the LFO strip is showing: the hovered one while it
+    /// is previewing, the selected one otherwise.
+    ///
+    /// \note Not the same question as activeControl(), and everything that draws
+    /// or reads the strip asks this one instead. \see
+    /// Preferences::previewLFOOnHover() and issue #210.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ModuleControlBase *displayedControl() const
+    {
+        return pPreviewControl_ ? pPreviewControl_ : pActiveControl_;
+    }
+
+    /// \brief Puts the strip back on the selected control, where a hover had lent
+    /// it to another. Does nothing when nothing is being previewed.
+    void endLFOPreview();
+
     ParameterID moduleControlID(ModuleControlBase const &) const;
 
     /// \brief The same, for a parameter no widget on a strip stands for: the
@@ -1438,7 +1477,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
             InterfacePage();
 
             TitledComboBox const &paletteComboBox() const { return palette_; }
-            TitledComboBox const &mouseOverComboBox() const { return moduleUIMouseOverReaction_; }
 
           private: // JUCE component overrides.
             void paint(juce::Graphics &) override;
@@ -1449,11 +1487,13 @@ class SpectrumWorxEditor final : private SkinLifetime,
           private:
             friend class Settings;
             /// \note Zoom first and the colour scheme under it, those being the
-            /// two a user reaches for. Each control draws its own title, so the
-            /// order is a layout decision rather than an artwork one.
+            /// two a user reaches for, then the three switches. Each control
+            /// draws its own title, so the order is a layout decision rather than
+            /// an artwork one.
             TitledComboBox zoom_;
             TitledComboBox palette_;
-            TitledComboBox moduleUIMouseOverReaction_;
+            LEDTextButton showLFOAnimation_;
+            LEDTextButton previewLFOOnHover_;
             LEDTextButton hideCursorOnKnobDrag_;
         }; // class InterfacePage
 
@@ -1470,6 +1510,9 @@ class SpectrumWorxEditor final : private SkinLifetime,
         static std::uint16_t const yMargin = 30;
         static std::uint16_t const yOffset = 7;
         static std::uint16_t const yStep = 60;
+        /// \note Between two LEDs, which carry no title of their own and so do
+        /// not need the room a combo box's does.
+        static std::uint16_t const ledStep = 30;
     }; // class Settings
 
     /// Tab indices into Settings, in addTab() order.
@@ -1483,10 +1526,39 @@ class SpectrumWorxEditor final : private SkinLifetime,
 
   private:
     friend class ModuleControlBase;
-    /// \note Written by ModuleUI::activate()/deactivate() and by
+    /// \note Written by ModuleUI::activate() and by
     /// ModuleControlBase::report{Active,Inactive}Control(), and nowhere else.
     ModuleUI *pSelectedModule_{nullptr};
     ModuleControlBase *pActiveControl_{nullptr};
+
+    /// \note And these by the four hover entry points above. \see issue #210.
+    ModuleUI *pHoveredModule_{nullptr};
+    ModuleControlBase *pHoveredControl_{nullptr};
+
+    /// \brief The hovered control while the LFO strip is lent to it, and nothing
+    /// the rest of the time. Never the selected control.
+    ModuleControlBase *pPreviewControl_{nullptr};
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief What the selected control's LFO strip was laid out over, kept so
+    /// that a preview can put it back.
+    ///
+    /// \note Kept rather than re-asked. The three numbers come off the *widget*
+    /// -- `ModuleControlImpl::reportActiveControl()` reads them from the template
+    /// -- and the editor holds a ModuleControlBase, which cannot.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    struct ControlRange
+    {
+        double minimum{0};
+        double maximum{0};
+        double interval{0};
+    } activeControlRange_;
+
+    /// \brief moduleControlActivated() without the bookkeeping: puts \p control's
+    /// LFO and readings on the strip, building it if there is none.
+    void showLFOFor(ModuleControlBase &control, double minimum, double maximum, double interval);
 
   private:
     /// \note First member, and a reference: everything below is built in the

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -663,14 +663,20 @@ ComboBox::ComboBox(juce::Component &parent, FrameStyle const &frame, int const w
 /// both ends.
 void ComboBox::paint(juce::Graphics &graphics)
 {
-    // the rim is the whole of "this box has the focus" -- white rather than the
-    // skin's blue -- and the halo is under both, so the box does not jump size
-    FramePainter::paint(
-        graphics,
-        juce::Rectangle<float>(0, 0, static_cast<float>(getWidth()),
-                               static_cast<float>(boxHeight_)),
-        frame_, ColourMap::getColour(showsAsSelected() ? ColourMap::FocusHalo : ColourMap::Accent),
-        ColourMap::getColour(ColourMap::ComboBackground), true /*halo*/);
+    // the rim is the whole of "this box is the selected one" -- white rather
+    // than the skin's blue, and halfway between the two for one merely under the
+    // pointer -- and the halo is under all three, so the box does not jump size
+    auto const accent(ColourMap::getColour(ColourMap::Accent));
+    auto const white(ColourMap::getColour(ColourMap::FocusHalo));
+    auto const rim(showsAsSelected()  ? white
+                   : showsAsHovered() ? accent.interpolatedWith(white, hoverStrength)
+                                      : accent);
+
+    FramePainter::paint(graphics,
+                        juce::Rectangle<float>(0, 0, static_cast<float>(getWidth()),
+                                               static_cast<float>(boxHeight_)),
+                        frame_, rim, ColourMap::getColour(ColourMap::ComboBackground),
+                        1.0f /*halo*/);
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
     graphics.setFont(Theme::singleton().labelFont());

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -40,6 +40,7 @@
 #include "painters/editorKnobPainter.hpp"
 #include "painters/framePainter.hpp"
 #include "painters/glyphPainter.hpp"
+#include "painters/highlight.hpp"
 #include "painters/knobPainter.hpp"
 #include "painters/panelPainter.hpp"
 
@@ -710,6 +711,10 @@ class ComboBox : public WidgetBase<>, public PopupMenuWithSelection
     /// \brief Whether the box draws as the selected one -- the keyboard, unless
     /// whoever owns it has another answer. \see DiscreteParameter.
     virtual bool showsAsSelected() const { return hasDirectFocus(); }
+
+    /// \brief And whether it draws as merely the one under the pointer, which
+    /// is a rim halfway to the selected one's. \see issue #210.
+    virtual bool showsAsHovered() const { return false; }
 
   protected: // juce::Component overrides
     void paint(juce::Graphics &) override;

--- a/src/gui/modules/moduleControl.cpp
+++ b/src/gui/modules/moduleControl.cpp
@@ -14,7 +14,6 @@
 
 #include "gui/editor/spectrumWorxEditor.hpp"
 #include "gui/modules/moduleUI.hpp"
-#include "gui/preferences.hpp"
 
 #include "le/parameters/lfo.hpp"
 #include "le/parameters/parser.hpp"
@@ -45,6 +44,26 @@ namespace LE::SW::GUI
 /// SpectrumWorxEditor::pActiveControl_ now, one per editor.
 
 bool ModuleControlBase::isActive() const { return this == editor().activeControl(); }
+bool ModuleControlBase::isHovered() const { return this == editor().hoveredControl(); }
+bool ModuleControlBase::isDisplayed() const { return this == editor().displayedControl(); }
+
+Highlight highlightFor(ModuleControlBase const &control)
+{
+    return control.isActive()    ? Highlight::Selected
+           : control.isHovered() ? Highlight::Hovered
+                                 : Highlight::None;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **The keyboard, and nothing else.** This used to read a preference --
+/// whether the pointer merely passing over a control should select it, and if so
+/// under what conditions -- and the answer nobody could make work was any of the
+/// ones that were not "no". A hovered control now has its own display, its own
+/// wheel and its own LFO preview, none of which move the selection. \see issue
+/// #210, and Preferences, which no longer has the question.
+///
+////////////////////////////////////////////////////////////////////////////////
 
 bool ModuleControlBase::tryActivateControl() const
 {
@@ -54,21 +73,7 @@ bool ModuleControlBase::tryActivateControl() const
     if (juce::Component::getNumCurrentlyModalComponents() != 0)
         return false;
 
-    Preferences::ModuleUIMouseOverReaction const desiredReaction(
-        preferences().moduleUIMouseOverReaction());
-    juce::Component const *const pFocusedComponent(juce::Component::getCurrentlyFocusedComponent());
-
-    bool const nothingFocused(noModuleOrModuleControlFocused());
-    bool const parentFocused(pFocusedComponent == &moduleUI());
-    bool const parentOrNothingFocused(parentFocused |
-                                      nothingFocused); // Intentional bitwise or as an optimization.
-    bool const controlFocused(pFocusedComponent == &widget());
-    if ((controlFocused) ||
-        (desiredReaction == Preferences::WhenParentOrNothingSelected && parentOrNothingFocused) ||
-        (desiredReaction == Preferences::WhenParentModuleSelected && parentFocused))
-        return true;
-    else
-        return false;
+    return juce::Component::getCurrentlyFocusedComponent() == &widget();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,24 +90,36 @@ bool ModuleControlBase::tryActivateControl() const
 bool ModuleControlBase::reportActiveControl(double const minimum, double const maximum,
                                             double const interval)
 {
-    if (tryActivateControl())
-    {
-        if (auto *const pOutgoing = editor().activeControl())
-            pOutgoing->deselect();
+    return tryActivateControl() && activateControl(minimum, maximum, interval);
+}
 
-        /// \note The control is marked as activated only after the editor
-        /// has been informed (and the LFO GUI created) to avoid race condition
-        /// crashes when a user activates a control that is being automated (and
-        /// SpectrumWorxEditor::updateActiveControlValue() gets called as a
-        /// response to setParameter() before the LFO gets created).
-        ///                                   (25.04.2013.) (Domagoj Saric)
-        editor().moduleControlActivated(*this, minimum, maximum, interval);
-        editor().pActiveControl_ = this;
-        // the halo is drawn on the selection, so the selection has to repaint
-        widget().repaint();
-        return true;
-    }
-    return false;
+/// \note The hand-over itself, split out because select() needs it without the
+/// question in front. \see the declaration of select().
+bool ModuleControlBase::activateControl(double const minimum, double const maximum,
+                                        double const interval)
+{
+    if (isActive())
+        return false;
+
+    //   The preview goes first, so that the strip is back on the control that is
+    // about to be deselected: moduleControlDectivated() asserts that it is
+    // showing whichever control it is told about. \see issue #210.
+    editor().endLFOPreview();
+
+    if (auto *const pOutgoing = editor().activeControl())
+        pOutgoing->deselect();
+
+    /// \note The control is marked as activated only after the editor
+    /// has been informed (and the LFO GUI created) to avoid race condition
+    /// crashes when a user activates a control that is being automated (and
+    /// SpectrumWorxEditor::updateActiveControlValue() gets called as a
+    /// response to setParameter() before the LFO gets created).
+    ///                                       (25.04.2013.) (Domagoj Saric)
+    editor().moduleControlActivated(*this, minimum, maximum, interval);
+    editor().pActiveControl_ = this;
+    // the ring is drawn on the selection, so the selection has to repaint
+    widget().repaint();
+    return true;
 }
 
 bool ModuleControlBase::reportInactiveControl()
@@ -191,12 +208,13 @@ void ModuleControlBase::addLFOMenuEntry(juce::PopupMenu &menu)
                  });
 }
 
+/// \note Selected **or** hovered, and it used to be only the first. A control the
+/// pointer is on takes the wheel without taking the selection, so an edit from
+/// one is as legitimate as an edit from the other -- and the strip it is on need
+/// not be the selected strip either. \see issue #210.
 void ModuleControlBase::moduleParameterChanged()
 {
-    LE_ASSERT(!editor().selectedModule() || editor().selectedModule() == &moduleUI());
-    LE_ASSERT(noModuleOrModuleControlFocused() || Detail::hasDirectFocus(widget()) ||
-              moduleUI().hasDirectFocus());
-    LE_ASSERT(isActive());
+    LE_ASSERT_MSG(isActive() || isHovered(), "an edit from a control the user is not on");
     LE_ASSERT(!isLFOEnabled());
 
     publishValue();
@@ -263,48 +281,49 @@ bool ModuleControlBase::needsOwnGesture() const
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note **Only where the mouse is what selects.** This was
-/// `reportInactiveControl()` outright, and it could not reach a control the user
-/// had *clicked*: the guard inside answers no while the control holds the
-/// keyboard, and holding the keyboard was the only way to be selected.
+/// \note **Neither of these touches the selection.** This pair was
+/// `reportActiveControl()` and `reportInactiveControl()`, guarded by a preference
+/// that decided whether the pointer selected a control at all -- and the
+/// selection had then to be defended from the pointer, which is what issue #139
+/// is a record of. A click selects; the pointer hovers; the two no longer
+/// compete.
 ///
-///   It is not any more -- a control stays selected after the focus has gone to
-/// the preset pane or to another application -- so an unguarded exit would drop
-/// the LFO strip on the next sweep of the mouse across the rack, which is the
-/// thing issue #139 is about. Under the default reaction the pointer never
-/// selects a control, so it has no business deselecting one.
-///
-/// \note `deselect()` rather than `reportInactiveControl()`: the widget's own
-/// `moduleControlDeactivated()` has to run, and it resolves in ModuleControlImpl.
+/// \note The outgoing control is told, for the reason the outgoing *selected* one
+/// is: JUCE delivers the exit before the next enter, so this is belt and braces
+/// rather than the usual route -- but it does call mouseExit() without a matching
+/// mouseEnter() in at least one case. \see ModuleUI::mouseExit().
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
+void ModuleControlBase::mouseEntered(double const minimum, double const maximum,
+                                     double const interval)
+{
+    if (isHovered())
+        return;
+
+    if (juce::Component::getNumCurrentlyModalComponents() != 0)
+        return;
+
+    if (auto *const pOutgoing = editor().hoveredControl())
+        pOutgoing->unhover();
+
+    editor().moduleControlHovered(*this, minimum, maximum, interval);
+    widget().repaint();
+}
+
 void ModuleControlBase::mouseLeft()
 {
-    if (preferences().moduleUIMouseOverReaction() == Preferences::Never)
+    if (!isHovered())
         return;
-    deselect();
+
+    editor().moduleControlUnhovered(*this);
+    widget().repaint();
 }
 
 void ModuleControlBase::configureControl(bool const mouseClickCanGrabFocus)
 {
     widget().setWantsKeyboardFocus(true);
     widget().setMouseClickGrabsKeyboardFocus(mouseClickCanGrabFocus);
-}
-
-bool ModuleControlBase::noModuleOrModuleControlFocused(SpectrumWorxEditor const &editor)
-{
-    // Implementation note:
-    //   We ignore focused widgets on auxiliary windows.
-    //                                        (07.07.2011.) (Domagoj Saric)
-    juce::Component const *const pFocusedComponent(juce::Component::getCurrentlyFocusedComponent());
-    return (pFocusedComponent == nullptr) || (pFocusedComponent == &editor) ||
-           (!editor.isParentOf(*pFocusedComponent));
-}
-
-bool ModuleControlBase::noModuleOrModuleControlFocused() const
-{
-    return noModuleOrModuleControlFocused(editor());
 }
 
 ModuleControlBase::Module &ModuleControlBase::module() { return moduleUI().module(); }
@@ -446,6 +465,13 @@ bool ModuleControlBase::isASharedModuleControl() const
     /// SharedModuleControls instance).
     ///                                       (12.02.2014.) (Domagoj Saric)
     return pModuleUI_ != widget().getParentComponent();
+}
+
+/// \note The same question the other way round, and the one the hover asks: the
+/// pointer over a shared control is not over any strip.
+ModuleUI *ModuleControlBase::stripDrawnOn()
+{
+    return isASharedModuleControl() ? nullptr : pModuleUI_;
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/modules/moduleControl.hpp
+++ b/src/gui/modules/moduleControl.hpp
@@ -118,6 +118,11 @@ template <class ImplWidget> class ModuleControl : public ParameterMenu
     static void moduleControlActivated() {}
     static void moduleControlDeactivated() {}
 
+    /// \note The pointer arriving or leaving, for a widget that has something to
+    /// re-key on it. A knob has: the wheel works on a hovered control as well as
+    /// on the selected one. \see issue #210.
+    static void moduleControlHoverChanged() {}
+
     static void updateForEngineSetupChanges(Engine::Setup const &) {}
 
   private:
@@ -126,6 +131,11 @@ template <class ImplWidget> class ModuleControl : public ParameterMenu
 }; // class ModuleControl
 
 class ModuleUI;
+
+/// \brief Which of the three a control draws itself as. The selection wins,
+/// there being one ring to draw and two questions that ask for it.
+/// \see issue #210.
+Highlight highlightFor(ModuleControlBase const &);
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -154,11 +164,28 @@ class ModuleControlBase
 
     virtual void lfoStateChanged() = 0;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Makes this the selected control, as a click on it does.
+    ///
+    /// \note What a click does is take the keyboard, and the keyboard is what
+    /// selects. This is the second half without the first, which is the only way
+    /// in for something that has no window: `grabKeyboardFocus()` on a component
+    /// that is on no screen jasserts rather than declining. tools/show-ui and the
+    /// headless cases in tests/gui are what it is for.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    virtual void select() = 0;
+
     /// \brief Tells this control it is no longer the selected one.
     ///
     /// \note Asked of the control that is *losing* the selection, by the one
     /// taking it. Losing the keyboard no longer does it. \see issue #139.
     virtual void deselect() = 0;
+
+    /// \brief The same for the pointer: told to the control the pointer is
+    /// leaving, by the one it has arrived at. \see issue #210.
+    virtual void unhover() = 0;
 
     virtual void updateForEngineSetupChanges(Engine::Setup const &) {}
 
@@ -201,11 +228,32 @@ class ModuleControlBase
     //...mrmlj...excludes non-lfoable parameters (Bypass)...
     std::uint8_t moduleParameterIndex() const { return parameterIndex_; }
 
-    /// \brief Whether this is the selected control -- the one the LFO strip is
-    /// showing, and the one wearing the halo. Not the keyboard. \see issue #139.
+    /// \brief Whether this is the selected control -- the one wearing the ring
+    /// and the one the shared controls follow. Not the keyboard. \see issue #139.
     bool isActive() const;
 
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Whether the pointer is on this control.
+    ///
+    ///   Which is not selecting it and never becomes selecting it: a hovered
+    /// control wears the ring at half strength, takes the wheel, and -- with
+    /// Preferences::previewLFOOnHover() on -- lends the LFO strip its own LFO
+    /// until the pointer leaves. \see issue #210.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    bool isHovered() const;
+
+    /// \brief Whether this is the control the LFO strip is currently showing,
+    /// which is the hovered one while it is previewing and the selected one
+    /// otherwise. \see SpectrumWorxEditor::displayedControl().
+    bool isDisplayed() const;
+
     bool isLFOEnabled() const;
+
+    /// \brief The strip this control is drawn on, or nothing -- the shared gain,
+    /// wet and frequency range stand above the rack rather than on a strip.
+    ModuleUI *stripDrawnOn();
 
     void moduleParameterChanged();
 
@@ -214,8 +262,18 @@ class ModuleControlBase
     /// this control under the mouse right now. \see the definition.
     void publishValue();
 
-    /// \brief What a control does when the pointer leaves it. \see the definition.
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \name What the pointer arriving and leaving does
+    ///
+    ///   Neither of them selects anything. \see issue #210, and
+    /// ModuleControlImpl, which is where the widget's own half is called from.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    ///@{
+    void mouseEntered(double minimum, double maximum, double interval);
     void mouseLeft();
+    ///@}
 
     ////////////////////////////////////////////////////////////////////////////
     ///
@@ -297,11 +355,11 @@ class ModuleControlBase
 
     static bool isActive(juce::Component const &);
 
-    bool noModuleOrModuleControlFocused() const; //...mrmlj...
-    static bool noModuleOrModuleControlFocused(SpectrumWorxEditor const &);
-
   protected:
     bool reportActiveControl(double minimum, double maximum, double interval);
+    /// \brief The same, with the question of whether it may be skipped: what
+    /// select() is over reportActiveControl(). \see the definition.
+    bool activateControl(double minimum, double maximum, double interval);
     bool reportInactiveControl();
 
     void configureControl(bool mouseClickCanGrabFocus);
@@ -401,11 +459,37 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
             ImplWidget::moduleControlDeactivated();
     }
 
+    /// \note The keyboard's step left out and the widget's own kept. \see the
+    /// declaration of select().
+    void select() override
+    {
+        bool const activated(ModuleControlBase::activateControl(ImplWidget::valueRangeMinimum(),
+                                                                ImplWidget::valueRangeMaximum(),
+                                                                ImplWidget::valueRangeQuantum()));
+        if (activated)
+            ImplWidget::moduleControlActivated();
+    }
+
+    void reportHoveredControl()
+    {
+        ModuleControlBase::mouseEntered(ImplWidget::valueRangeMinimum(),
+                                        ImplWidget::valueRangeMaximum(),
+                                        ImplWidget::valueRangeQuantum());
+        ImplWidget::moduleControlHoverChanged();
+    }
+
     /// \note The same thing asked from outside. `moduleControlDeactivated()` is
     /// the widget's own and resolves in this template, so the editor cannot reach
     /// it through a ModuleControlBase -- and it has to, now that the control
     /// losing the selection is told by the one taking it. \see issue #139.
     void deselect() override { reportInactiveControl(); }
+
+    /// \note And the same again for the pointer. \see issue #210.
+    void unhover() override
+    {
+        ModuleControlBase::mouseLeft();
+        ImplWidget::moduleControlHoverChanged();
+    }
 
     using ModuleControlBase::isActive;
 
@@ -441,8 +525,11 @@ class ModuleControlImpl final : public ModuleControlBase, public ImplWidget
     ////////////////////////////////////////////////////////////////////////////
     virtual void focusLost(juce::Component::FocusChangeType) noexcept override {}
 
-    virtual void mouseEnter(juce::MouseEvent const &) override { reportActiveControl(); }
-    virtual void mouseExit(juce::MouseEvent const &) noexcept override { mouseLeft(); }
+    /// \note The pointer takes the *hover* and never the selection, which is what
+    /// the mouse-over reaction preference used to be able to change. \see issue
+    /// #210.
+    virtual void mouseEnter(juce::MouseEvent const &) override { reportHoveredControl(); }
+    virtual void mouseExit(juce::MouseEvent const &) noexcept override { unhover(); }
 }; // class ModuleControlImpl
 
 #pragma warning(pop)

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -95,12 +95,20 @@ void ModuleLEDTextButton::paintButton(juce::Graphics &g, bool const isMouseOverB
     /// \note A combo box's selected background, borrowed: this button stands
     /// where one does and says it is the selected control the same way. It was
     /// `paintImage( ModuleComboOn )` while that was a file.
-    if (control().isActive())
-        FramePainter::paint(g,
-                            juce::Rectangle<float>(0, -1, static_cast<float>(moduleComboWidth),
-                                                   static_cast<float>(moduleComboHeight)),
-                            moduleComboFrame, ColourMap::getColour(ColourMap::FocusHalo),
-                            ColourMap::getColour(ColourMap::ComboBackground), true /*halo*/);
+    ///
+    /// \note And the same background at half strength for the control merely
+    /// under the pointer. \see issue #210.
+    if (float const strength(control().isActive()    ? 1.0f
+                             : control().isHovered() ? hoverStrength
+                                                     : 0.0f);
+        strength > 0)
+        FramePainter::paint(
+            g,
+            juce::Rectangle<float>(0, -1, static_cast<float>(moduleComboWidth),
+                                   static_cast<float>(moduleComboHeight)),
+            moduleComboFrame,
+            ColourMap::getColour(ColourMap::FocusHalo).withMultipliedAlpha(strength),
+            ColourMap::getColour(ColourMap::ComboBackground), strength);
     g.setOrigin(3, 1);
     LEDTextButton::paintButton(g, isMouseOverButton, isButtonDown);
 }
@@ -222,9 +230,10 @@ void TriggerButton::paintButton(juce::Graphics &graphics, bool const isMouseOver
     if (fade)
         graphics.endTransparencyLayer();
 
-    if (control().isActive())
+    if (control().isActive() || control().isHovered())
         KnobPainter::paintFocusRing(graphics, face.getCentre().toFloat(),
-                                    static_cast<float>(face.getWidth()) / 2);
+                                    static_cast<float>(face.getWidth()) / 2,
+                                    control().isActive() ? 1.0f : hoverStrength);
 }
 
 ModuleKnob::ModuleKnob(juce::Component &parent, unsigned int const x, unsigned int const y)
@@ -280,6 +289,38 @@ void ModuleKnob::mouseDrag(juce::MouseEvent const &event) noexcept
     Knob::mouseDrag(event);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Where an LFO bound sits on this knob's travel.
+///
+///   An LFO's bounds are normalised over the parameter's own range -- the same
+/// mapping the strip's two-value slider is laid out with -- and the wedge is
+/// drawn in proportion of *length*, which is not the same thing on a skewed
+/// range. So the bound becomes a value first and a position second.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+float ModuleKnob::positionOfLFOBound(float const bound)
+{
+    auto const minimum(getMinimum());
+    auto const maximum(getMaximum());
+    return static_cast<float>(
+        juce::Slider::valueToProportionOfLength(minimum + bound * (maximum - minimum)));
+}
+
+/// \note Nothing at all unless the user has asked for the sweep to be still: with
+/// the animation on, the wedge is already saying everything the band would.
+/// \see Preferences::showLFOAnimation() and issue #210.
+std::optional<juce::Range<float>> ModuleKnob::lfoRangeToDraw()
+{
+    if (preferences().showLFOAnimation() || !isLFOEnabled())
+        return std::nullopt;
+
+    auto const &lfo(control().lfo());
+    return juce::Range<float>(positionOfLFOBound(lfo.lowerBound()),
+                              positionOfLFOBound(lfo.upperBound()));
+}
+
 void ModuleKnob::paint(juce::Graphics &graphics)
 {
     // valueToProportionOfLength() rather than getNormalisedValue(), so a skewed
@@ -290,7 +331,7 @@ void ModuleKnob::paint(juce::Graphics &graphics)
         graphics,
         juce::Rectangle<float>(static_cast<float>(marginForGlow), static_cast<float>(marginForGlow),
                                static_cast<float>(diameter_), static_cast<float>(diameter_)),
-        value, polarity_ == Bipolar, control().isActive());
+        value, polarity_ == Bipolar, highlightFor(control()), lfoRangeToDraw());
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
     {
@@ -420,8 +461,17 @@ bool ModuleKnob::isOnKnobFace(juce::Point<int> const position) const
 }
 
 void ModuleKnob::moduleControlActivated() { syncMouseWheelAndLFOState(); }
-void ModuleKnob::moduleControlDeactivated() { setScrollWheelEnabled(false); }
-void ModuleKnob::syncMouseWheelAndLFOState() { setScrollWheelEnabled(!isLFOEnabled()); }
+void ModuleKnob::moduleControlDeactivated() { syncMouseWheelAndLFOState(); }
+void ModuleKnob::moduleControlHoverChanged() { syncMouseWheelAndLFOState(); }
+
+/// \note Hovered as well as selected, which is the wheel half of issue #210: a
+/// knob the pointer is on takes notches without taking the selection. Off for
+/// everything else, which is what keeps a wheel from moving the values of the
+/// knobs a user is scrolling the rack past -- issue #124.
+void ModuleKnob::syncMouseWheelAndLFOState()
+{
+    setScrollWheelEnabled(!isLFOEnabled() && (control().isActive() || control().isHovered()));
+}
 
 #ifdef __GNUC__ //...mrmlj... GCC 4.6, Clang 2.8-3.2
 unsigned int const ModuleKnob::spaceForText /* = 27*/;
@@ -480,29 +530,22 @@ void DiscreteParameter::mouseDown(juce::MouseEvent const &event)
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note Takes the selection first, exactly as mouseDown() above does and for
-/// the same reason: `moduleParameterChanged()` asserts that the control being
-/// changed is the selected one, which is what puts its LFO on screen. A wheel
-/// that edited a control while a different module stayed selected would be the
-/// state those assertions exist to catch.
+/// \note **The wheel does not select, and used to.** It took the keyboard first,
+/// because `moduleParameterChanged()` asserted that the control being changed was
+/// the selected one -- so a notch over a box moved the LFO strip and the shared
+/// controls to it, and it needed a window to do so at all, focus being the
+/// window manager's to refuse.
 ///
-/// \note Which means a wheel needs a window, since focus does. That is a real
-/// cost and it is paid where the click already pays it. \see
-/// tests/gui/moduleControlFocusTests.cpp.
+///   A control under the pointer may now be edited without being selected, which
+/// is what the wheel wanted all along. \see issue #210, and
+/// ModuleKnob::syncMouseWheelAndLFOState() for the knob's half of the same
+/// change.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
 void DiscreteParameter::mouseWheelMove(juce::MouseEvent const &event,
                                        juce::MouseWheelDetails const &wheel)
 {
-    if (!hasDirectFocus())
-    {
-        juce::Component::SafePointer<juce::Component> const self(this);
-        grabKeyboardFocus();
-        if (!self || !hasDirectFocus())
-            return;
-    }
-
     if (isLFOEnabled())
         return;
 
@@ -672,7 +715,10 @@ void ModuleUI::moveToSlot(std::uint8_t const slotIndex)
 
 void ModuleUI::paint(juce::Graphics &graphics)
 {
-    paintModuleStrip(graphics, getLocalBounds().toFloat(), selected());
+    paintModuleStrip(graphics, getLocalBounds().toFloat(),
+                     selected()  ? Highlight::Selected
+                     : hovered() ? Highlight::Hovered
+                                 : Highlight::None);
     graphics.setColour(ColourMap::getColour(ColourMap::Accent));
     graphics.drawHorizontalLine(nameRule, static_cast<float>(ModuleUI::border),
                                 Math::convert<float>(getWidth() - ModuleUI::border));
@@ -739,29 +785,34 @@ void ModuleUI::mouseUp(juce::MouseEvent const &event) noexcept
         editor().moduleDragEnd(*this, event);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note **The pointer marks the strip, it does not select it.** These were
+/// `activate()` and `deactivate()` behind a preference that decided whether a
+/// sweep across the rack should move the selection -- which took the LFO strip
+/// and the shared controls with it, and is what issue #139 spent its length
+/// defending against. \see issue #210.
+///
+/// \note Nothing here needs to ask where the pointer went. Moving onto one of
+/// this strip's own controls sends this an exit and that control an enter, in
+/// that order and before anything is painted, and the control puts the strip's
+/// hover straight back. \see SpectrumWorxEditor::moduleControlHovered().
+///
+////////////////////////////////////////////////////////////////////////////////
+
 void ModuleUI::mouseEnter(juce::MouseEvent const &event)
 {
     updateCursorFor(event.getPosition());
-
-    if (selectionTracksMouseMovements())
-        activate();
+    editor().moduleHovered(*this);
 }
 
 void ModuleUI::mouseMove(juce::MouseEvent const &event) { updateCursorFor(event.getPosition()); }
 
-void ModuleUI::mouseExit(juce::MouseEvent const &event) noexcept
-{
-    /// \note In some strange cases (e.g. while a ComboBox drop down menu is
-    /// open and the mouse is moved over a module) JUCE will call mouseExit()
-    /// without first calling mouseEnter().
-    ///                                       (24.05.2012.) (Domagoj Saric)
-    if (!editor().selectedModule())
-        return;
-
-    if (selectionTracksMouseMovements() &&
-        !juce::Rectangle<int>(0, 0, width, height).contains(event.x, event.y))
-        deactivate();
-}
+/// \note In some strange cases (e.g. while a ComboBox drop down menu is open and
+/// the mouse is moved over a module) JUCE will call mouseExit() without first
+/// calling mouseEnter() -- which moduleUnhovered() answers by doing nothing.
+///                                           (24.05.2012.) (Domagoj Saric)
+void ModuleUI::mouseExit(juce::MouseEvent const &) noexcept { editor().moduleUnhovered(*this); }
 
 void ModuleUI::focusGained(FocusChangeType)
 {
@@ -787,7 +838,6 @@ void ModuleUI::focusOfChildComponentChanged(FocusChangeType const changeType)
 
 void ModuleUI::activate()
 {
-    LE_ASSERT(hasFocus() || selectionTracksMouseMovements());
     if (this->selected())
         return;
 
@@ -811,23 +861,6 @@ void ModuleUI::activate()
     repaint();
 }
 
-void ModuleUI::deactivate()
-{
-    LE_ASSERT(selected());
-    LE_ASSERT(!hasFocus());
-
-    editor().moduleDeactivated();
-    editor().pSelectedModule_ = nullptr;
-    repaint();
-}
-
-bool ModuleUI::selectionTracksMouseMovements() const
-{
-    return (preferences().moduleUIMouseOverReaction() ==
-            Preferences::WhenParentOrNothingSelected) &&
-           ModuleControlBase::noModuleOrModuleControlFocused(editor());
-}
-
 namespace
 {
 auto const bypassIndex = LE::Parameters::IndexOf<Effects::BaseParameters::Parameters,
@@ -837,7 +870,7 @@ void setParameterControl(ModuleControlBase &control, float const parameterValue,
                          ModuleUI::ParameterChangeSource const source)
 {
     control.setValue(parameterValue);
-    if ((source == ModuleUI::AutomationOrPreset) && control.isActive())
+    if ((source == ModuleUI::AutomationOrPreset) && control.isDisplayed())
     {
         SpectrumWorxEditor::fromChild(control.widget()).updateActiveControlValue();
     }
@@ -981,6 +1014,7 @@ SpectrumWorxEditor &ModuleUI::editor() { return editor_; }
 SpectrumWorxEditor const &ModuleUI::editor() const { return editor_; }
 
 bool ModuleUI::selected() const { return this == editor().selectedModule(); }
+bool ModuleUI::hovered() const { return this == editor().hoveredModule(); }
 
 SharedModuleControls &ModuleUI::sharedControls()
 {

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -162,6 +162,7 @@ class ModuleKnob : public Knob, public ModuleControl<ModuleKnob>
 
     void moduleControlActivated();
     void moduleControlDeactivated();
+    void moduleControlHoverChanged();
 
     double valueRangeMinimum() const { return getMinimum(); }
     double valueRangeMaximum() const { return getMaximum(); }
@@ -174,6 +175,13 @@ class ModuleKnob : public Knob, public ModuleControl<ModuleKnob>
 
   private:
     void syncMouseWheelAndLFOState();
+
+    /// \brief The band an LFO's travel covers, in the knob's own proportions, or
+    /// nothing where there is none to draw. \see the definitions and issue #210.
+    ///@{
+    std::optional<juce::Range<float>> lfoRangeToDraw();
+    float positionOfLFOBound(float bound);
+    ///@}
 
   private:
     Quantization quantization_;
@@ -360,6 +368,7 @@ class DiscreteParameter : public ComboBox, public ModuleControl<DiscreteParamete
     /// \note The selection rather than the keyboard, as on every other module
     /// control. \see ModuleControlBase::isActive() and issue #139.
     bool showsAsSelected() const override { return control().isActive(); }
+    bool showsAsHovered() const override { return control().isHovered(); }
 
   protected: // ModuleControl interface.
     juce::String const &getTextFromValue(value_type const valueIndex) const
@@ -461,6 +470,21 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
     /// pointer into freed storage.
     bool selected() const;
 
+    /// \brief And whether the pointer is somewhere on it, which is a fainter
+    /// version of the same halo and nothing else. \see issue #210.
+    bool hovered() const;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Makes this the selected strip. `[main-thread]`
+    ///
+    /// \note Public because the pointer no longer does it: a strip is selected by
+    /// the keyboard reaching it or one of its controls, and a headless case has
+    /// no keyboard to give. \see issue #210 and tests/gui.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    void activate();
+
   public:
     ////////////////////////////////////////////////////////////////////////////
     ///
@@ -491,9 +515,6 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
   private:
     friend class SpectrumWorxEditor;
     friend class SharedModuleControls; //...mrmlj...
-    void activate();
-    void deactivate();
-    bool selectionTracksMouseMovements() const;
 
   private:
     /// \brief A hand over a drag handle and the arrow everywhere else. \see

--- a/src/gui/painters/framePainter.cpp
+++ b/src/gui/painters/framePainter.cpp
@@ -44,13 +44,13 @@ juce::Rectangle<float> FramePainter::rimWithin(juce::Rectangle<float> const boun
 
 void FramePainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
                          FrameStyle const &style, juce::Colour const rim, juce::Colour const fill,
-                         bool const halo)
+                         float const haloStrength)
 {
     auto const frame(rimWithin(bounds, style));
     auto const inside(frame.reduced(style.rimThickness));
     auto const insideRadius(style.cornerRadius - style.rimThickness);
 
-    if (halo && (style.glowRings > 0))
+    if ((haloStrength > 0) && (style.glowRings > 0))
     {
         //   Outermost first, each ring covered in turn by the brighter one
         // inside it, so what shows is the difference between them.
@@ -60,7 +60,8 @@ void FramePainter::paint(juce::Graphics &graphics, juce::Rectangle<float> const 
             auto const outwards(
                 style.glowRings > 1 ? static_cast<float>(ring - 1) / (style.glowRings - 1) : 0.0f);
             graphics.setColour(white.withAlpha(
-                style.glowInnerAlpha + (style.glowOuterAlpha - style.glowInnerAlpha) * outwards));
+                haloStrength *
+                (style.glowInnerAlpha + (style.glowOuterAlpha - style.glowInnerAlpha) * outwards)));
             auto const reach(static_cast<float>(ring));
             graphics.fillRoundedRectangle(frame.expanded(reach), style.cornerRadius + reach);
         }

--- a/src/gui/painters/framePainter.hpp
+++ b/src/gui/painters/framePainter.hpp
@@ -74,11 +74,12 @@ class FramePainter
   public:
     /// \brief Draws a frame filling \p bounds.
     ///
-    /// \param halo whether to lay the glow down first. A module strip asks for
-    /// it only when it is the live one; a combo box always has it and says
-    /// which one has the focus with \p rim instead.
+    /// \param haloStrength what to multiply the glow's opacity by, zero for no
+    /// glow at all. A module strip asks for the full one only when it is the
+    /// selected one and a fraction of it under the pointer; a combo box always
+    /// has it and says which one is selected with \p rim instead.
     static void paint(juce::Graphics &, juce::Rectangle<float> bounds, FrameStyle const &,
-                      juce::Colour rim, juce::Colour fill, bool halo);
+                      juce::Colour rim, juce::Colour fill, float haloStrength);
 
     /// \brief Where the rim's outer edge lands, for a caller that has to put
     /// something else against it.

--- a/src/gui/painters/highlight.hpp
+++ b/src/gui/painters/highlight.hpp
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file highlight.hpp
+/// -------------------
+///
+///   What a control says about the pointer and the selection, and how strongly.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef highlight_hpp__0C7B34E9_18A6_4D52_B7F1_6A29D4E8C305
+#define highlight_hpp__0C7B34E9_18A6_4D52_B7F1_6A29D4E8C305
+//------------------------------------------------------------------------------
+
+namespace LE::SW::GUI
+{
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The three things a module control or a module strip can be.
+///
+///   Selected and hovered are two questions, not two points on one scale -- a
+/// control the pointer is on while another one is selected is both -- but only
+/// one of them can be drawn, and the selection is the one that wins. So this is
+/// what a widget hands its painter after it has decided. \see issue #210.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+enum class Highlight
+{
+    None,
+    Hovered, ///< the pointer is on it: whatever Selected draws, at hoverStrength
+    Selected ///< and this is the one the LFO strip and the shared controls follow
+}; // enum class Highlight
+
+/// \brief What a hover is drawn at, against a selection's full strength.
+///
+/// \note Half, which is what issue #210 asks for and what makes the two tell
+/// apart at a glance rather than on inspection.
+float constexpr hoverStrength{0.5f};
+
+} // namespace LE::SW::GUI
+
+//------------------------------------------------------------------------------
+#endif // highlight_hpp

--- a/src/gui/painters/knobPainter.cpp
+++ b/src/gui/painters/knobPainter.cpp
@@ -92,9 +92,9 @@ void KnobPainter::paintCap(juce::Graphics &graphics, juce::Rectangle<float> cons
 }
 
 void KnobPainter::paintFocusRing(juce::Graphics &graphics, juce::Point<float> const centre,
-                                 float const radius)
+                                 float const radius, float const strength)
 {
-    auto const edge(ColourMap::getColour(ColourMap::FocusHalo));
+    auto const edge(ColourMap::getColour(ColourMap::FocusHalo).withMultipliedAlpha(strength));
     auto const reach(radius + focusGlow);
     auto halo(radialAbout(centre, reach, edge.withAlpha(0.0f), edge.withAlpha(0.0f)));
     halo.addColour(radius / reach, edge);

--- a/src/gui/painters/knobPainter.hpp
+++ b/src/gui/painters/knobPainter.hpp
@@ -134,14 +134,19 @@ class KnobPainter
     ///
     ////////////////////////////////////////////////////////////////////////////
     ///@{
-    /// \brief The ring that says a round control has the keyboard focus: white
-    /// on \p radius and gone \c focusGlow either side of it.
+    /// \brief The ring that says a round control is the selected one: white on
+    /// \p radius and gone \c focusGlow either side of it.
+    ///
+    /// \param strength what to multiply its opacity by, which is how a control
+    /// merely under the pointer wears the same ring more faintly. \see
+    /// hoverStrength and issue #210.
     ///
     /// \note Skin file 58 until 18.08.2026 -- a 53 x 53 disc carrying a radial
     /// gradient whose ten stops were all the same white and differed only in
     /// opacity. A plain stroke reads as a hard outline against the dome's black
     /// edge, which is not what this looked like.
-    static void paintFocusRing(juce::Graphics &, juce::Point<float> centre, float radius);
+    static void paintFocusRing(juce::Graphics &, juce::Point<float> centre, float radius,
+                               float strength = 1.0f);
 
     /// In pixels either side of the rim, and the reason a knob is laid out with
     /// a margin around it. \see ModuleKnob::marginForGlow.

--- a/src/gui/painters/moduleKnobPainter.cpp
+++ b/src/gui/painters/moduleKnobPainter.cpp
@@ -28,7 +28,8 @@ namespace LE::SW::GUI
 ////////////////////////////////////////////////////////////////////////////////
 
 void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
-                     float const normalisedValue, bool const bipolar, bool const selected)
+                     float const normalisedValue, bool const bipolar, Highlight const highlight,
+                     std::optional<juce::Range<float>> const lfoRange)
 {
     using namespace ModuleKnobStyle;
 
@@ -43,25 +44,44 @@ void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const boun
     /// \note How far the wedge has opened, which the cap's radius follows.
     auto const openness(bipolar ? std::abs(2 * value - 1) : value);
 
-    // The far edge is the value; the near one is the stop it opens from.
-    auto const to(KnobPainter::angleFor(value));
-    auto const from(bipolar ? 0.0f : -KnobPainter::halfSweepDegrees);
-    juce::Path pie;
-    pie.addPieSegment(
-        bounds.withSizeKeepingCentre(2 * radius * wedgeRadius, 2 * radius * wedgeRadius),
-        juce::degreesToRadians(std::min(from, to)), juce::degreesToRadians(std::max(from, to)),
-        0.0f);
-    graphics.setColour(ColourMap::getColour(ColourMap::Accent));
-    graphics.fillPath(pie);
+    auto const fillArc([&](float const one, float const other, ColourMap::Name const colour) {
+        juce::Path pie;
+        pie.addPieSegment(
+            bounds.withSizeKeepingCentre(2 * radius * wedgeRadius, 2 * radius * wedgeRadius),
+            juce::degreesToRadians(std::min(one, other)),
+            juce::degreesToRadians(std::max(one, other)), 0.0f);
+        graphics.setColour(ColourMap::getColour(colour));
+        graphics.fillPath(pie);
+    });
 
-    auto const cap(capRadiusClosed + (capRadiusOpen - capRadiusClosed) * openness);
+    if (lfoRange)
+        // between the two bounds, where the value would be from a stop to itself
+        fillArc(KnobPainter::angleFor(juce::jlimit(0.0f, 1.0f, lfoRange->getStart())),
+                KnobPainter::angleFor(juce::jlimit(0.0f, 1.0f, lfoRange->getEnd())),
+                ColourMap::ModuleKnobLFORange);
+    else
+        // the far edge is the value; the near one is the stop it opens from
+        fillArc(KnobPainter::angleFor(value), bipolar ? 0.0f : -KnobPainter::halfSweepDegrees,
+                ColourMap::Accent);
+
+    /// \note And the cap stays shut under a range. It grows with the *value* so
+    /// that the accent keeps a roughly even thickness as it lengthens, and a
+    /// range has no length to follow -- one that grew with the span would draw a
+    /// wide travel thinner than a narrow one, which is backwards.
+    auto const cap(lfoRange ? capRadiusClosed
+                            : capRadiusClosed + (capRadiusOpen - capRadiusClosed) * openness);
     KnobPainter::paintCap(graphics, bounds, cap, cap /*a hard edge*/,
                           ColourMap::getColour(ColourMap::ModuleKnobCap));
 
-    if (selected)
-        KnobPainter::paintFocusRing(graphics, centre, radius);
-    else
-        KnobPainter::paintDomeRim(graphics, bounds, rimThickness);
+    switch (highlight)
+    {
+    case Highlight::Selected:
+        return KnobPainter::paintFocusRing(graphics, centre, radius);
+    case Highlight::Hovered:
+        return KnobPainter::paintFocusRing(graphics, centre, radius, hoverStrength);
+    case Highlight::None:
+        return KnobPainter::paintDomeRim(graphics, bounds, rimThickness);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gui/painters/moduleKnobPainter.hpp
+++ b/src/gui/painters/moduleKnobPainter.hpp
@@ -15,9 +15,12 @@
 #ifndef moduleKnobPainter_hpp__47E0B93C_5A18_4D72_BC69_0E3F81A5D264
 #define moduleKnobPainter_hpp__47E0B93C_5A18_4D72_BC69_0E3F81A5D264
 //------------------------------------------------------------------------------
+#include "gui/painters/highlight.hpp"
 #include "gui/painters/knobPainter.hpp"
 
 #include <juce_graphics/juce_graphics.h>
+
+#include <optional>
 
 namespace LE::SW::GUI
 {
@@ -47,13 +50,17 @@ namespace LE::SW::GUI
 /// it -- which is what the artwork did, and what keeps the blue a band of
 /// roughly even thickness rather than a lengthening spike.
 ///
+///   Where an LFO's travel is drawn the *wedge* is what it replaces -- same
+/// radius, same arc, translucent, and between the two bounds rather than out
+/// from a stop. \see paintModuleKnob() for why the value goes.
+///
 /// \note Radii are fractions of the knob's own radius, so they hold at both the
 /// 51 px module knob and the 23 px shared one. The rim and the focus halo are in
 /// pixels instead: they are hairlines at both sizes rather than something that
 /// scales with them.
 namespace ModuleKnobStyle
 {
-/// \note Geometry only. The colours are ColourMap's -- three ModuleKnob* entries,
+/// \note Geometry only. The colours are ColourMap's -- four ModuleKnob* entries,
 /// plus Accent for the wedge and FocusHalo for the ring.
 float constexpr innerGradientRadius{0.26f}; ///< the dome holds its centre colour in to here
 float constexpr wedgeRadius{0.717f};
@@ -109,10 +116,22 @@ void paintTriggerButton(juce::Graphics &, juce::Rectangle<float> bounds, bool on
 ///
 /// \param normalisedValue where the value sits in its range, 0 to 1; for a
 /// \p bipolar knob 0.5 is the centre the wedge opens from.
-/// \param selected whether this is the control the interface is showing -- which
-/// is not the keyboard focus. \see ModuleControlBase::isActive().
+/// \param highlight whether this is the control the interface is showing, or the
+/// one the pointer is over -- neither of which is the keyboard focus. \see
+/// ModuleControlBase::isActive() and ModuleControlBase::isHovered().
+/// \param lfoRange the two ends of an LFO's travel, on the same 0 to 1 scale,
+/// where there is one to draw. Nothing is the usual answer: the range is shown
+/// only for a parameter under an LFO whose sweep the user has asked not to see.
+///
+/// \note **The range is drawn *instead of* the value, and \p normalisedValue is
+/// then only the cap's business.** An LFO's bounds are absolute over the
+/// parameter's own range rather than an excursion either side of where it was
+/// left, so while one is running the value under it is not where the parameter
+/// is and nothing reads it -- a wedge saying otherwise is a wrong answer that
+/// also covers the right one. \see Preferences::showLFOAnimation(), issue #210.
 void paintModuleKnob(juce::Graphics &, juce::Rectangle<float> bounds, float normalisedValue,
-                     bool bipolar, bool selected);
+                     bool bipolar, Highlight,
+                     std::optional<juce::Range<float>> lfoRange = std::nullopt);
 
 } // namespace LE::SW::GUI
 

--- a/src/gui/painters/moduleStripPainter.cpp
+++ b/src/gui/painters/moduleStripPainter.cpp
@@ -23,10 +23,13 @@ namespace LE::SW::GUI
 ////////////////////////////////////////////////////////////////////////////////
 
 void paintModuleStrip(juce::Graphics &graphics, juce::Rectangle<float> const bounds,
-                      bool const selected)
+                      Highlight const highlight)
 {
+    float const halo(highlight == Highlight::Selected  ? 1.0f
+                     : highlight == Highlight::Hovered ? hoverStrength
+                                                       : 0.0f);
     FramePainter::paint(graphics, bounds, moduleStripFrame, ColourMap::getColour(ColourMap::Accent),
-                        ColourMap::getColour(ColourMap::ModuleBackground), selected);
+                        ColourMap::getColour(ColourMap::ModuleBackground), halo);
 }
 
 } // namespace LE::SW::GUI

--- a/src/gui/painters/moduleStripPainter.hpp
+++ b/src/gui/painters/moduleStripPainter.hpp
@@ -14,6 +14,7 @@
 #define moduleStripPainter_hpp__B6D5210F_9C34_4E8A_A017_58D2E6B4739C
 //------------------------------------------------------------------------------
 #include "gui/painters/framePainter.hpp"
+#include "gui/painters/highlight.hpp"
 #include "gui/painters/ruleStyle.hpp"
 
 #include <juce_graphics/juce_graphics.h>
@@ -49,8 +50,10 @@ FrameStyle constexpr moduleStripFrame{
 
 /// \brief Draws the frame a module's controls sit in, into \p bounds.
 ///
-/// \param selected whether this is the strip whose controls the editor is
-/// showing, which is the halo and nothing else.
+/// \param highlight whether this is the strip whose controls the editor is
+/// showing, or merely the one the pointer is over. Either way it is the halo and
+/// nothing else, at full strength for the first and hoverStrength for the
+/// second. \see issue #210.
 ///
 /// \note `graphics.setOpacity( 0.5f )` stood at the call site and dimmed an
 /// unselected strip's frame. It has done nothing since the artwork became a
@@ -60,7 +63,7 @@ FrameStyle constexpr moduleStripFrame{
 /// change of appearance rather than a port. It also would not have been an
 /// improvement: the knobs, the name and the rule are children and full strength
 /// whatever the frame does, and the halo already says which strip is live.
-void paintModuleStrip(juce::Graphics &, juce::Rectangle<float> bounds, bool selected);
+void paintModuleStrip(juce::Graphics &, juce::Rectangle<float> bounds, Highlight);
 
 } // namespace LE::SW::GUI
 

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -19,7 +19,6 @@
 #include <sst/plugininfra/userdefaults.h>
 
 #include <algorithm>
-#include <array>
 #include <cstdio>
 #include <optional>
 #include <string>
@@ -42,7 +41,8 @@ std::string defaultsFileName() { return std::string(productName) + "UserDefaults
 
 enum PreferenceKey
 {
-    moduleUIMouseOverReactionKey,
+    showLFOAnimationKey,
+    previewLFOOnHoverKey,
     hideCursorOnKnobDragKey,
     zoomPercentKey,
     paletteKey,
@@ -56,8 +56,10 @@ std::string preferenceKeyName(PreferenceKey const key)
 {
     switch (key)
     {
-    case moduleUIMouseOverReactionKey:
-        return "moduleUIMouseOverReaction";
+    case showLFOAnimationKey:
+        return "showLFOAnimation";
+    case previewLFOOnHoverKey:
+        return "previewLFOOnHover";
     case hideCursorOnKnobDragKey:
         return "hideCursorOnKnobDrag";
     case zoomPercentKey:
@@ -84,35 +86,11 @@ void reportPreferencesError(std::string const &message, std::string const &title
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// The enumerations, by name
+// The palette, by name
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr std::array<char const *, 3> mouseOverReactionNames{"Never", "WhenParentModuleSelected",
-                                                             "WhenParentOrNothingSelected"};
-
-/// The table is indexed by the enumerator, so it has to cover it.
-static_assert(mouseOverReactionNames.size() == Preferences::WhenParentOrNothingSelected + 1);
-
-template <typename Enumeration, std::size_t count>
-std::string nameOf(Enumeration const value, std::array<char const *, count> const &names)
-{
-    auto const index(static_cast<std::size_t>(value));
-    LE_ASSERT(index < count);
-    return names[index];
-}
-
-template <typename Enumeration, std::size_t count>
-Enumeration valueNamed(std::string const &name, std::array<char const *, count> const &names,
-                       Enumeration const valueIfUnrecognised)
-{
-    for (std::size_t index(0); index < count; ++index)
-        if (name == names[index])
-            return static_cast<Enumeration>(index);
-    return valueIfUnrecognised;
-}
-
-/// \note The same, over ColourMap::nameOf() rather than over a table here: the
-/// palettes are the map's own enumeration and their spellings belong with it.
+/// \note Over ColourMap::nameOf() rather than a table here: the palettes are the
+/// map's own enumeration and their spellings belong with it.
 ColourMap::Palette paletteNamed(std::string const &name,
                                 ColourMap::Palette const valueIfUnrecognised)
 {
@@ -161,10 +139,9 @@ Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Sto
 {
     auto &provider(storage_->provider);
 
-    moduleUIMouseOverReaction_ = valueNamed(
-        provider.getUserDefaultValue(moduleUIMouseOverReactionKey,
-                                     nameOf(moduleUIMouseOverReaction_, mouseOverReactionNames)),
-        mouseOverReactionNames, moduleUIMouseOverReaction_);
+    showLFOAnimation_ = provider.getUserDefaultValue(showLFOAnimationKey, showLFOAnimation_) != 0;
+    previewLFOOnHover_ =
+        provider.getUserDefaultValue(previewLFOOnHoverKey, previewLFOOnHover_) != 0;
 
     palette_ = paletteNamed(provider.getUserDefaultValue(paletteKey, ColourMap::nameOf(palette_)),
                             palette_);
@@ -190,11 +167,16 @@ bool Preferences::isOfferedZoom(unsigned int const percent)
 
 Preferences::~Preferences() = default;
 
-void Preferences::setModuleUIMouseOverReaction(ModuleUIMouseOverReaction const value)
+void Preferences::setShowLFOAnimation(bool const value)
 {
-    moduleUIMouseOverReaction_ = value;
-    storage_->provider.updateUserDefaultValue(moduleUIMouseOverReactionKey,
-                                              nameOf(value, mouseOverReactionNames));
+    showLFOAnimation_ = value;
+    storage_->provider.updateUserDefaultValue(showLFOAnimationKey, value ? 1 : 0);
+}
+
+void Preferences::setPreviewLFOOnHover(bool const value)
+{
+    previewLFOOnHover_ = value;
+    storage_->provider.updateUserDefaultValue(previewLFOOnHoverKey, value ? 1 : 0);
 }
 
 void Preferences::setPalette(ColourMap::Palette const value)

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -47,29 +47,22 @@ namespace LE::SW::GUI
 /// `<folder>/SpectrumWorxUserDefaults.xml`.
 ///
 /// \note Values are cached in members rather than read through the provider on
-/// every call: `moduleUIMouseOverReaction()` is asked on mouse movement over a
-/// module control, and the provider's answer is a map lookup and a string
-/// comparison. Each setter writes its own key through, so the file is one
-/// rewrite per user click rather than three.
+/// every call: `showLFOAnimation()` is asked once per knob per repaint, and the
+/// provider's answer is a map lookup and a string comparison. Each setter writes
+/// its own key through, so the file is one rewrite per user click rather than
+/// five.
 ///
-/// \note The enumerations are streamed by *name*, not by ordinal, so inserting a
-/// value in the middle cannot silently change what an existing file means and the
-/// file stays legible to whoever opens it. The names are the enum identifiers, so
-/// a value in the file can be grepped for in the source, and an unrecognised one
-/// reads as the default.
+/// \note The one enumeration in here -- the palette -- is streamed by *name*, not
+/// by ordinal, so inserting a value in the middle cannot silently change what an
+/// existing file means and the file stays legible to whoever opens it. The names
+/// are the enum identifiers, so a value in the file can be grepped for in the
+/// source, and an unrecognised one reads as the default.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
 class Preferences
 {
   public:
-    enum ModuleUIMouseOverReaction
-    {
-        Never,
-        WhenParentModuleSelected,
-        WhenParentOrNothingSelected
-    };
-
     ////////////////////////////////////////////////////////////////////////////
     ///
     /// \brief The zooms the Interface page offers, ascending, as percentages.
@@ -103,17 +96,39 @@ class Preferences
     Preferences(Preferences const &) = delete; // makes non-copyable
     Preferences &operator=(Preferences const &) = delete;
 
-    ModuleUIMouseOverReaction moduleUIMouseOverReaction() const
-    {
-        return moduleUIMouseOverReaction_;
-    }
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Whether a knob an LFO is driving follows the sweep.
+    ///
+    ///   On, the value moves as the LFO moves it, which is what the plugin has
+    /// always done. Off, the knob draws the LFO's *bounds* instead and draws no
+    /// value at all -- the same information, and honestly, without eight strips'
+    /// worth of movement in the corner of the eye. \see paintModuleKnob(),
+    /// ColourMap::ModuleKnobLFORange and issue #210.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    bool showLFOAnimation() const { return showLFOAnimation_; }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief Whether the LFO strip follows the pointer as well as the click.
+    ///
+    ///   A control is selected by clicking it, whatever this says. With it on,
+    /// merely hovering one shows its LFO for as long as the pointer is there and
+    /// puts it back afterwards; the selection -- and the ring that marks it --
+    /// does not move. \see SpectrumWorxEditor::displayedControl() and issue #210.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    bool previewLFOOnHover() const { return previewLFOOnHover_; }
+
     ColourMap::Palette palette() const { return palette_; }
     bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
     /// Always one of zoomPercentages.
     unsigned int zoomPercent() const { return zoomPercent_; }
 
     /// Each of these writes the file. `[main-thread]`
-    void setModuleUIMouseOverReaction(ModuleUIMouseOverReaction);
+    void setShowLFOAnimation(bool);
+    void setPreviewLFOOnHover(bool);
     /// \note Stores it. Painting in it is ColourMap::setPalette()'s half, and
     /// the two are done together -- \see SpectrumWorxEditor::setPalette(),
     /// which is the only place a user changes this.
@@ -134,7 +149,8 @@ class Preferences
     class Storage;
     std::unique_ptr<Storage> storage_;
 
-    ModuleUIMouseOverReaction moduleUIMouseOverReaction_{Never};
+    bool showLFOAnimation_{true};
+    bool previewLFOOnHover_{true};
     ColourMap::Palette palette_{ColourMap::ClassicBlue};
     bool hideCursorOnKnobDrag_{true};
     unsigned int zoomPercent_{defaultZoomPercent};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(sw-plugin-tests
         gui/lfoDisplayTests.cpp
         gui/moduleControlFocusTests.cpp
         gui/moduleDragTests.cpp
+        gui/moduleHoverTests.cpp
         gui/moduleMenuTests.cpp
         gui/overlayPanelTests.cpp
         gui/paletteTests.cpp

--- a/tests/gui/discreteParameterTests.cpp
+++ b/tests/gui/discreteParameterTests.cpp
@@ -127,6 +127,16 @@ void scroll(juce::Component &component, float const deltaY)
     component.mouseWheelMove(event, wheel);
 }
 
+/// \brief The pointer arriving over \p component, which is what earns a module
+/// control its wheel. \see issue #210.
+void pointerEnters(juce::Component &component)
+{
+    auto const centre(component.getLocalBounds().getCentre().toFloat());
+    component.mouseEnter(juce::MouseEvent(
+        juce::Desktop::getInstance().getMainMouseSource(), centre, juce::ModifierKeys(), 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, &component, &component, juce::Time(), centre, juce::Time(), 1, false));
+}
+
 /// Every descendant of \p root that is a \p Widget, in child order.
 template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Component &root)
 {
@@ -522,4 +532,93 @@ TEST_CASE("A wheel does nothing while the combo box's menu is open", "[gui][comb
     ///
     ////////////////////////////////////////////////////////////////////////////
     juce::PopupMenu::dismissAllActiveMenus();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note Issue #124's other half, and what issue #210 turned it into. A wheel
+/// over a module strip's combo box used to take the module selection before it
+/// would move -- otherwise it would have edited one module's parameter while a
+/// different one stayed selected, which is the state `moduleParameterChanged()`'s
+/// assertions exist to catch. It needed a window to do that at all, focus being
+/// the window manager's to refuse.
+///
+///   The pointer being on a control is now reason enough to edit it, so the
+/// wheel does the thing it was always trying to do: it steps the box under the
+/// pointer and leaves the ring where the user last clicked.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A wheel over a module combo box steps it without selecting it", "[gui][modules][combo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto &editor(instance.editor());
+    auto &strip(stripFor(editor, "Swappah"));
+
+    auto *const pComboBox(firstComboBox(strip));
+    REQUIRE(pComboBox != nullptr);
+    auto &comboBox(*pComboBox);
+    auto &control(GUI::ModuleControlBase::controlForWidget(comboBox));
+
+    REQUIRE(editor.activeControl() != &control);
+
+    /// \note Put at the top of the list first, and the reason is the point of
+    /// `MenuOrder`: a row is not a value. Swappah's Mode is declared Both,
+    /// Magnitudes, Phases and *listed* Magnitudes, Phases, Both, so its default
+    /// of zero is the **last** row -- and a step down the list from there is
+    /// correctly refused. Starting at a known row is what makes this a case
+    /// about the wheel rather than about which parameter it landed on.
+    comboBox.setSelectedIndex(0);
+    auto const first(comboBox.getValue());
+
+    pointerEnters(comboBox);
+    REQUIRE(control.isHovered());
+
+    // Away from the user, which is down the list.
+    scroll(comboBox, +0.3f);
+
+    // The row moved, without a menu having been opened at all...
+    CHECK(comboBox.getValue() != first);
+    CHECK_FALSE(comboBox.menuActive());
+    // ...and the selection did not follow the pointer. \see issue #210.
+    CHECK(editor.activeControl() != &control);
+
+    // And back where it started, which is the gesture a user actually makes.
+    scroll(comboBox, -0.3f);
+    CHECK(comboBox.getValue() == first);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The LFO owns the value, so a row the wheel moved to would be overwritten
+/// by the next sweep. The same guard the menu is behind, and the same one
+/// ModuleKnob turns its own wheel off with. \see syncMouseWheelAndLFOState().
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A wheel over a combo box the LFO owns moves nothing", "[gui][modules][lfo][combo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    SWTest::Instance instance;
+    instance.openEditor();
+
+    auto &editor(instance.editor());
+    auto &strip(stripFor(editor, "Swappah"));
+
+    auto *const pComboBox(firstComboBox(strip));
+    REQUIRE(pComboBox != nullptr);
+    auto &comboBox(*pComboBox);
+    auto &control(GUI::ModuleControlBase::controlForWidget(comboBox));
+
+    editor.setLFOEnabled(control, true);
+    REQUIRE(control.isLFOEnabled());
+
+    pointerEnters(comboBox);
+
+    auto const opened(comboBox.getValue());
+    scroll(comboBox, -0.3f);
+    CHECK(comboBox.getValue() == opened);
 }

--- a/tests/gui/knobMenuTests.cpp
+++ b/tests/gui/knobMenuTests.cpp
@@ -143,10 +143,11 @@ class KnobUnderTest
         pControl_ = firstKnob(*pModuleUI);
         REQUIRE(pControl_ != nullptr);
 
-        /// \note The range the LFO strip's two-value bound slider is laid out
-        /// over; an LFO's bounds are normalised, so the knob's own units do not
-        /// come into it. \see lfoDisplayTests.cpp, which sets it up the same way.
-        editor.moduleControlActivated(*pControl_, 0.0, 1.0, 0.0);
+        /// \note Really selected, rather than only having the strip built for
+        /// it: the wheel is keyed on the selection as well as on the LFO, and
+        /// select() is the click's own step without the keyboard a headless case
+        /// cannot give. \see issue #210.
+        pControl_->select();
 
         // Whatever building the strip and the panel queued is not a case's.
         drain(instance.toEngine());

--- a/tests/gui/knobPaintingTests.cpp
+++ b/tests/gui/knobPaintingTests.cpp
@@ -62,10 +62,12 @@ template <typename Painter> juce::Image render(Painter &&paint)
     return image;
 }
 
-juce::Image moduleKnob(float const value, bool const bipolar)
+juce::Image moduleKnob(float const value, bool const bipolar,
+                       GUI::Highlight const highlight = GUI::Highlight::None,
+                       std::optional<juce::Range<float>> const lfoRange = std::nullopt)
 {
     return render([&](juce::Graphics &graphics, juce::Rectangle<float> const bounds) {
-        GUI::paintModuleKnob(graphics, bounds, value, bipolar, false /*not selected*/);
+        GUI::paintModuleKnob(graphics, bounds, value, bipolar, highlight, lfoRange);
     });
 }
 
@@ -103,6 +105,55 @@ TEST_CASE("Both knobs draw the value they are given", "[gui][knob]")
     // ...and the polarity is a parameter rather than a decoration: at the centre
     // of the range a unipolar wedge is half open and a bipolar one is shut.
     CHECK(differ(moduleKnob(0.5f, false), moduleKnob(0.5f, true)));
+}
+
+TEST_CASE("A module knob draws its three highlights differently", "[gui][knob]")
+{
+    juce::ScopedJuceInitialiser_GUI const juceInitialiser;
+
+    /// \note Three renders and three inequalities rather than a colour: what
+    /// would go wrong here is a hover drawn at the selection's strength, or at
+    /// none at all, and either reads as "the pointer does nothing". \see issue
+    /// #210.
+    auto const plain(moduleKnob(0.5f, false, GUI::Highlight::None));
+    auto const hovered(moduleKnob(0.5f, false, GUI::Highlight::Hovered));
+    auto const selected(moduleKnob(0.5f, false, GUI::Highlight::Selected));
+
+    CHECK(differ(plain, hovered));
+    CHECK(differ(plain, selected));
+    CHECK(differ(hovered, selected));
+}
+
+TEST_CASE("An LFO range is drawn, and only where there is one", "[gui][knob][lfo]")
+{
+    juce::ScopedJuceInitialiser_GUI const juceInitialiser;
+
+    ///   The band the knob wears instead of following the sweep, and the binding
+    /// to the bounds it stands for. \see Preferences::showLFOAnimation().
+    auto const none(moduleKnob(0.5f, false));
+    CHECK(differ(none, moduleKnob(0.5f, false, GUI::Highlight::None, {{0.1f, 0.9f}})));
+
+    // ...and it is the *bounds* that are drawn, not merely the fact of them.
+    CHECK(differ(moduleKnob(0.5f, false, GUI::Highlight::None, {{0.1f, 0.9f}}),
+                 moduleKnob(0.5f, false, GUI::Highlight::None, {{0.6f, 0.9f}})));
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \note **And the value is not drawn beside it.** The band replaces the
+    /// wedge rather than joining it: an LFO's bounds are absolute over the
+    /// parameter's range rather than an excursion around where it was left, so
+    /// the value under a running LFO is not where the parameter is. Drawn as well
+    /// it was both a wrong answer and, being opaque, the thing covering the right
+    /// one.
+    ///
+    ///   Two values and one band, which is exact where a pixel count is not: with
+    /// the wedge still drawn under the band the two rendered differently, and
+    /// with it drawn over them they differed along the arc they shared -- so
+    /// "something changed" passed either way while nothing useful was visible.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    CHECK_FALSE(differ(moduleKnob(0.0f, false, GUI::Highlight::None, {{0.1f, 0.9f}}),
+                       moduleKnob(1.0f, false, GUI::Highlight::None, {{0.1f, 0.9f}})));
 }
 
 TEST_CASE("Both knobs sweep through the same arc", "[gui][knob]")

--- a/tests/gui/lfoDisplayTests.cpp
+++ b/tests/gui/lfoDisplayTests.cpp
@@ -40,6 +40,7 @@
 #include "gui/modules/moduleControl.hpp"
 #include "gui/modules/moduleUI.hpp"
 #include "gui/painters/backgroundPainter.hpp"
+#include "gui/preferences.hpp"
 
 #include "le/parameters/lfoImpl.hpp"
 #include "le/parameters/parametersUtilities.hpp"
@@ -66,6 +67,22 @@ constexpr std::uint8_t
     syncTypesIndex(LE::Parameters::IndexOf<LFOImpl::Parameters, LFOImpl::SyncTypes>::value);
 constexpr std::uint8_t
     waveformIndex(LE::Parameters::IndexOf<LFOImpl::Parameters, LFOImpl::Waveform>::value);
+
+/// \brief Whether two renders of the same widget differ anywhere.
+///
+/// \note Pixels rather than a colour: what a case here asks is that a drawing
+/// followed something, and naming a colour would pin the palette instead. Same
+/// rule as knobPaintingTests.cpp.
+bool differsFrom(juce::Image const &a, juce::Image const &b)
+{
+    if ((a.getWidth() != b.getWidth()) || (a.getHeight() != b.getHeight()))
+        return true;
+    for (int y(0); y < a.getHeight(); ++y)
+        for (int x(0); x < a.getWidth(); ++x)
+            if (a.getPixelAt(x, y) != b.getPixelAt(x, y))
+                return true;
+    return false;
+}
 
 /// \brief The first module control in \p component's subtree, which is a knob on
 /// the module strip and therefore something an LFO can be attached to.
@@ -615,4 +632,71 @@ TEST_CASE("A second editor's LFO well has a mark in it", "[gui][lfo][skin]")
     auto const *const pMark(pDisplay->waveformMenu().getSelectedItemIcon());
     REQUIRE(pMark != nullptr);
     CHECK(pMark->isValid());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The band a knob wears instead of following the sweep did not follow the
+/// bounds at all: with the animation off the widget's *value* never changes, and
+/// a repaint had only ever ridden along with one, so the knob kept whatever band
+/// it had been built with. \see issue #210.
+///
+/// \note Rendered rather than inspected: what the knob draws is what the bug was
+/// about, and `lfoRangeToDraw()` is its own business.
+///
+/// \note That the *value* cannot hide the band is not asked here and cannot
+/// usefully be: the two arcs shared an outer edge when it could, so even a band
+/// entirely under the wedge left a ring of antialiasing behind and every render
+/// differed from every other. It is a statement about radii instead. \see
+/// knobPaintingTests.cpp.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A knob follows the LFO bounds while the animation is off", "[gui][lfo][knob]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    PanelUnderTest const panel(instance);
+    auto &editor(instance.editor());
+
+    LE::SW::GUI::preferences().setShowLFOAnimation(false);
+    editor.setLFOEnabled(panel.control(), true);
+    REQUIRE(panel.control().isLFOEnabled());
+
+    auto &widget(panel.control().widget());
+    auto const drawn([&] {
+        juce::Image image(juce::Image::ARGB, widget.getWidth(), widget.getHeight(), true,
+                          juce::SoftwareImageType{});
+        juce::Graphics graphics(image);
+        widget.paintEntireComponent(graphics, false);
+        return image;
+    });
+
+    auto *const pPanel(editor.lfoDisplay());
+    REQUIRE(pPanel != nullptr);
+    auto &range(pPanel->range());
+
+    /// \note sendNotificationSync, which is what makes this reachable without a
+    /// message loop: juce::Slider calls its listeners from inside the call.
+    range.setMinValue(0.1, juce::sendNotificationSync);
+    range.setMaxValue(0.4, juce::sendNotificationSync);
+    auto const narrow(drawn());
+
+    range.setMaxValue(0.9, juce::sendNotificationSync);
+    auto const wide(drawn());
+    CHECK(differsFrom(narrow, wide));
+
+    //   ...and the band belongs to the animation switch rather than to the LFO:
+    // with the sweep showing, the wedge says everything the band would.
+    LE::SW::GUI::preferences().setShowLFOAnimation(true);
+    CHECK(differsFrom(wide, drawn()));
+
+    //   The same bounds draw the same knob again, which is what says the check
+    // above was about the bounds rather than about something else having moved.
+    LE::SW::GUI::preferences().setShowLFOAnimation(false);
+    range.setMaxValue(0.4, juce::sendNotificationSync);
+    CHECK_FALSE(differsFrom(narrow, drawn()));
+
+    LE::SW::GUI::preferences().setShowLFOAnimation(true);
 }

--- a/tests/gui/moduleControlFocusTests.cpp
+++ b/tests/gui/moduleControlFocusTests.cpp
@@ -714,101 +714,6 @@ TEST_CASE("One press on a module combo box selects it and opens its menu", "[gui
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \note Issue #124's other half. A module strip's combo box takes the module
-/// selection before it will move, exactly as a press on it does -- otherwise a
-/// wheel would edit one module's parameter while a different one stayed
-/// selected, which is the state `moduleParameterChanged()`'s assertions exist to
-/// catch.
-///
-/// \note Which is why the case is here rather than beside the other wheel cases:
-/// focus needs a window, and this file is where the window is.
-///
-////////////////////////////////////////////////////////////////////////////////
-
-TEST_CASE("A wheel over a module combo box selects it and steps it", "[gui][modules][combo]")
-{
-    SWTest::HostSideJuce const juceIsUp;
-
-    if (!SWTest::aWindowCanBeMade())
-        SKIP(SWTest::noWindow);
-
-    SWTest::Instance instance;
-    DesktopEditor const window(instance);
-    if (!window.tookTheKeyboard())
-        SKIP(keyboardRefused);
-
-    auto &editor(window.editor());
-    auto &moduleUI(stripFor(editor, "Swappah"));
-
-    auto *const pControl(firstControlOfType<GUI::DiscreteParameter>(moduleUI));
-    REQUIRE(pControl != nullptr);
-    auto &control(*pControl);
-    auto &comboBox(dynamic_cast<GUI::ComboBox &>(control.widget()));
-
-    REQUIRE(editor.activeControl() != &control);
-
-    /// \note Put at the top of the list first, and the reason is the point of
-    /// `MenuOrder`: a row is not a value. Swappah's Mode is declared Both,
-    /// Magnitudes, Phases and *listed* Magnitudes, Phases, Both, so its default
-    /// of zero is the **last** row -- and a step down the list from there is
-    /// correctly refused. Starting at a known row is what makes this a case
-    /// about the wheel rather than about which parameter it landed on.
-    comboBox.setSelectedIndex(0);
-    auto const first(comboBox.getValue());
-
-    /// \note Away from the user, which is down the list. \see
-    /// ComboBox::mouseWheelMove() and issue #124.
-    scrollOnce(comboBox, +0.3f);
-
-    // It selected, which is what puts the control's LFO on screen...
-    CHECK(editor.activeControl() == &control);
-    // ...and the row moved, without a menu having been opened at all.
-    CHECK(comboBox.getValue() != first);
-    CHECK_FALSE(comboBox.menuActive());
-
-    // And back where it started, which is the gesture a user actually makes.
-    scrollOnce(comboBox, -0.3f);
-    CHECK(comboBox.getValue() == first);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// \note The LFO owns the value, so a row the wheel moved to would be overwritten
-/// by the next sweep. The same guard the menu is behind, and the same one
-/// ModuleKnob turns its own wheel off with. \see syncMouseWheelAndLFOState().
-///
-////////////////////////////////////////////////////////////////////////////////
-
-TEST_CASE("A wheel over a combo box the LFO owns moves nothing", "[gui][modules][lfo][combo]")
-{
-    SWTest::HostSideJuce const juceIsUp;
-
-    if (!SWTest::aWindowCanBeMade())
-        SKIP(SWTest::noWindow);
-
-    SWTest::Instance instance;
-    DesktopEditor const window(instance);
-    if (!window.tookTheKeyboard())
-        SKIP(keyboardRefused);
-
-    auto &editor(window.editor());
-    auto &moduleUI(stripFor(editor, "Swappah"));
-
-    auto *const pControl(firstControlOfType<GUI::DiscreteParameter>(moduleUI));
-    REQUIRE(pControl != nullptr);
-    auto &control(*pControl);
-    auto &comboBox(dynamic_cast<GUI::ComboBox &>(control.widget()));
-
-    control.lfo().parameters().set<Parameters::LFOImpl::Enabled>(true);
-    REQUIRE(control.isLFOEnabled());
-
-    auto const opened(comboBox.getValue());
-    scrollOnce(comboBox, -0.3f);
-    CHECK(comboBox.getValue() == opened);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
 /// Selection is not a gesture
 /// --------------------------
 ///
@@ -1310,9 +1215,9 @@ TEST_CASE("Dropping the selected module clears both selections", "[gui][modules]
 /// after the keyboard has gone to the preset pane, and without a second guard the
 /// next sweep of the mouse across it would silently drop the LFO strip.
 ///
-///   The preference is the right question: with the default reaction the mouse
-/// never *selects* a control, so it has no business deselecting one.
-/// \see Preferences::ModuleUIMouseOverReaction and issue #139.
+///   The pointer is the right question: it never *selects* a control, so it has
+/// no business deselecting one. It was a preference that said so and is now the
+/// only behaviour there is. \see issue #139 and issue #210.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1329,14 +1234,12 @@ TEST_CASE("The mouse passing over a clicked control does not deselect it",
     if (!window.tookTheKeyboard())
         SKIP(keyboardRefused);
 
-    // \note A folder of this case's own, and the reaction set in it rather than
-    // read. The suite points every case at one shared folder, and something in it
-    // writes there -- so what this would otherwise see is whatever ran last.
+    // \note A folder of this case's own. The suite points every case at one
+    // shared folder, and something in it writes there -- so what this would
+    // otherwise see is whatever ran last.
     fs::path const folder(fs::path(SW_TEST_OUTPUT_DIR) / "preferences" / "mouseOverKeepsClicked");
     fs::remove_all(folder);
     GUI::setPreferencesFolder(folder);
-    GUI::preferences().setModuleUIMouseOverReaction(GUI::Preferences::Never);
-    REQUIRE(GUI::preferences().moduleUIMouseOverReaction() == GUI::Preferences::Never);
 
     auto &editor(window.editor());
     auto &moduleUI(stripFor(editor, "Freeze"));

--- a/tests/gui/moduleHoverTests.cpp
+++ b/tests/gui/moduleHoverTests.cpp
@@ -1,0 +1,233 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// moduleHoverTests.cpp
+/// --------------------
+///
+///   What the *pointer* does to a module strip and to the controls on it, which
+/// as of issue #210 is a separate question from what a click does.
+///
+///   The rule, in one line: hovering marks, clicking selects, and marking never
+/// becomes selecting. A hovered control wears the selection's ring at half
+/// strength, takes the wheel, and -- when the user has asked for it -- lends the
+/// LFO strip its own LFO until the pointer leaves.
+///
+/// \note No window anywhere in this file, unlike moduleControlFocusTests.cpp:
+/// none of this goes through the keyboard, which is the whole point of it.
+/// Selection, where a case needs one, is `ModuleControlBase::select()` -- the
+/// click's own step with the keyboard left out.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "gui/editorHarness.hpp"
+
+/// \note Before anything that names SW::Module, as moduleControlFocusTests.cpp
+/// is: the module chain downcasts a node to it.
+#include "core/modules/moduleDSPAndGUI.hpp"
+
+#include "gui/modules/moduleControl.hpp"
+#include "gui/modules/moduleUI.hpp"
+#include "gui/preferences.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <catch2/catch_test_macros.hpp>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace LE;
+using namespace LE::SW;
+
+namespace GUI = LE::SW::GUI;
+
+/// \brief An event over the middle of \p component, carrying no button: a hover
+/// is not a press, and JUCE's own mouseEnter carries no modifiers either.
+juce::MouseEvent pointerOver(juce::Component &component)
+{
+    auto const centre(component.getLocalBounds().getCentre().toFloat());
+    return juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(), centre,
+                            juce::ModifierKeys(), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &component,
+                            &component, juce::Time(), centre, juce::Time(), 1, false);
+}
+
+void pointerEnters(juce::Component &component) { component.mouseEnter(pointerOver(component)); }
+void pointerLeaves(juce::Component &component) { component.mouseExit(pointerOver(component)); }
+
+/// \brief One editor with one effect in the first slot, and its strip.
+///
+/// \note Pitch Shifter because it is the effect the other GUI cases reach for and
+/// because it has two knobs of its own, which is what a case about "this control
+/// and that one" needs.
+class RackUnderTest
+{
+  public:
+    explicit RackUnderTest(SWTest::Instance &instance)
+    {
+        instance.openEditor();
+        auto &editor(instance.editor());
+        editor.addUserAddedModule(0);
+        editor.resyncModuleRack();
+
+        pStrip_ = editor.regionInSlot(0);
+        REQUIRE(pStrip_ != nullptr);
+        REQUIRE(pStrip_->module().numberOfEffectSpecificParameters() >= 2);
+    }
+
+    GUI::ModuleUI &strip() const { return *pStrip_; }
+    GUI::ModuleControlBase &control(std::uint8_t const index) const
+    {
+        return pStrip_->effectSpecificParameterControl(index);
+    }
+    juce::Component &widget(std::uint8_t const index) const { return control(index).widget(); }
+
+  private:
+    GUI::ModuleUI *pStrip_{nullptr};
+}; // class RackUnderTest
+
+//------------------------------------------------------------------------------
+} // anonymous namespace
+//------------------------------------------------------------------------------
+
+TEST_CASE("The pointer marks a control and its strip without selecting either",
+          "[gui][modules][hover]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    RackUnderTest const rack(instance);
+    auto &editor(instance.editor());
+
+    REQUIRE(editor.hoveredControl() == nullptr);
+    REQUIRE(editor.activeControl() == nullptr);
+
+    pointerEnters(rack.widget(0));
+
+    CHECK(editor.hoveredControl() == &rack.control(0));
+    CHECK(editor.hoveredModule() == &rack.strip());
+    CHECK(rack.control(0).isHovered());
+
+    ///   And nothing was selected by it, which is the whole of the change: a
+    /// sweep of the pointer across the rack used to be able to move the selection
+    /// -- and with it the LFO strip and the shared controls -- under a preference
+    /// nobody could get right. \see issue #210 and issue #139.
+    CHECK(editor.activeControl() == nullptr);
+    CHECK(editor.selectedModule() == nullptr);
+
+    pointerLeaves(rack.widget(0));
+
+    CHECK(editor.hoveredControl() == nullptr);
+    CHECK(editor.hoveredModule() == nullptr);
+}
+
+TEST_CASE("The pointer moving from a strip onto its knob leaves the strip marked",
+          "[gui][modules][hover]")
+{
+    ///   JUCE marks one component as being under the pointer, so entering a child
+    /// *exits* its parent -- and the strip's own hover would go out from under
+    /// the user's hand as they reached a knob on it. What makes it work without
+    /// arithmetic is the order: the exit is delivered before the enter.
+    SWTest::HostSideJuce const juceIsUp;
+
+    SWTest::Instance instance;
+    RackUnderTest const rack(instance);
+    auto &editor(instance.editor());
+
+    pointerEnters(rack.strip());
+    REQUIRE(editor.hoveredModule() == &rack.strip());
+
+    pointerLeaves(rack.strip()); // ...as JUCE announces the knob
+    pointerEnters(rack.widget(0));
+
+    CHECK(editor.hoveredModule() == &rack.strip());
+    CHECK(editor.hoveredControl() == &rack.control(0));
+
+    // ...and off the knob to somewhere that is not the rack at all.
+    pointerLeaves(rack.widget(0));
+
+    CHECK(editor.hoveredModule() == nullptr);
+    CHECK(editor.hoveredControl() == nullptr);
+}
+
+TEST_CASE("A hover lends the LFO strip to the hovered control and gives it back",
+          "[gui][modules][hover][lfo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    GUI::preferences().setPreviewLFOOnHover(true);
+
+    SWTest::Instance instance;
+    RackUnderTest const rack(instance);
+    auto &editor(instance.editor());
+
+    rack.control(0).select();
+    REQUIRE(editor.activeControl() == &rack.control(0));
+    REQUIRE(editor.displayedControl() == &rack.control(0));
+
+    pointerEnters(rack.widget(1));
+
+    // The strip follows the pointer...
+    CHECK(editor.displayedControl() == &rack.control(1));
+    CHECK(rack.control(1).isDisplayed());
+    // ...and the ring does not. \see issue #210.
+    CHECK(editor.activeControl() == &rack.control(0));
+
+    pointerLeaves(rack.widget(1));
+
+    CHECK(editor.displayedControl() == &rack.control(0));
+    CHECK(editor.activeControl() == &rack.control(0));
+}
+
+TEST_CASE("With the preview off a hover leaves the LFO strip where it was",
+          "[gui][modules][hover][lfo]")
+{
+    SWTest::HostSideJuce const juceIsUp;
+    GUI::preferences().setPreviewLFOOnHover(false);
+
+    SWTest::Instance instance;
+    RackUnderTest const rack(instance);
+    auto &editor(instance.editor());
+
+    rack.control(0).select();
+    REQUIRE(editor.displayedControl() == &rack.control(0));
+
+    pointerEnters(rack.widget(1));
+
+    // Marked, and that is all it is: the ring at half strength and the wheel.
+    CHECK(rack.control(1).isHovered());
+    CHECK(editor.displayedControl() == &rack.control(0));
+
+    pointerLeaves(rack.widget(1));
+    CHECK(editor.displayedControl() == &rack.control(0));
+
+    GUI::preferences().setPreviewLFOOnHover(true);
+}
+
+TEST_CASE("Clicking a control the pointer was previewing keeps the strip on it",
+          "[gui][modules][hover][lfo]")
+{
+    ///   The order that had to be got right: a click arrives on a control the
+    /// preview is already showing, so the strip has to go back to the *outgoing*
+    /// selection before the hand-over and then forward to the new one.
+    /// `moduleControlDectivated()` asserts that the strip is showing whichever
+    /// control it is told about, and would fire otherwise.
+    SWTest::HostSideJuce const juceIsUp;
+    GUI::preferences().setPreviewLFOOnHover(true);
+
+    SWTest::Instance instance;
+    RackUnderTest const rack(instance);
+    auto &editor(instance.editor());
+
+    rack.control(0).select();
+    pointerEnters(rack.widget(1));
+    REQUIRE(editor.displayedControl() == &rack.control(1));
+
+    rack.control(1).select();
+
+    CHECK(editor.activeControl() == &rack.control(1));
+    CHECK(editor.displayedControl() == &rack.control(1));
+
+    // ...and the pointer leaving does not now take the strip away with it.
+    pointerLeaves(rack.widget(1));
+    CHECK(editor.displayedControl() == &rack.control(1));
+}

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -138,8 +138,8 @@ template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Compone
 /// box arrived as a fourth and this said so.
 GUI::TitledComboBox &comboBoxOffering(Editor &editor, std::size_t const choices)
 {
-    /// Zoom, colour scheme and mouse-over reaction.
-    std::size_t constexpr onTheInterfacePage{3};
+    /// Zoom and colour scheme, the page's three switches being LEDs.
+    std::size_t constexpr onTheInterfacePage{2};
 
     auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
     REQUIRE(comboBoxes.size() == onTheInterfacePage);
@@ -156,18 +156,38 @@ GUI::TitledComboBox &zoomComboBox(Editor &editor)
 {
     return comboBoxOffering(editor, Preferences::zoomPercentages.size());
 }
-GUI::TitledComboBox &mouseOverComboBox(Editor &editor) { return comboBoxOffering(editor, 3); }
 
-/// The one LED on the Interface page, found through the combo boxes so that the
-/// module strips' own LEDs cannot be picked up instead.
-GUI::LEDTextButton &hideCursorButton(Editor &editor)
+/// \brief One of the Interface page's LEDs, by the caption it carries.
+///
+/// \note Found through the zoom box's parent so that the module strips' own LEDs
+/// cannot be picked up instead, and by name because there are three of them.
+GUI::LEDTextButton &ledCaptioned(Editor &editor, juce::String const &caption)
 {
-    auto *const pPage(mouseOverComboBox(editor).getParentComponent());
+    auto *const pPage(zoomComboBox(editor).getParentComponent());
     REQUIRE(pPage != nullptr);
 
     auto const buttons(descendantsOfType<GUI::LEDTextButton>(*pPage));
-    REQUIRE(buttons.size() == 1);
+    REQUIRE(buttons.size() == 3);
+
+    for (auto *const pButton : buttons)
+        if (pButton->getName() == caption)
+            return *pButton;
+
+    FAIL("no LED on the Interface page is captioned " << caption);
     return *buttons.front();
+}
+
+GUI::LEDTextButton &hideCursorButton(Editor &editor)
+{
+    return ledCaptioned(editor, "Hide cursor on knob drag");
+}
+GUI::LEDTextButton &lfoAnimationButton(Editor &editor)
+{
+    return ledCaptioned(editor, "Show LFO animation");
+}
+GUI::LEDTextButton &lfoPreviewButton(Editor &editor)
+{
+    return ledCaptioned(editor, "Preview LFO on hover");
 }
 
 /// An editor with the Interface page up.
@@ -188,7 +208,8 @@ TEST_CASE("With no preferences file every value is at its default", "[gui][prefe
 {
     Preferences const preferences(caseFolder("absent"));
 
-    CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
+    CHECK(preferences.showLFOAnimation());
+    CHECK(preferences.previewLFOOnHover());
     CHECK(preferences.hideCursorOnKnobDrag());
     CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
 
@@ -204,7 +225,8 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
 
     {
         Preferences written(folder);
-        written.setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
+        written.setShowLFOAnimation(false);
+        written.setPreviewLFOOnHover(false);
         written.setPalette(GUI::ColourMap::ClassicRed);
         written.setHideCursorOnKnobDrag(false);
         written.setZoomPercent(75);
@@ -213,7 +235,8 @@ TEST_CASE("Every preference survives a new instance over the same folder", "[gui
     }
 
     Preferences const read(folder);
-    CHECK(read.moduleUIMouseOverReaction() == Preferences::WhenParentModuleSelected);
+    CHECK(!read.showLFOAnimation());
+    CHECK(!read.previewLFOOnHover());
     CHECK(read.palette() == GUI::ColourMap::ClassicRed);
     CHECK(!read.hideCursorOnKnobDrag());
     CHECK(read.zoomPercent() == 75);
@@ -233,15 +256,16 @@ TEST_CASE("The file names its keys and its enumerated values", "[gui][preference
     auto const folder(caseFolder("names"));
 
     Preferences preferences(folder);
-    preferences.setModuleUIMouseOverReaction(Preferences::WhenParentOrNothingSelected);
+    preferences.setPalette(GUI::ColourMap::ClassicGreen);
+    preferences.setShowLFOAnimation(false);
     preferences.setHideCursorOnKnobDrag(false);
     preferences.setZoomPercent(125);
 
     auto const file(contentsOf(preferences.file()));
     CAPTURE(file);
 
-    CHECK(file.find("key=\"moduleUIMouseOverReaction\" value=\"WhenParentOrNothingSelected\"") !=
-          std::string::npos);
+    CHECK(file.find("key=\"palette\" value=\"ClassicGreen\"") != std::string::npos);
+    CHECK(file.find("key=\"showLFOAnimation\" value=\"0\"") != std::string::npos);
     CHECK(file.find("key=\"hideCursorOnKnobDrag\" value=\"0\"") != std::string::npos);
     CHECK(file.find("key=\"zoomPercent\" value=\"125\"") != std::string::npos);
 }
@@ -254,14 +278,14 @@ TEST_CASE("A value this build does not recognise reads as the default", "[gui][p
     write(folder / "SpectrumWorxUserDefaults.xml",
           "<?xml version = \"1.0\" encoding = \"UTF-8\" ?>\n"
           "<defaults version=\"1\">\n"
-          "  <default key=\"moduleUIMouseOverReaction\" value=\"Sideways\" type=\"1\"/>\n"
-          "  <default key=\"palette\" value=\"ClassicRed\" type=\"1\"/>\n"
+          "  <default key=\"palette\" value=\"Sideways\" type=\"1\"/>\n"
           "  <default key=\"zoomPercent\" value=\"300\" type=\"2\"/>\n"
+          "  <default key=\"showLFOAnimation\" value=\"0\" type=\"2\"/>\n"
           "</defaults>\n");
 
     Preferences const preferences(folder);
 
-    CHECK(preferences.moduleUIMouseOverReaction() == Preferences::Never);
+    CHECK(preferences.palette() == GUI::ColourMap::ClassicBlue);
 
     /// \note 300 is a zoom, and a reasonable one -- issue #55 asks for it -- but
     /// it is not one this build offers, and the combo box could show nothing for
@@ -271,7 +295,7 @@ TEST_CASE("A value this build does not recognise reads as the default", "[gui][p
     CHECK(preferences.zoomPercent() == Preferences::defaultZoomPercent);
 
     // ...and neither unreadable key cost it the one beside it.
-    CHECK(preferences.palette() == GUI::ColourMap::ClassicRed);
+    CHECK(!preferences.showLFOAnimation());
 }
 
 TEST_CASE("Every offered zoom scales the skin by its own percentage", "[gui][preferences]")
@@ -310,36 +334,42 @@ TEST_CASE("Every offered zoom scales the skin by its own percentage", "[gui][pre
 TEST_CASE("The Interface page opens showing what is in the preferences", "[gui][preferences]")
 {
     useCaseFolder("pageReads");
-    GUI::preferences().setModuleUIMouseOverReaction(Preferences::WhenParentModuleSelected);
+    GUI::preferences().setZoomPercent(75);
+    GUI::preferences().setShowLFOAnimation(false);
     GUI::preferences().setHideCursorOnKnobDrag(false);
 
     SWTest::HostSideJuce const juce;
     SWTest::Instance instance;
     auto &editor(editorOnTheInterfacePage(instance));
 
-    CHECK(mouseOverComboBox(editor).getSelectedID() == Preferences::WhenParentModuleSelected);
+    CHECK(zoomComboBox(editor).getSelectedID() == 75);
+    CHECK(!lfoAnimationButton(editor).getToggleState());
+    CHECK(lfoPreviewButton(editor).getToggleState());
     CHECK(!hideCursorButton(editor).getToggleState());
 }
 
-TEST_CASE("Choosing a mouse-over reaction on the page writes it to the file", "[gui][preferences]")
+TEST_CASE("Toggling the LFO switches on the page writes them to the file", "[gui][preferences]")
 {
-    useCaseFolder("pageWritesTheComboBox");
-    GUI::preferences().setModuleUIMouseOverReaction(Preferences::Never);
+    useCaseFolder("pageWritesTheLFOLEDs");
+    GUI::preferences().setShowLFOAnimation(true);
+    GUI::preferences().setPreviewLFOOnHover(true);
 
     SWTest::HostSideJuce const juce;
     SWTest::Instance instance;
     auto &editor(editorOnTheInterfacePage(instance));
 
-    auto &comboBox(mouseOverComboBox(editor));
-    comboBox.setSelectedID(Preferences::WhenParentOrNothingSelected);
-    Editor::Settings::comboBoxValueChanged(comboBox);
+    /// \note sendNotificationSync, which is what makes this reachable headlessly:
+    /// juce::Button calls its listeners from inside the call rather than posting.
+    lfoAnimationButton(editor).setToggleState(false, juce::sendNotificationSync);
+    lfoPreviewButton(editor).setToggleState(false, juce::sendNotificationSync);
 
-    CHECK(GUI::preferences().moduleUIMouseOverReaction() ==
-          Preferences::WhenParentOrNothingSelected);
+    CHECK(!GUI::preferences().showLFOAnimation());
+    CHECK(!GUI::preferences().previewLFOOnHover());
 
     // And on disk, which is the half issue #61 was about.
     Preferences const onDisk(GUI::preferences().file().parent_path());
-    CHECK(onDisk.moduleUIMouseOverReaction() == Preferences::WhenParentOrNothingSelected);
+    CHECK(!onDisk.showLFOAnimation());
+    CHECK(!onDisk.previewLFOOnHover());
 }
 
 TEST_CASE("Toggling hide-cursor-on-knob-drag on the page writes it to the file",

--- a/tests/gui/sliderMenuTests.cpp
+++ b/tests/gui/sliderMenuTests.cpp
@@ -85,12 +85,10 @@ class StripUnderTest
 
         /// \note The strip has to be *selected* and not merely have a control
         /// activated: SharedModuleControls -- which the frequency range lives on
-        /// -- is built by moduleActivated(), and a mouse entering the region is
-        /// the public way in. The preference that gates it is Never by default.
-        /// \see ModuleUI::selectionTracksMouseMovements().
-        LE::SW::GUI::preferences().setModuleUIMouseOverReaction(
-            LE::SW::GUI::Preferences::WhenParentOrNothingSelected);
-        static_cast<juce::Component &>(*pModuleUI).mouseEnter(pressAt(*pModuleUI, 1, 0));
+        /// -- is built by moduleActivated(). The pointer does not select one and
+        /// a headless case has no keyboard to give it, so it is asked directly.
+        /// \see ModuleUI::activate() and issue #210.
+        pModuleUI->activate();
         REQUIRE(editor.selectedModule() == pModuleUI);
 
         pControl_ = &pModuleUI->effectSpecificParameterControl(0);
@@ -305,9 +303,7 @@ TEST_CASE("The frequency range's menu is about the thumb pressed", "[gui][module
     auto *const pModuleUI(editor.regionInSlot(0));
     REQUIRE(pModuleUI != nullptr);
 
-    LE::SW::GUI::preferences().setModuleUIMouseOverReaction(
-        LE::SW::GUI::Preferences::WhenParentOrNothingSelected);
-    static_cast<juce::Component &>(*pModuleUI).mouseEnter(pressAt(*pModuleUI, 1, 0));
+    pModuleUI->activate();
     REQUIRE(editor.selectedModule() == pModuleUI);
     REQUIRE(editor.activeControl() == nullptr);
 
@@ -350,9 +346,9 @@ TEST_CASE("The frequency range's menu is about the thumb pressed", "[gui][module
 /// entries key on, and what "Reset to default value" would have written -- was
 /// about the module's Bypass.
 ///
-/// \note The preference is put back to its default here, which is the harder
-/// half: with `Never` the press may not take the selection, and what the menu is
-/// about must not depend on whether it did.
+/// \note And the pointer never takes the selection, which is the harder half:
+/// the press may leave the knob selected, and what the menu is about must not
+/// depend on whether it did. \see issue #210.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -370,23 +366,20 @@ TEST_CASE("The frequency range's menu is about the thumb pressed while a knob is
     auto *const pModuleUI(editor.regionInSlot(0));
     REQUIRE(pModuleUI != nullptr);
 
-    LE::SW::GUI::preferences().setModuleUIMouseOverReaction(
-        LE::SW::GUI::Preferences::WhenParentOrNothingSelected);
-    static_cast<juce::Component &>(*pModuleUI).mouseEnter(pressAt(*pModuleUI, 1, 0));
+    pModuleUI->activate();
     REQUIRE(editor.selectedModule() == pModuleUI);
 
-    /// \note A knob taking the selection the way the pointer gives it, rather
-    /// than `moduleControlActivated()` -- which builds the strip without making
+    /// \note A knob really taking the selection, rather than
+    /// `moduleControlActivated()` -- which builds the strip without making
     /// anything the *active* control, and it is that pointer the frequency range
-    /// asks about.
+    /// asks about. select() is the click's own step without the keyboard, which
+    /// a headless case cannot give. \see issue #210.
     auto &knob(pModuleUI->effectSpecificParameterControl(0));
-    static_cast<juce::Component &>(knob.widget()).mouseEnter(pressAt(knob.widget(), 1, 0));
+    knob.select();
     REQUIRE(editor.activeControl() == &knob);
 
     auto &range(editor.sharedModuleControls().frequencyRange());
     auto &widget(static_cast<juce::Component &>(range));
-
-    LE::SW::GUI::preferences().setModuleUIMouseOverReaction(LE::SW::GUI::Preferences::Never);
 
     // the sweep that leaves the slider standing for nothing
     widget.mouseEnter(pressAt(range, 1, 0));
@@ -421,7 +414,6 @@ TEST_CASE("The frequency range's menu is about the thumb pressed while a knob is
     CHECK(range.parameterMenuID().binaryValue ==
           idFor(LE::Parameters::IndexOf<Parameters, StopFrequency>::value));
 
-    // ...and the knob kept the halo throughout, the preference saying the pointer
-    // may not take it
+    // ...and the knob kept the ring throughout: the pointer may not take it
     CHECK(editor.activeControl() == &knob);
 }

--- a/tools/show-ui/pages/editorPage.cpp
+++ b/tools/show-ui/pages/editorPage.cpp
@@ -229,6 +229,7 @@ class EditorPage final : public juce::Component
         {
             fillFirstSlot();
             showModuleDrop();
+            showHighlights();
         }
 
         if (openPresetBrowser)
@@ -424,6 +425,66 @@ class EditorPage final : public juce::Component
         std::fprintf(stderr, "sw-show-ui: %s at %s\n", swap ? "swap" : "insert", pIndex + 1);
         editor_->showModuleDrop(
             {swap ? Drop::swap : Drop::insert, static_cast<std::uint8_t>(std::atoi(pIndex + 1))});
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief SW_SHOW_UI_HIGHLIGHT -- everything issue #210 asks an eye about, in
+    /// one picture: a selected strip and control beside a hovered strip and
+    /// control, and on the selected knob the band an LFO's travel draws when the
+    /// user has asked not to watch the sweep.
+    ///
+    ///   The selection has to read as louder than the hover at a glance, the
+    /// hover has to read as something rather than nothing, and the band has to be
+    /// tellable from the wedge it sits under. None of the three is a question a
+    /// case can answer.
+    ///
+    /// \note None of it is otherwise reachable from a render. The pointer does
+    /// not exist here, and the selection goes through the keyboard -- which an
+    /// offscreen editor cannot take, `grabKeyboardFocus()` jasserting on a
+    /// component that is on no screen rather than declining. So they are asked
+    /// for directly: select() is the click's own step less the keyboard, and
+    /// mouseEnter() is what JUCE would deliver.
+    ///
+    /// \note A render switch rather than an interactive one: it turns the LFO
+    /// animation preference off, and only `--render` points the preferences at a
+    /// folder of its own. \see usePreferencesOfNobodyInParticular().
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    void showHighlights()
+    {
+        if (!std::getenv("SW_SHOW_UI_HIGHLIGHT"))
+            return;
+
+        // a second strip, so that "selected" and "hovered" are side by side
+        editor_->addUserAddedModule(0);
+        editor_->resyncModuleRack();
+
+        auto *const pSelected(editor_->regionInSlot(0));
+        auto *const pHovered(editor_->regionInSlot(1));
+        LE_ASSERT_MSG(pSelected && pHovered, "The harness could not fill two slots.");
+        if (!pSelected || !pHovered)
+            return;
+
+        pSelected->activate();
+
+        auto &selected(pSelected->effectSpecificParameterControl(0));
+        selected.select();
+
+        //   An LFO over part of the knob's travel, with the animation off, which
+        // is the only state that draws the band. \see ModuleKnob::lfoRangeToDraw()
+        GUI::preferences().setShowLFOAnimation(false);
+        editor_->setLFOEnabled(selected, true);
+        selected.lfo().setLowerBound(0.25f);
+        selected.lfo().setUpperBound(0.80f);
+
+        auto &widget(pHovered->effectSpecificParameterControl(0).widget());
+        auto const centre(widget.getLocalBounds().getCentre().toFloat());
+        widget.mouseEnter(juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(),
+                                           centre, juce::ModifierKeys(), 1.0f, 0.0f, 0.0f, 0.0f,
+                                           0.0f, &widget, &widget, juce::Time(), centre,
+                                           juce::Time(), 1, false));
     }
 
     HarnessHost host_;

--- a/tools/show-ui/pages/knobsPage.cpp
+++ b/tools/show-ui/pages/knobsPage.cpp
@@ -36,6 +36,48 @@ namespace
 
 namespace GUI = LE::SW::GUI;
 
+struct Row
+{
+    char const *caption;
+    unsigned int diameter;
+    bool editor;  ///< an EditorKnob rather than a ModuleKnob
+    bool bipolar; ///< module knobs only, as are the two below
+    GUI::Highlight highlight{GUI::Highlight::None};
+
+    /// \brief Whether this row is an LFO's travel rather than a value.
+    ///
+    /// \note And the row then sweeps the *band* rather than the value, because
+    /// the value is not drawn while there is one -- nine identical knobs would be
+    /// the correct picture and a useless one. \see paintModuleKnob().
+    bool lfoRange{false};
+}; // struct Row
+
+/// \brief A band a third of the travel wide, starting \p position of the way
+/// along, which is what a banded row shows at each of its nine steps.
+juce::Range<float> lfoBandAt(float const position)
+{
+    float constexpr width{0.35f};
+    auto const start(position * (1 - width));
+    return {start, start + width};
+}
+
+Row const rows[]{
+    {"EditorKnob, 83 px (in, out and mix)", GUI::EditorKnob::diameter, true, false},
+    {"ModuleKnob unipolar, 77 px", GUI::ModuleKnob::diameter, false, false},
+    {"ModuleKnob bipolar, 77 px", GUI::ModuleKnob::diameter, false, true},
+    {"ModuleKnob unipolar, 77 px, hovered", GUI::ModuleKnob::diameter, false, false,
+     GUI::Highlight::Hovered},
+    {"ModuleKnob unipolar, 77 px, selected", GUI::ModuleKnob::diameter, false, false,
+     GUI::Highlight::Selected},
+    {"ModuleKnob, 77 px, an LFO's travel swept across it -- no value is drawn",
+     GUI::ModuleKnob::diameter, false, false, GUI::Highlight::None, true},
+    {"ModuleKnob, 77 px, the same, selected", GUI::ModuleKnob::diameter, false, false,
+     GUI::Highlight::Selected, true},
+    {"ModuleKnob unipolar, 35 px (gain and wet)", GUI::ModuleKnob::smallDiameter, false, false},
+    {"ModuleKnob bipolar, 35 px, selected", GUI::ModuleKnob::smallDiameter, false, true,
+     GUI::Highlight::Selected},
+};
+
 class KnobsPage final : public juce::Component
 {
   public:
@@ -43,7 +85,7 @@ class KnobsPage final : public juce::Component
     {
         if (!GUI::Theme::haveSingleton())
             GUI::Theme::createSingleton();
-        setSize(margin * 2 + steps * cell, margin * 2 + rows * cell + headerHeight);
+        setSize(margin * 2 + steps * cell, margin * 2 + rowCount * cell + headerHeight);
     }
 
     void paint(juce::Graphics &graphics) override
@@ -55,7 +97,7 @@ class KnobsPage final : public juce::Component
         label(graphics, "The editor's knobs, painted", margin, margin, 22.5f, juce::Colours::white);
 
         int y(margin + headerHeight);
-        for (auto const &row : rows_)
+        for (auto const &row : rows)
         {
             label(graphics, row.caption, margin, y - 21, 16.5f, juce::Colours::grey);
             for (unsigned int step(0); step < steps; ++step)
@@ -68,7 +110,10 @@ class KnobsPage final : public juce::Component
                 if (row.editor)
                     GUI::paintEditorKnob(graphics, face, value);
                 else
-                    GUI::paintModuleKnob(graphics, face, value, row.bipolar, row.selected);
+                    GUI::paintModuleKnob(graphics, face, value, row.bipolar, row.highlight,
+                                         row.lfoRange
+                                             ? std::optional<juce::Range<float>>(lfoBandAt(value))
+                                             : std::nullopt);
             }
             y += cell;
         }
@@ -80,25 +125,7 @@ class KnobsPage final : public juce::Component
     static constexpr int margin{30};
     static constexpr int headerHeight{60};
 
-    struct Row
-    {
-        char const *caption;
-        unsigned int diameter;
-        bool editor;  ///< an EditorKnob rather than a ModuleKnob
-        bool bipolar; ///< module knobs only, as is the one below
-        bool selected;
-    }; // struct Row
-
-    static constexpr Row rows_[]{
-        {"EditorKnob, 83 px (in, out and mix)", GUI::EditorKnob::diameter, true, false, false},
-        {"ModuleKnob unipolar, 77 px", GUI::ModuleKnob::diameter, false, false, false},
-        {"ModuleKnob bipolar, 77 px", GUI::ModuleKnob::diameter, false, true, false},
-        {"ModuleKnob unipolar, 77 px, selected", GUI::ModuleKnob::diameter, false, false, true},
-        {"ModuleKnob unipolar, 35 px (gain and wet)", GUI::ModuleKnob::smallDiameter, false, false,
-         false},
-        {"ModuleKnob bipolar, 35 px, selected", GUI::ModuleKnob::smallDiameter, false, true, true},
-    };
-    static constexpr int rows{int(std::size(rows_))};
+    static constexpr int rowCount{int(std::size(rows))};
 
     static void label(juce::Graphics &graphics, juce::String const &text, int const x, int const y,
                       float const height, juce::Colour const colour)


### PR DESCRIPTION
The interface had one preference for what the pointer passing over a control should do and three answers to it, and none of them worked. The two that reacted moved the *selection* -- and with it the LFO strip and the shared controls -- so a sweep across the rack undid whatever the user had just clicked, which is what issue #139 spent its length defending against; and the one that did not react, the default, left the pointer meaning nothing at all.

The pointer now marks rather than selects, always. A control under it wears the selection's ring at half strength and takes the wheel; the strip it is on wears a fainter version of the selected strip's halo. A click still selects and the ring stays where the click left it, so the two no longer compete. Two switches replace the three answers:

  - Preview LFO on hover lends the LFO strip to whatever the pointer is over and gives it back when it leaves. The white ring does not follow.

  - Show LFO animation, turned off, stops a knob under an LFO from following the sweep and draws the LFO's bounds on it instead, in a palette entry of their own. The knob shows the parameter's own value rather than freezing wherever the sweep happened to leave it, which is the complaint issue #204 was about.

Both default to on, so a knob behaves as it always has until the user says otherwise.

A wheel over a combo box no longer takes the keyboard first, which is what it needed a window for; the two cases about it move to the file that has the rest of the wheel. SW_SHOW_UI_HIGHLIGHT renders the four states side by side, none of which a render could otherwise reach -- the pointer does not exist offscreen and the selection goes through a keyboard an offscreen editor cannot take.

Closes #210

Assisted-by: Claude Opus 5 (1M context)