### PR TITLE
Ask clap-helpers for minimal contract checking

### DIFF
--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -55,7 +55,8 @@ clap_plugin_descriptor const *descriptor();
 clap_plugin const *createPlugin(clap_host const *);
 
 static constexpr auto misbehaviourLevel = clap::helpers::MisbehaviourHandler::Ignore;
-static constexpr auto checkingLevel = clap::helpers::CheckingLevel::Maximal;
+// not Maximal: it answers every get_value by walking the whole parameter list
+static constexpr auto checkingLevel = clap::helpers::CheckingLevel::Minimal;
 
 using PluginHelper = clap::helpers::Plugin<misbehaviourLevel, checkingLevel>;
 


### PR DESCRIPTION
CheckingLevel::Maximal answers every clap_plugin_params.get_value and every value_to_text by walking the whole parameter list looking for the id -- 696 get_info calls each -- inside the plugin, before the host sees anything. It is the quadratic behaviour issue #223 was chasing, and it was ours, not the host's: a 26 second REAPER session that reads 5,700 parameter values spent 4 million get_info calls on it.

A fix for the underlying walk is in flight upstream at https://github.com/free-audio/clap-helpers/pull/100 - Once it lands and the submodule moves, Maximal costs one get_info per lookup instead of 696 and this can go back.

Part of #223

Assisted-by: Claude Opus 5 (1M context)