### PR TITLE
Wake the main thread for a parameter the host wrote

### DIFF
--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -804,7 +804,10 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
 
     // the host moving a parameter is an edit; drainCommands() applying what the
     // interface queued is not, the interface having already reported it
-    markCurrentProgramAsModified();
+    //
+    // the flag alone, as an editor edit gets: the host wrote this one, and
+    // ext/state.h makes a parameter change dirty without being told \see #225
+    markCurrentProgramAsEdited();
 
     // the main thread's copy of the same state, and not gated on there being an
     // editor: paramsValue and stateSave read programMain_ with the window shut
@@ -815,8 +818,11 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
     // a dropped echo leaves programMain_ behind the engine for that parameter
     // permanently, this being the only thing that carries a host's write across
     if (applied == Plugins::ErrorCode<Protocol>::Success)
+    {
         pushed(toUI_.push(Threading::baseParameterChanged(parameterID.binaryValue, value)),
                "The echo queue is full; the main thread's Program is now behind the engine.");
+        requestEchoDrain();
+    }
 
     // only a module-chain parameter changes what the *other* parameters are: it
     // decides which effect a slot holds, and so how many that slot has and what
@@ -838,6 +844,14 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
         requestRescan(CLAP_PARAM_RESCAN_VALUES);
 
     return isSlotSelector && (effectBefore != effectAfter);
+}
+
+/// \note `[thread-safe]`, which `clap_host::request_callback` is, and reached
+/// from the audio thread.
+void SpectrumWorxCLAP::requestEchoDrain()
+{
+    if (!pendingEchoDrain_.exchange(true, std::memory_order_acq_rel))
+        _host.requestCallback();
 }
 
 void SpectrumWorxCLAP::requestRescan(clap_param_rescan_flags const flags)
@@ -1209,6 +1223,9 @@ void SpectrumWorxCLAP::runEngine(clap_process const *const process, std::uint32_
 
 void SpectrumWorxCLAP::onMainThread() noexcept
 {
+    // cleared before the drain, so an echo pushed while it runs asks again
+    // rather than being swallowed
+    pendingEchoDrain_.store(false, std::memory_order_release);
     drainEngineEvents();
 
     // the other half of the fallback in process(): resync for the failure case,

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -200,6 +200,12 @@ class SpectrumWorxCLAP final
     /// that the state is dirty". \see issue #219.
     void markCurrentProgramAsEdited() const;
 
+    /// \brief Asks the host for the callback that drains the echo ring.
+    ///
+    /// \note Coalesced: the drain takes the whole ring, so one outstanding
+    /// request covers however many events a block carried.
+    void requestEchoDrain();
+
   public:
     explicit SpectrumWorxCLAP(clap_host const *);
     ~SpectrumWorxCLAP() override;
@@ -563,6 +569,15 @@ class SpectrumWorxCLAP final
     /// parameter event in process(). Mutable because marking tells the host
     /// something and changes nothing about the plugin.
     mutable std::atomic<bool> pendingMarkDirty_{false};
+
+    /// \brief An echo is on the ring and the main thread has not been woken.
+    ///
+    /// \note Its own flag since issue #225. The wake-up used to arrive as a side
+    /// effect of `markSessionAsUnsaved()`'s deferral, so when a parameter write
+    /// stopped announcing itself the echo sat there: the interface did not move
+    /// and `paramsValue` answered from a `programMain_` blocks behind the engine.
+    /// Draining the ring is not the same errand as telling the host to save.
+    std::atomic<bool> pendingEchoDrain_{false};
 
     /// What the editor moved, waiting for a process() or flush() to carry it to
     /// the host.

--- a/tests/clap/hostInteropTests.cpp
+++ b/tests/clap/hostInteropTests.cpp
@@ -39,6 +39,7 @@
 #include "core/parameterID.hpp"
 #include "core/threading/threadCheck.hpp"
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstring>
@@ -65,6 +66,22 @@ clap_param_info firstGlobalParameter(clap_plugin const &plugin, clap_plugin_para
         if (std::strcmp(info.module, "Global") == 0)
             return info;
     FAIL("no global parameter");
+    return {};
+}
+
+/// \brief The slot selector for module \p slot, as the host is shown it.
+clap_param_info slotSelector(clap_plugin const &plugin, clap_plugin_params const &params,
+                             std::uint8_t const slot)
+{
+    for (auto const &info : allParameterInfo(plugin, params))
+    {
+        LE::SW::ParameterID parameterID;
+        parameterID.binaryValue = info.id;
+        if ((parameterID.type() == LE::SW::ParameterID::ModuleChainParameter) &&
+            (parameterID.value._.moduleChain.moduleIndex == slot))
+            return info;
+    }
+    FAIL("no slot selector for that module");
     return {};
 }
 
@@ -181,14 +198,18 @@ TEST_CASE("The same host is not marked dirty from inside the audio callback", "[
     // this different from the deferral a thread-check-less host gets. The plugin
     // asks, is told this is not the main thread, and defers on the strength of
     // the answer rather than on the absence of one.
+    //
+    // A slot change carries it, since issue #225: an ordinary parameter write is
+    // implicitly dirty and no longer announces itself, so it would leave nothing
+    // to defer. Filling a slot changes the shape of the parameter list.
     Entry const entry;
     TestHost host{TestHost::everything()};
     ActivePlugin plugin(48000, 512, host);
 
     auto const &params(parameters(*plugin));
-    auto const global(firstGlobalParameter(*plugin, params));
+    auto const selector(slotSelector(*plugin, params, 0));
 
-    OneParameterEvent const edit(global.id, aDifferentValue(*plugin, params, global));
+    OneParameterEvent const edit(selector.id, selector.min_value + 1);
 
     std::vector<float> leftIn(512, 0.0f), rightIn(512, 0.0f);
     std::vector<float> leftOut(512), rightOut(512);
@@ -206,6 +227,50 @@ TEST_CASE("The same host is not marked dirty from inside the audio callback", "[
 ////////////////////////////////////////////////////////////////////////////////
 // What the editor sends out
 ////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A parameter the host writes reaches the main thread unprompted", "[clap][host]")
+{
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    ///   The engine applies a host's write on the audio thread and echoes it over
+    /// `toUI_`; `drainEngineEvents()` is what turns that into `programMain_` and
+    /// a moving control, and it runs on the callback. So the push has to *ask*
+    /// for one -- nothing else on this path will.
+    ///
+    ///   It used to arrive by accident. `markSessionAsUnsaved()` deferred through
+    /// `request_callback`, so every parameter event armed a callback whether or
+    /// not anything needed draining, and issue #225 stopped calling it. The suite
+    /// stayed green: automation moved nothing until a save or a gesture happened
+    /// past, and then the whole backlog arrived at once.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    Entry const entry;
+    TestHost host{TestHost::everything()};
+    ActivePlugin plugin(48000, 512, host);
+
+    auto const &params(parameters(*plugin));
+    auto const global(firstGlobalParameter(*plugin, params));
+    auto const wanted(aDifferentValue(*plugin, params, global));
+
+    unsigned const callbacksBefore(host.mainThreadCallbacks);
+
+    OneParameterEvent const write(global.id, wanted);
+
+    std::vector<float> leftIn(512, 0.0f), rightIn(512, 0.0f);
+    std::vector<float> leftOut(512), rightOut(512);
+    plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr, &*write);
+
+    // the ask, which is the half that went missing
+    CHECK(host.mainThreadCallbacks > callbacksBefore);
+
+    // and what the ask is for: the main thread's copy, which paramsValue answers
+    // from and which a control redraws off
+    plugin.pumpMainThread();
+
+    double readBack{0};
+    REQUIRE(params.get_value(&*plugin, global.id, &readBack));
+    CHECK(readBack == Catch::Approx(wanted));
+}
 
 TEST_CASE("A knob drag reaches the host as a balanced gesture around its value", "[clap][host]")
 {
@@ -646,25 +711,6 @@ TEST_CASE("Learning the host's tempo does not move the LFO periods", "[clap][hos
 // What counts as the chain having changed
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace
-{
-/// \brief The slot selector for module \p slot, as the host is shown it.
-clap_param_info slotSelector(clap_plugin const &plugin, clap_plugin_params const &params,
-                             std::uint8_t const slot)
-{
-    for (auto const &info : allParameterInfo(plugin, params))
-    {
-        LE::SW::ParameterID parameterID;
-        parameterID.binaryValue = info.id;
-        if ((parameterID.type() == LE::SW::ParameterID::ModuleChainParameter) &&
-            (parameterID.value._.moduleChain.moduleIndex == slot))
-            return info;
-    }
-    FAIL("no slot selector for that module");
-    return {};
-}
-} // anonymous namespace
-
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// \note The regression this file exists to hold on to. `handleEvent()` decides
@@ -678,10 +724,12 @@ clap_param_info slotSelector(clap_plugin const &plugin, clap_plugin_params const
 /// it write the parameter set back. \see issue #172 and the note on the return
 /// value in `handleEvent()`.
 ///
-/// \note `rescanFlags` and not `mainThreadCallbacks`, which cannot tell these
-/// cases apart: `markCurrentProgramAsModified()` asks for a callback on the same
-/// path, so *any* parameter event arms one. What is being pinned is narrower --
-/// that the callback, when it runs, has no rescan to deliver.
+/// \note `rescanFlags` and not `mainThreadCallbacks`. It used to be that
+/// `markCurrentProgramAsModified()` armed a callback on the same path, so *any*
+/// parameter event set one going and the two cases could not be told apart that
+/// way; since issue #225 only a chain change does. The narrower claim is the one
+/// worth pinning either way -- that the callback, when it runs, has no rescan to
+/// deliver.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/core/threadCheckTests.cpp
+++ b/tests/core/threadCheckTests.cpp
@@ -17,6 +17,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 //------------------------------------------------------------------------------
+#include "core/parameterID.hpp"
 #include "core/threading/threadCheck.hpp"
 
 #include "swClapEntryImpl.hpp"
@@ -63,9 +64,14 @@ Observation observation;
 ///
 /// \note That combination is what makes `markCurrentProgramAsModified()` defer:
 /// it cannot ask which thread it is on, so it records the intent and calls
-/// `request_callback`, which is `[thread-safe]`. Any parameter event delivered to
+/// `request_callback`, which is `[thread-safe]`. A slot change delivered to
 /// process() therefore reaches this host callback from inside the audio callback,
 /// which is the observation point -- no test hook in the plugin, just the API.
+///
+/// \note A slot change and not any parameter, since issue #225: an ordinary
+/// parameter write is a dirty state implicitly and no longer announces itself, so
+/// it would arrive here silently. Filling a slot changes the shape of the
+/// parameter list, which the host does have to be told about.
 clap_host const &observingHost()
 {
     static clap_host_state const state{
@@ -264,12 +270,21 @@ TEST_CASE("The plugin calls its host back from inside the audio callback",
         static_cast<clap_plugin_params const *>(pPlugin->get_extension(pPlugin, CLAP_EXT_PARAMS)));
     REQUIRE(pParams != nullptr);
 
-    // Index 0 is a global parameter, so it exists whatever is in the slots -- a
-    // parameter no effect owns is dropped by handleEvent() before it reaches the
-    // host callback this is watching for.
+    // the selector for the first slot, which starts empty: min_value is
+    // `noModule` and one above it is the first effect, so this genuinely fills it
     clap_param_info info{};
-    REQUIRE(pParams->get_info(pPlugin, 0, &info));
-    OneEvent const event(info.id, info.default_value);
+    bool found(false);
+    for (std::uint32_t index(0); !found && (index < pParams->count(pPlugin)); ++index)
+    {
+        REQUIRE(pParams->get_info(pPlugin, index, &info));
+        LE::SW::ParameterID parameterID;
+        parameterID.binaryValue = info.id;
+        found = (parameterID.type() == LE::SW::ParameterID::ModuleChainParameter) &&
+                (parameterID.value._.moduleChain.moduleIndex == 0);
+    }
+    REQUIRE(found);
+
+    OneEvent const event(info.id, info.min_value + 1);
 
     std::vector<float> leftIn(blockSize, 0.0f), rightIn(blockSize, 0.0f);
     std::vector<float> leftOut(blockSize, 0.0f), rightOut(blockSize, 0.0f);
@@ -298,6 +313,7 @@ TEST_CASE("The plugin calls its host back from inside the audio callback",
     // on, so it deferred -- and the deferral is only correct if it really does
     // arrive later.
     CHECK(observation.markedDirty.load() == 0);
+
     pPlugin->on_main_thread(pPlugin);
     CHECK(observation.markedDirty.load() == 1);
 


### PR DESCRIPTION
A host's parameter write is applied on the audio thread and echoed for the main thread to pick up, and REAPER answers the mark_dirty that used to carry it by re-reading all 696 parameters -- 62% of the message thread while an automation lane moves.

Marking dirty was redundant anyway; ext/state.h makes a parameter change imply it. But that call was also the only thing asking for the callback that drains the echo, so dropping it alone left automation moving nothing until a save happened past and the whole backlog arrived at once. Draining the echo is now its own request.

The two cases pinning the deferral moved to a slot change, which still has something to announce, and a new one holds on to the wake-up.

Closes #225

Assisted-by: Claude Opus 5 (1M context)