### PR TITLE
Stop marking the session dirty on every parameter change

### DIFF
--- a/src/core/host_interop/plugin2HostImpl.hpp
+++ b/src/core/host_interop/plugin2HostImpl.hpp
@@ -230,7 +230,9 @@ class Plugin2HostActiveInteropImpl : public Base
         impl().host().automatedParameterChanged(
             Plugin2HostInteropControler::make<typename Impl::ParameterSelector>(parameterID),
             newValue);
-        impl().markCurrentProgramAsModified();
+        // the flag, not the host call: this runs once per mouse move of a drag,
+        // and a parameter change is a dirty state without saying so \see #219
+        impl().markCurrentProgramAsEdited();
     }
 
   protected:

--- a/src/gui/editor/editorHost.hpp
+++ b/src/gui/editor/editorHost.hpp
@@ -419,9 +419,10 @@ class EditorHost
 
     /// \brief Says the session has changed in a way that is not a parameter.
     ///
-    /// \note The preset comment is the one that needs it: everything else goes
-    /// out through `editParameter`, which tells the host on the way past, so a
+    /// \note The preset comment is the one that needs it: everything else is a
+    /// parameter, and ext/state.h makes a parameter change dirty implicitly, so a
     /// project closed after typing a comment would be offered as unmodified.
+    /// \see issue #219.
     virtual void markStateModified() const = 0;
 
     /// \brief The preset the plugin is playing. \see LoadedPreset

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -1626,7 +1626,7 @@ void SpectrumWorxCLAP::HostProxy::automatedParameterChanged(
         const_cast<SpectrumWorxCLAP &>(plugin_).requestRescan(
             CLAP_PARAM_RESCAN_INFO | CLAP_PARAM_RESCAN_TEXT | CLAP_PARAM_RESCAN_VALUES);
 
-    plugin_.markCurrentProgramAsModified();
+    plugin_.markCurrentProgramAsEdited();
     plugin_.requestParameterFlush();
 }
 
@@ -1725,10 +1725,25 @@ void SpectrumWorxCLAP::markCurrentProgramAsModified() const
     /// \note Before the host question and not behind it: the browser's two Save
     /// buttons read this, and whether a host offers `clap.state` has nothing to
     /// do with whether the user has edited the preset. \see issue #177.
-    const_cast<SpectrumWorxCLAP &>(*this).loadedPreset_.modified.store(true,
-                                                                       std::memory_order_relaxed);
+    markCurrentProgramAsEdited();
 
     markSessionAsUnsaved();
+}
+
+/// \note What an editor edit gets instead. `clap_host_state.mark_dirty` from the
+/// UI thread is a synchronous call into the host on every mouse move of a drag,
+/// and ext/state.h says a parameter change already implies a dirty state. REAPER
+/// answers one by re-reading all 696 parameters, finding each index by walking
+/// `get_info` from zero, which held the interface at 24 frames a second.
+/// \see issue #219.
+///
+/// \note handleEvent()'s write keeps the full call: it defers, and the deferral
+/// coalesces, so a host writing a parameter every block still marks dirty once
+/// per callback rather than once per event.
+void SpectrumWorxCLAP::markCurrentProgramAsEdited() const
+{
+    const_cast<SpectrumWorxCLAP &>(*this).loadedPreset_.modified.store(true,
+                                                                       std::memory_order_relaxed);
 }
 
 void SpectrumWorxCLAP::markSessionAsUnsaved() const

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -193,6 +193,13 @@ class SpectrumWorxCLAP final
     /// without anybody having edited anything. \see LoadedPreset::modified
     void markCurrentProgramAsModified() const;
 
+    /// \brief The edited flag on its own, for a change the host already knows it
+    /// has to save.
+    ///
+    /// \note ext/state.h: "If a parameter value changes, then it is implicit
+    /// that the state is dirty". \see issue #219.
+    void markCurrentProgramAsEdited() const;
+
   public:
     explicit SpectrumWorxCLAP(clap_host const *);
     ~SpectrumWorxCLAP() override;

--- a/tests/clap/hostInteropTests.cpp
+++ b/tests/clap/hostInteropTests.cpp
@@ -106,12 +106,46 @@ TEST_CASE("A host that answers the thread check is marked dirty where it stands"
     /// offers the thread check; against one, the mark belongs *here*, in the call,
     /// and a deferral would be a pointless round trip through the message loop.
     ///
-    /// \note An edit made in the *editor* is the main-thread route, and very
-    /// nearly the only one. `params.flush()` is `[active ? audio-thread :
-    /// main-thread]` (ext/params.h:303) and this plugin is active, so a host
-    /// event is an audio-thread event whether it arrives through flush() or
-    /// through process(); the case below is that half. What is left on the main
-    /// thread is the window: a knob, a preset load, a session restore.
+    /// \note The window is the main-thread route. `params.flush()` is `[active ?
+    /// audio-thread : main-thread]` (ext/params.h:303) and this plugin is
+    /// active, so a host event is an audio-thread event whether it arrives
+    /// through flush() or through process(); the case below is that half.
+    ///
+    /// \note A knob is *not* the trigger any more, which is what the case below
+    /// this one is about: a parameter change marks the state dirty implicitly, so
+    /// the editor announces only what is not one. \see issue #219.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    Entry const entry;
+    TestHost host{TestHost::everything()};
+    ActivePlugin plugin(48000, 512, host);
+
+    unsigned const callbacksBefore(host.mainThreadCallbacks);
+
+    // the preset comment's route, and what markStateModified() is for
+    editorHostOf(*plugin).markStateModified();
+
+    // It asked...
+    CHECK(host.threadChecks > 0);
+    // ...and acted on the answer, without a callback to come back on.
+    CHECK(host.dirtyMarks > 0);
+    CHECK(host.mainThreadCallbacks == callbacksBefore);
+}
+
+TEST_CASE("A knob does not mark the session dirty", "[clap][host]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    ///   ext/state.h: "If a parameter value changes, then it is implicit that
+    /// the state is dirty". The value still reaches the host -- that is the
+    /// gesture case further down -- so nothing is lost by keeping quiet, and a
+    /// host is entitled to answer `mark_dirty` however it likes.
+    ///
+    ///   REAPER answers it by re-reading every parameter it has, and finds each
+    /// one's index by walking `get_info` from zero. At 696 parameters that is
+    /// 696 squared calls per sweep, on the main thread, and a drag calling it
+    /// once per mouse move held the interface at 24 frames a second.
+    /// \see issue #219.
     ///
     ////////////////////////////////////////////////////////////////////////////
     Entry const entry;
@@ -126,17 +160,19 @@ TEST_CASE("A host that answers the thread check is marked dirty where it stands"
     target.binaryValue = global.id;
 
     unsigned const callbacksBefore(host.mainThreadCallbacks);
+    unsigned const marksBefore(host.dirtyMarks);
 
     editorHostOf(*plugin).automation().automatedParameterChanged(
         target,
         {static_cast<float>(wanted),
          static_cast<float>((wanted - global.min_value) / (global.max_value - global.min_value))});
 
-    // It asked...
-    CHECK(host.threadChecks > 0);
-    // ...and acted on the answer, without a callback to come back on.
-    CHECK(host.dirtyMarks > 0);
+    // neither the call nor the deferral that would end in one
+    CHECK(host.dirtyMarks == marksBefore);
     CHECK(host.mainThreadCallbacks == callbacksBefore);
+
+    // and the edited flag, which the browser's Save buttons read, is set anyway
+    CHECK(editorHostOf(*plugin).loadedPreset().modified.load());
 }
 
 TEST_CASE("The same host is not marked dirty from inside the audio callback", "[clap][host]")


### PR DESCRIPTION
clap/ext/state.h makes a parameter change imply a dirty state, so the mark_dirty alongside it was redundant. REAPER answers one by re-reading every parameter and finding each index by walking get_info from zero -- at 696 parameters, a drag calling it per mouse move held the editor at 24 frames a second. Non-parameter changes still announce themselves.

Closes #219

Assisted-by: Claude Opus 5 (1M context)