### PR TITLE
Further UI tweaks

### DIFF
--- a/src/gui/colourMap.cpp
+++ b/src/gui/colourMap.cpp
@@ -150,8 +150,6 @@ juce::Colour ColourMap::classic(Name const name)
         return juce::Colour(0xFF0A0909u);
     case ModuleKnobCap:
         return juce::Colour(0xFF000000u);
-    case ModuleKnobLFORange:
-        return juce::Colour(0x8013B5EAu);
 
     case FocusHalo:
         return juce::Colour(0xFFFFFFFFu);

--- a/src/gui/colourMap.hpp
+++ b/src/gui/colourMap.hpp
@@ -109,16 +109,6 @@ class ColourMap
         ModuleKnobDomeRim,    ///< the dome at its rim, and the hairline on it
         ModuleKnobCap,        ///< the cap over the wedge's inside
 
-        /// \brief The arc an LFO's bounds cover, drawn where the wedge is drawn
-        /// and under it.
-        ///
-        /// \note Translucent, and that is the whole of it: this says "the value
-        /// lives somewhere in here" against a wedge that says where it is now.
-        /// Only drawn with the animation turned off. \see
-        /// Preferences::showLFOAnimation() and issue #210.
-        ModuleKnobLFORange,
-        ///@}
-
         /// The halo around whichever control has the focus.
         FocusHalo,
 

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2659,10 +2659,10 @@ struct LFOTextData
 std::size_t const lfoWidth = 174;
 
 LFOTextData sliderTexts[] = {
-    {0, &periodRatioString, 14, 36, 158, 18, juce::Justification::right},        // period ratio
-    {0, &periodMillisecondsString, 14, 71, 158, 18, juce::Justification::right}, // period ms
+    {0, &periodRatioString, 14, 37, 158, 18, juce::Justification::right},        // period ratio
+    {0, &periodMillisecondsString, 14, 69, 158, 18, juce::Justification::right}, // period ms
     {0, &rangeValueString, 14, 93, lfoWidth - 15 - 3, 18, juce::Justification::right}, // range max
-    {0, &rangeValueString, 15, 126, lfoWidth - 15, 18, juce::Justification::left},     // range min
+    {0, &rangeValueString, 15, 125, lfoWidth - 15, 18, juce::Justification::left},     // range min
     {0, &phaseString, 14, 177, 158, 18, juce::Justification::right},                   // phase %
 };
 
@@ -2680,7 +2680,7 @@ struct FixedText
 #pragma warning(pop)
 
 static FixedText const fixedText[] = {
-    {"Period", 36 + 14},
+    {"Period", 37 + 14},
     {"Range", 93 + 14},
     {"Waveform", 149 + 14},
     {"Phase", 177 + 14},
@@ -3771,11 +3771,12 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep + yOffset, "Zoom"),
       palette_(*this, xMargin, yMargin + 1 * yStep + yOffset, "Color Scheme"),
-      showLFOAnimation_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset, "Show LFO animation"),
+      showLFOAnimation_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset,
+                        "Animate LFO modulations"),
       previewLFOOnHover_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + ledStep,
-                         "Preview LFO on hover"),
+                         "Hover shows LFO settings"),
       hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + 2 * ledStep,
-                            "Hide cursor on knob drag")
+                            "Hide cursor on knob edits")
 {
     Settings &parent(
         Utility::ParentFromMember<Settings, InterfacePage, &Settings::interfacePage_>()(*this));

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1510,8 +1510,6 @@ class SpectrumWorxEditor final : private SkinLifetime,
         static std::uint16_t const yMargin = 30;
         static std::uint16_t const yOffset = 7;
         static std::uint16_t const yStep = 60;
-        /// \note Between two LEDs, which carry no title of their own and so do
-        /// not need the room a combo box's does.
         static std::uint16_t const ledStep = 30;
     }; // class Settings
 

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -123,7 +123,7 @@ TriggerButton::TriggerButton(juce::Component &parent, unsigned int const x, unsi
     addToParentAndShow(parent, *this);
 
     // the extra height is the caption's room under the face. \see paintButton()
-    setBounds(x, y, ModuleUI::width, TriggerButtonStyle::diameter + 20);
+    setBounds(x, y - 2, ModuleUI::width, TriggerButtonStyle::diameter + 18);
 
     setTriggeredOnMouseDown(true);
 
@@ -214,14 +214,17 @@ void TriggerButton::mouseUp(juce::MouseEvent const &e) noexcept
 void TriggerButton::paintButton(juce::Graphics &graphics, bool const isMouseOverButton,
                                 bool const isButtonDown)
 {
-    auto const face(faceBounds());
+    auto const face(faceBounds().translated(0, 2));
 
     graphics.setColour(ColourMap::getColour(ColourMap::Text));
-    graphics.setFont(DrawableText::defaultFont());
-    graphics.drawFittedText(getName(), 0, face.getHeight() + 3, getWidth(), 17,
+    juce::Font font(Theme::singleton().labelFont());
+    font.setHeight(15);
+    graphics.setFont(font);
+    graphics.drawFittedText(getName(), 0, face.getHeight() + 5, getWidth(), 17,
                             juce::Justification::horizontallyCentred, 1);
 
     bool const fade(isMouseOverButton && !isButtonDown);
+
     if (fade)
         graphics.beginTransparencyLayer(PointerFeedback::over);
 

--- a/src/gui/painters/moduleKnobPainter.cpp
+++ b/src/gui/painters/moduleKnobPainter.cpp
@@ -58,7 +58,7 @@ void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const boun
         // between the two bounds, where the value would be from a stop to itself
         fillArc(KnobPainter::angleFor(juce::jlimit(0.0f, 1.0f, lfoRange->getStart())),
                 KnobPainter::angleFor(juce::jlimit(0.0f, 1.0f, lfoRange->getEnd())),
-                ColourMap::ModuleKnobLFORange);
+                ColourMap::Accent);
     else
         // the far edge is the value; the near one is the stop it opens from
         fillArc(KnobPainter::angleFor(value), bipolar ? 0.0f : -KnobPainter::halfSweepDegrees,
@@ -68,10 +68,11 @@ void paintModuleKnob(juce::Graphics &graphics, juce::Rectangle<float> const boun
     /// that the accent keeps a roughly even thickness as it lengthens, and a
     /// range has no length to follow -- one that grew with the span would draw a
     /// wide travel thinner than a narrow one, which is backwards.
-    auto const cap(lfoRange ? capRadiusClosed
+    auto const cap(lfoRange ? capRadiusLFO
                             : capRadiusClosed + (capRadiusOpen - capRadiusClosed) * openness);
-    KnobPainter::paintCap(graphics, bounds, cap, cap /*a hard edge*/,
-                          ColourMap::getColour(ColourMap::ModuleKnobCap));
+    auto const color(lfoRange ? ColourMap::getColour(ColourMap::ModuleKnobDomeCentre)
+                              : ColourMap::getColour(ColourMap::ModuleKnobCap));
+    KnobPainter::paintCap(graphics, bounds, cap, cap /*a hard edge*/, color);
 
     switch (highlight)
     {

--- a/src/gui/painters/moduleKnobPainter.hpp
+++ b/src/gui/painters/moduleKnobPainter.hpp
@@ -62,10 +62,11 @@ namespace ModuleKnobStyle
 {
 /// \note Geometry only. The colours are ColourMap's -- four ModuleKnob* entries,
 /// plus Accent for the wedge and FocusHalo for the ring.
-float constexpr innerGradientRadius{0.26f}; ///< the dome holds its centre colour in to here
-float constexpr wedgeRadius{0.717f};
-float constexpr capRadiusClosed{0.22f}; ///< with the wedge shut
-float constexpr capRadiusOpen{0.48f};   ///< with it fully open
+float constexpr innerGradientRadius{0.25f}; ///< the dome holds its centre colour in to here
+float constexpr wedgeRadius{0.75f};
+float constexpr capRadiusLFO{0.25f};   ///< when LFO is enabled for a module knob
+float constexpr capRadiusClosed{0.2f}; ///< with the wedge shut
+float constexpr capRadiusOpen{0.5f};   ///< with it fully open
 
 /// \note The wedge's travel is KnobPainter::halfSweepDegrees, shared with the
 /// editor knob's pointer -- see the note there.
@@ -91,10 +92,10 @@ float constexpr rimThickness{1.0f}; ///< px
 /// is hard edged, and stays that way.
 namespace TriggerButtonStyle
 {
-float constexpr capRadius{0.201f};     ///< the black cap, out to where it is solid
-float constexpr capEdgeRadius{0.260f}; ///< and where it has faded into the dome
-float constexpr litRadius{0.113f};     ///< the blue eye that says it is on
-float constexpr litEdgeRadius{0.172f}; ///< which fades out inside the cap
+float constexpr capRadius{0.2f};       ///< the black cap, out to where it is solid
+float constexpr capEdgeRadius{0.25f};  ///< and where it has faded into the dome
+float constexpr litRadius{0.1f};       ///< the blue eye that says it is on
+float constexpr litEdgeRadius{0.175f}; ///< which fades out inside the cap
 
 /// \note Both pairs are a straight fade fitted to the artwork's stops, and the
 /// fit is good: the cap's own ramp read 0.92, 0.63 and 0.375 opaque at the three

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -104,7 +104,7 @@ class Preferences
     /// always done. Off, the knob draws the LFO's *bounds* instead and draws no
     /// value at all -- the same information, and honestly, without eight strips'
     /// worth of movement in the corner of the eye. \see paintModuleKnob(),
-    /// ColourMap::ModuleKnobLFORange and issue #210.
+    /// and issue #210.
     ///
     ////////////////////////////////////////////////////////////////////////////
     bool showLFOAnimation() const { return showLFOAnimation_; }

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -179,15 +179,15 @@ GUI::LEDTextButton &ledCaptioned(Editor &editor, juce::String const &caption)
 
 GUI::LEDTextButton &hideCursorButton(Editor &editor)
 {
-    return ledCaptioned(editor, "Hide cursor on knob drag");
+    return ledCaptioned(editor, "Hide cursor on knob edits");
 }
 GUI::LEDTextButton &lfoAnimationButton(Editor &editor)
 {
-    return ledCaptioned(editor, "Show LFO animation");
+    return ledCaptioned(editor, "Animate LFO modulations");
 }
 GUI::LEDTextButton &lfoPreviewButton(Editor &editor)
 {
-    return ledCaptioned(editor, "Preview LFO on hover");
+    return ledCaptioned(editor, "Hover shows LFO settings");
 }
 
 /// An editor with the Interface page up.


### PR DESCRIPTION
TriggerButton now has the same label style as regular knob, and the focus ring is not clipped at the top of the circle.

Pixel-precise repositioning of LFO Period and Range min/max labels so that they are always 10px away from the slider groove.

Removed ColourMap::ModuleKnobLFORange, just using Accent color instead, and painting the knob cap using ModuleKnobDomeCentre color too, so LFO assigned parameters definitely look different from normal knobs.

Modified ModuleKnobStyle and TriggerButtonStyle to use "nice" number while still looking basically as intended.

Renamed the three boolean GUI settings.