### PR TITLE
Animate the module rack when it changes

### DIFF
--- a/src/gui.cmake
+++ b/src/gui.cmake
@@ -57,6 +57,7 @@ target_compile_definitions(sw-gui-resources PRIVATE LE_ENABLE_ASSERT_HANDLER)
 ################################################################################
 
 add_library(sw-gui-widgets STATIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/gui/animation.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/gui.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gui/preferences.cpp
 )

--- a/src/gui/animation.cpp
+++ b/src/gui/animation.cpp
@@ -1,0 +1,167 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file animation.cpp
+/// -------------------
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "animation.hpp"
+
+/// `fadeOutComponent()`, which is the shrink and already guards the display list.
+#include "gui.hpp"
+#include "preferences.hpp"
+
+#include "le/utility/assert.hpp"
+
+namespace LE::SW::GUI
+{
+
+namespace
+{
+/// \note getBounds() is the untransformed rectangle -- JUCE keeps the two apart --
+/// so the pivot does not drift as the scale is reapplied frame by frame.
+void scaleAboutCentre(juce::Component &component, float const scale)
+{
+    auto const centre(component.getBounds().getCentre().toFloat());
+    component.setTransform(juce::AffineTransform::scale(scale, scale, centre.x, centre.y));
+}
+/// \note Zero stays zero, so the "should I" test survives the scaling.
+unsigned int growAndShrinkMilliseconds(AnimationStyle const style)
+{
+    return static_cast<unsigned int>(millisecondsFor(style) * growAndShrinkFactor);
+}
+} // namespace
+
+char const *nameOf(AnimationStyle const style)
+{
+    switch (style)
+    {
+    case NoAnimation:
+        return "NoAnimation";
+    case FastAnimation:
+        return "FastAnimation";
+    case SlowAnimation:
+        return "SlowAnimation";
+    case numberOfAnimationStyles:
+        break;
+    }
+    LE_UNREACHABLE_CODE();
+}
+
+unsigned int millisecondsFor(AnimationStyle const style)
+{
+    switch (style)
+    {
+    case NoAnimation:
+        return 0;
+    case FastAnimation:
+        return fastAnimationMilliseconds;
+    case SlowAnimation:
+        return slowAnimationMilliseconds;
+    case numberOfAnimationStyles:
+        break;
+    }
+    LE_UNREACHABLE_CODE();
+}
+
+AnimationStyle styleFor(juce::Component const &component)
+{
+    // nothing to see, so nothing to spend frames on
+    if (!component.isShowing())
+        return NoAnimation;
+
+    // asking is fatal rather than merely pointless with no displays: the
+    // animator's proxy dereferences getDisplayForRect(), which is null then
+    if (juce::Desktop::getInstance().getDisplays().displays.isEmpty())
+        return NoAnimation;
+
+    return preferences().animationStyle();
+}
+
+void moveTo(juce::Component &component, int const x, int const y)
+{
+    auto &animator(juce::Desktop::getInstance().getAnimator());
+    auto const target(component.getBounds().withPosition(x, y));
+
+    // where it is when nothing is running, so this is both "already there" and
+    // "already going there"
+    if (animator.getComponentDestination(&component) == target)
+        return;
+
+    auto const milliseconds(millisecondsFor(styleFor(component)));
+    if (milliseconds == 0)
+    {
+        // the style can be turned off with one in flight
+        animator.cancelAnimation(&component, false);
+        component.setTopLeftPosition(x, y);
+        return;
+    }
+
+    animator.animateComponent(&component, target, 1.0f, static_cast<int>(milliseconds), false,
+                              slideStartSpeed, slideEndSpeed);
+}
+
+void shrinkAway(juce::Component &component)
+{
+    if (auto const milliseconds = growAndShrinkMilliseconds(styleFor(component)); milliseconds != 0)
+        fadeOutComponent(component, 0, milliseconds, true);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// GrowIn
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// \note Stops, and deliberately does not put the transform back: this is held by
+/// the component it grows, so by the time it runs that component is already
+/// inside its own destructor and is in no state to be told it moved.
+GrowIn::~GrowIn() { stopTimer(); }
+
+void GrowIn::start(juce::Component &component)
+{
+    auto const milliseconds(growAndShrinkMilliseconds(styleFor(component)));
+    if (milliseconds == 0)
+        return;
+
+    finish(); // a strip told to grow twice starts again rather than jumping
+
+    pComponent_ = &component;
+    duration_ = static_cast<int>(milliseconds);
+    elapsed_ = 0;
+    scaleAboutCentre(component, initialGrowScale);
+    startTimer(animationFrameMilliseconds);
+}
+
+void GrowIn::timerCallback()
+{
+    elapsed_ += animationFrameMilliseconds;
+
+    if (!pComponent_ || (elapsed_ >= duration_))
+    {
+        finish();
+        return;
+    }
+
+    auto const progress(static_cast<float>(elapsed_) / static_cast<float>(duration_));
+    // smoothstep, so it settles instead of stopping dead -- the ease
+    // juce::ComponentAnimator gives the slide running beside it
+    auto const eased(progress * progress * (3.0f - 2.0f * progress));
+    scaleAboutCentre(*pComponent_, initialGrowScale + (1.0f - initialGrowScale) * eased);
+}
+
+void GrowIn::finish()
+{
+    stopTimer();
+    if (pComponent_)
+        pComponent_->setTransform(juce::AffineTransform());
+    pComponent_ = nullptr;
+    elapsed_ = duration_ = 0;
+}
+
+//------------------------------------------------------------------------------
+} // namespace LE::SW::GUI
+//------------------------------------------------------------------------------

--- a/src/gui/animation.hpp
+++ b/src/gui/animation.hpp
@@ -1,0 +1,186 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file animation.hpp
+/// -------------------
+///
+///   How a module strip moves when the rack changes under it, and the one place
+/// the timings are written down.
+///
+///   The rack is recomputed rather than updated -- resyncModuleRack() makes it a
+/// function of the chain -- so every strip that has to move is told a new slot
+/// and every strip that has to go is destroyed. Both are instantaneous, and this
+/// is what puts a few frames between the two states so a user can see which
+/// strip went where.
+///
+/// \note Three motions, and they compose: a strip *slides* to a slot it did not
+/// use to be in, *grows* when it is new, and *shrinks* when it is destroyed. An
+/// add is a grow with the strips after it sliding right, a delete is a shrink
+/// with the strips after it sliding left, and a drag is sliding on its own.
+///
+/// \note Two mechanisms behind them, and not by preference. The slide and the
+/// shrink are juce::ComponentAnimator's, which is where the shrink already was.
+/// The grow cannot be: the animator's proxy takes its snapshot at the
+/// component's *current* size, so it can animate away from a full-size strip and
+/// never towards one, and animating the real bounds is no good either because a
+/// strip's children sit at fixed offsets and a half-height one would show its
+/// top half rather than a small copy. So the grow is a scale transform, which is
+/// how ZoomedEditor already draws the whole editor at 150%.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef animation_hpp__A3F1C0D5_7B24_4E68_9C1A_5D0E82B6F413
+#define animation_hpp__A3F1C0D5_7B24_4E68_9C1A_5D0E82B6F413
+//------------------------------------------------------------------------------
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <cstdint>
+
+namespace LE::SW::GUI
+{
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief What the user picked on the Interface page.
+///
+/// \note Streamed by name, like the palette, so a value added here cannot change
+/// what an existing preferences file means. \see Preferences::animationStyle().
+///
+////////////////////////////////////////////////////////////////////////////////
+
+enum AnimationStyle : std::uint8_t
+{
+    NoAnimation,
+    FastAnimation,
+    SlowAnimation,
+
+    numberOfAnimationStyles
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Calibration
+//
+//   Everything about how the rack feels is these numbers. A style is a duration
+// and nothing else, so a fourth one is a name and a number.
+////////////////////////////////////////////////////////////////////////////////
+
+/// \brief What a style means, and what the other timings here are relative to:
+/// how long a strip takes to slide one slot.
+inline constexpr unsigned int fastAnimationMilliseconds{150};
+inline constexpr unsigned int slowAnimationMilliseconds{350};
+
+/// \brief How much longer a strip takes to grow or shrink than to slide.
+/// \note Equal durations are not equal speeds: a slide crosses a whole slot and
+/// a grow crosses half a strip, so matching the two makes an add read as a
+/// flicker next to a drag that reads as a move.
+inline constexpr float growAndShrinkFactor{1.2f};
+
+/// \note juce::ComponentAnimator's easing, for the slide and the shrink: zero at
+/// both ends accelerates from rest and settles rather than stopping dead.
+inline constexpr double slideStartSpeed{0.0};
+inline constexpr double slideEndSpeed{0.0};
+
+/// \brief How small a strip starts before it grows, as a fraction of itself.
+/// \note Not zero: a zero scale is a singular transform, and JUCE maps points
+/// through this one to decide what the mouse is over.
+inline constexpr float initialGrowScale{0.08f};
+
+/// \note 60 Hz, which is a frame on the displays this runs on and is the rate
+/// juce::ComponentAnimator picks for itself.
+inline constexpr int animationFrameMilliseconds{1000 / 60};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// \brief The enumerator's own spelling, which is what goes in the file.
+char const *nameOf(AnimationStyle);
+
+/// \brief How long \p style gives a slide, and zero for NoAnimation -- which is
+/// how everything here asks "should I". A grow and a shrink take
+/// growAndShrinkFactor of it.
+unsigned int millisecondsFor(AnimationStyle);
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The style \p component would move with, which is NoAnimation whenever
+/// moving it could not be seen.
+///
+/// \note The screen test rather than the preference alone, and it is doing three
+/// jobs: it keeps the rack the editor builds in its own constructor from growing
+/// in one strip at a time, it keeps an offscreen render from catching a strip
+/// mid-scale, and it keeps the headless suites -- which never put the editor on
+/// a desktop -- reading final positions instead of interpolated ones.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+AnimationStyle styleFor(juce::Component const &);
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Slides \p component to (\p x, \p y), or puts it there.
+///
+/// \note Idempotent, which matters because the rack is recomputed: a resync
+/// tells every surviving strip its slot whether or not it changed, and several
+/// can be queued. A component already there, or already on its way there, is
+/// left alone rather than restarted from wherever the last one had got to.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void moveTo(juce::Component &, int x, int y);
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief Shrinks \p component to nothing where it stands.
+///
+/// \note For a component about to be destroyed, and it must be called from the
+/// destructor rather than before it: what animates is a snapshot the animator
+/// takes here and owns, so the strip itself can go as soon as this returns.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+void shrinkAway(juce::Component &);
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \class GrowIn
+///
+/// \brief Scales a component up from nothing about its own centre.
+///
+/// \note Held by the component it grows, so that a strip destroyed mid-grow takes
+/// its timer with it. The transform is cleared at the end and by the destructor,
+/// because a component left transformed is one whose getBounds() no longer says
+/// where it is on screen.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+class GrowIn final : private juce::Timer
+{
+  public:
+    GrowIn() = default;
+    ~GrowIn() override;
+
+    GrowIn(GrowIn const &) = delete; // makes non-copyable
+    GrowIn &operator=(GrowIn const &) = delete;
+
+    /// \brief Starts \p component at initialGrowScale and runs it up to itself.
+    /// \note Does nothing under NoAnimation, which includes a component that is
+    /// not on screen -- so a strip built for the rack the editor opens with is
+    /// simply there. \see styleFor().
+    void start(juce::Component &);
+
+  private:
+    void timerCallback() override;
+
+    /// \brief Puts the transform back and stops.
+    void finish();
+
+    juce::Component::SafePointer<juce::Component> pComponent_;
+    int elapsed_{0};
+    int duration_{0};
+}; // class GrowIn
+
+//------------------------------------------------------------------------------
+} // namespace LE::SW::GUI
+//------------------------------------------------------------------------------
+#endif // animation_hpp

--- a/src/gui/editor/spectrumWorxEditor.cpp
+++ b/src/gui/editor/spectrumWorxEditor.cpp
@@ -2047,6 +2047,7 @@ void SpectrumWorxEditor::createModuleRegion(LE::Utility::IntrusivePtr<Module> co
             return;
         }
         addToParentAndShow(mainArea_, *pRegion);
+        pRegion->growIntoSlot();
         return;
     }
 
@@ -2337,9 +2338,11 @@ SpectrumWorxEditor::ModuleMenuButton::ModuleMenuButton(SpectrumWorxEditor &paren
 void SpectrumWorxEditor::ModuleMenuButton::moveToSlot(std::uint8_t const slotIndex)
 {
     //...mrmlj..."magic number" adjustments...
-    setTopLeftPosition(6 + ModuleUI::horizontalOffset +
-                           ((ModuleUI::width + ModuleUI::distance) * slotIndex),
-                       (ModuleUI::verticalOffset - 6) + (ModuleUI::height / 2) - (getHeight() / 2));
+    moveTo(*this,
+           6 + ModuleUI::horizontalOffset + ((ModuleUI::width + ModuleUI::distance) * slotIndex),
+           (ModuleUI::verticalOffset - 6) + (ModuleUI::height / 2) - (getHeight() / 2));
+    // after the move, so that one coming back to a rack that filled up arrives
+    // where it belongs rather than sliding in from where it was hidden
     setIsVisible(slotIndex < SW::Constants::maxNumberOfModules);
 }
 
@@ -3637,6 +3640,10 @@ void SpectrumWorxEditor::Settings::comboBoxValueChanged(ComboBox const &comboBox
     {
         editor.setPalette(static_cast<ColourMap::Palette>(value));
     }
+    else if (&comboBox == &settings.interfacePage_.animationComboBox())
+    {
+        preferences().setAnimationStyle(static_cast<AnimationStyle>(value));
+    }
     else
     {
         LE_UNREACHABLE_CODE();
@@ -3771,11 +3778,12 @@ void SpectrumWorxEditor::Settings::EnginePage::paint(juce::Graphics &g)
 SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     : PanelBackground(SettingsPage), zoom_(*this, xMargin, yMargin + 0 * yStep + yOffset, "Zoom"),
       palette_(*this, xMargin, yMargin + 1 * yStep + yOffset, "Color Scheme"),
-      showLFOAnimation_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset,
+      animation_(*this, xMargin, yMargin + 2 * yStep + yOffset, "Module Animations"),
+      showLFOAnimation_(*this, xMargin - 4, yMargin + 3 * yStep + yOffset,
                         "Animate LFO modulations"),
-      previewLFOOnHover_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + ledStep,
+      previewLFOOnHover_(*this, xMargin - 4, yMargin + 3 * yStep + yOffset + ledStep,
                          "Hover shows LFO settings"),
-      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 2 * yStep + yOffset + 2 * ledStep,
+      hideCursorOnKnobDrag_(*this, xMargin - 4, yMargin + 3 * yStep + yOffset + 2 * ledStep,
                             "Hide cursor on knob edits")
 {
     Settings &parent(
@@ -3809,6 +3817,12 @@ SpectrumWorxEditor::Settings::InterfacePage::InterfacePage()
     palette_.addItem(ColourMap::DarkPurple, "Dark Purple");
     palette_.addItem(ColourMap::DarkGray, "Dark Gray");
     palette_.setSelectedIndex(preferences().palette());
+
+    // spelled here rather than taken from nameOf(), for the reason above
+    animation_.addItem(NoAnimation, "None");
+    animation_.addItem(FastAnimation, "Fast");
+    animation_.addItem(SlowAnimation, "Slow");
+    animation_.setSelectedIndex(preferences().animationStyle());
 
     showLFOAnimation_.setToggleState(preferences().showLFOAnimation(), juce::dontSendNotification);
     showLFOAnimation_.addListener(&parent);

--- a/src/gui/editor/spectrumWorxEditor.hpp
+++ b/src/gui/editor/spectrumWorxEditor.hpp
@@ -1477,6 +1477,7 @@ class SpectrumWorxEditor final : private SkinLifetime,
             InterfacePage();
 
             TitledComboBox const &paletteComboBox() const { return palette_; }
+            TitledComboBox const &animationComboBox() const { return animation_; }
 
           private: // JUCE component overrides.
             void paint(juce::Graphics &) override;
@@ -1487,11 +1488,12 @@ class SpectrumWorxEditor final : private SkinLifetime,
           private:
             friend class Settings;
             /// \note Zoom first and the colour scheme under it, those being the
-            /// two a user reaches for, then the three switches. Each control
-            /// draws its own title, so the order is a layout decision rather than
-            /// an artwork one.
+            /// two a user reaches for, then how the rack moves, then the three
+            /// switches. Each control draws its own title, so the order is a
+            /// layout decision rather than an artwork one.
             TitledComboBox zoom_;
             TitledComboBox palette_;
+            TitledComboBox animation_;
             LEDTextButton showLFOAnimation_;
             LEDTextButton previewLFOOnHover_;
             LEDTextButton hideCursorOnKnobDrag_;

--- a/src/gui/modules/moduleUI.cpp
+++ b/src/gui/modules/moduleUI.cpp
@@ -692,7 +692,10 @@ ModuleUI::~ModuleUI()
         LE_ASSERT(!hasFocus());
     }
 
-    fadeOutComponent(*this, 0, 600, true);
+    // before the shrink, which is a snapshot: a strip dropped mid-grow would
+    // otherwise be photographed small and shrink from there
+    setTransform(juce::AffineTransform());
+    shrinkAway(*this);
 }
 
 void ModuleUI::setUpForEffect(char const *const effectName, char const *const effectDescription)
@@ -703,6 +706,8 @@ void ModuleUI::setUpForEffect(char const *const effectName, char const *const ef
     description_ = effectDescription;
 }
 
+/// \note `slot_` is assigned now and the pixels arrive over the next few frames.
+/// That gap is why every caller reads slot() rather than getX(). \see GUI::moveTo().
 void ModuleUI::moveToSlot(std::uint8_t const slotIndex)
 {
     /// \note The assignment is new, and its absence was invisible for as long as
@@ -713,7 +718,7 @@ void ModuleUI::moveToSlot(std::uint8_t const slotIndex)
     /// without asking the chain.
     slot_ = slotIndex;
     std::uint16_t const myHorizontalOffset(horizontalOffset + slotIndex * (width + distance));
-    setTopLeftPosition(myHorizontalOffset, verticalOffset);
+    moveTo(*this, myHorizontalOffset, verticalOffset);
 }
 
 void ModuleUI::paint(juce::Graphics &graphics)

--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -13,6 +13,7 @@
 #ifndef moduleUI_hpp__8228E5F3_535E_4B08_9AD0_072C9fA7AD93
 #define moduleUI_hpp__8228E5F3_535E_4B08_9AD0_072C9fA7AD93
 //------------------------------------------------------------------------------
+#include "gui/animation.hpp"
 #include "gui/gui.hpp"
 #include "gui/painters/moduleKnobPainter.hpp"
 #include "gui/painters/moduleStripPainter.hpp"
@@ -509,6 +510,12 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
 
     void moveToSlot(std::uint8_t slotIndex);
 
+    /// \brief Scales the strip up from nothing where it stands.
+    /// \note Not the constructor's: a strip is parented after it is built, and
+    /// an unparented component is one styleFor() reads as off screen. \see
+    /// SpectrumWorxEditor::createModuleRegion().
+    void growIntoSlot() { growIn_.start(*this); }
+
     ModuleControlBase &effectSpecificParameterControl(std::uint8_t parameterIndex);
     ModuleControlBase const &effectSpecificParameterControl(std::uint8_t parameterIndex) const;
 
@@ -600,6 +607,10 @@ class ModuleUI final : public WidgetBase<>, private juce::Button::Listener
     juce::String description_;
 
     std::uint8_t slot_{0};
+
+    /// \note Last of the members, so that it stops before anything it could be
+    /// scaling is destroyed.
+    GrowIn growIn_;
 
   public:
     /// \note All std::uint16_t, including the four that fit in a byte. These are

--- a/src/gui/preferences.cpp
+++ b/src/gui/preferences.cpp
@@ -46,6 +46,7 @@ enum PreferenceKey
     hideCursorOnKnobDragKey,
     zoomPercentKey,
     paletteKey,
+    animationStyleKey,
     numberOfPreferenceKeys
 };
 
@@ -66,6 +67,8 @@ std::string preferenceKeyName(PreferenceKey const key)
         return "zoomPercent";
     case paletteKey:
         return "palette";
+    case animationStyleKey:
+        return "animationStyle";
     case numberOfPreferenceKeys:
         break;
     }
@@ -99,6 +102,22 @@ ColourMap::Palette paletteNamed(std::string const &name,
         auto const palette(static_cast<ColourMap::Palette>(index));
         if (name == ColourMap::nameOf(palette))
             return palette;
+    }
+    return valueIfUnrecognised;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The animation style, by name
+////////////////////////////////////////////////////////////////////////////////
+
+AnimationStyle animationStyleNamed(std::string const &name,
+                                   AnimationStyle const valueIfUnrecognised)
+{
+    for (unsigned int index(0); index < numberOfAnimationStyles; ++index)
+    {
+        auto const style(static_cast<AnimationStyle>(index));
+        if (name == nameOf(style))
+            return style;
     }
     return valueIfUnrecognised;
 }
@@ -146,6 +165,9 @@ Preferences::Preferences(fs::path const &folder) : storage_(std::make_unique<Sto
     palette_ = paletteNamed(provider.getUserDefaultValue(paletteKey, ColourMap::nameOf(palette_)),
                             palette_);
 
+    animationStyle_ = animationStyleNamed(
+        provider.getUserDefaultValue(animationStyleKey, nameOf(animationStyle_)), animationStyle_);
+
     hideCursorOnKnobDrag_ =
         provider.getUserDefaultValue(hideCursorOnKnobDragKey, hideCursorOnKnobDrag_) != 0;
 
@@ -183,6 +205,12 @@ void Preferences::setPalette(ColourMap::Palette const value)
 {
     palette_ = value;
     storage_->provider.updateUserDefaultValue(paletteKey, ColourMap::nameOf(value));
+}
+
+void Preferences::setAnimationStyle(AnimationStyle const value)
+{
+    animationStyle_ = value;
+    storage_->provider.updateUserDefaultValue(animationStyleKey, nameOf(value));
 }
 
 void Preferences::setHideCursorOnKnobDrag(bool const value)

--- a/src/gui/preferences.hpp
+++ b/src/gui/preferences.hpp
@@ -27,6 +27,9 @@
 #ifndef preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
 #define preferences_hpp__6F0B2C41_9D77_4A5E_8C3B_1E4A0D96B27F
 //------------------------------------------------------------------------------
+/// `AnimationStyle`, which is one of the answers.
+#include "animation.hpp"
+
 /// `ColourMap::Palette`, which is one of the answers.
 #include "colourMap.hpp"
 
@@ -52,8 +55,8 @@ namespace LE::SW::GUI
 /// its own key through, so the file is one rewrite per user click rather than
 /// five.
 ///
-/// \note The one enumeration in here -- the palette -- is streamed by *name*, not
-/// by ordinal, so inserting a value in the middle cannot silently change what an
+/// \note The enumerations in here -- the palette and the animation style -- are
+/// streamed by *name*, not by ordinal, so inserting a value in the middle cannot silently change what an
 /// existing file means and the file stays legible to whoever opens it. The names
 /// are the enum identifiers, so a value in the file can be grepped for in the
 /// source, and an unrecognised one reads as the default.
@@ -122,6 +125,19 @@ class Preferences
     bool previewLFOOnHover() const { return previewLFOOnHover_; }
 
     ColourMap::Palette palette() const { return palette_; }
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    /// \brief How the module rack moves when it changes, or NoAnimation.
+    ///
+    ///   A strip grows when it is added, shrinks when it is removed, and slides
+    /// when a slot ahead of it is filled or emptied. Under NoAnimation each of
+    /// those is where it ends up straight away. \see GUI::styleFor(), which is
+    /// what every caller asks rather than reading this directly -- it is also
+    /// NoAnimation whenever the motion could not be seen. Issue #47.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    AnimationStyle animationStyle() const { return animationStyle_; }
     bool hideCursorOnKnobDrag() const { return hideCursorOnKnobDrag_; }
     /// Always one of zoomPercentages.
     unsigned int zoomPercent() const { return zoomPercent_; }
@@ -133,6 +149,7 @@ class Preferences
     /// the two are done together -- \see SpectrumWorxEditor::setPalette(),
     /// which is the only place a user changes this.
     void setPalette(ColourMap::Palette);
+    void setAnimationStyle(AnimationStyle);
     void setHideCursorOnKnobDrag(bool);
     /// \note A percentage this build does not offer is ignored, for the same
     /// reason an unrecognised enumeration name is: the file is the user's to
@@ -152,6 +169,7 @@ class Preferences
     bool showLFOAnimation_{true};
     bool previewLFOOnHover_{true};
     ColourMap::Palette palette_{ColourMap::ClassicBlue};
+    AnimationStyle animationStyle_{FastAnimation};
     bool hideCursorOnKnobDrag_{true};
     unsigned int zoomPercent_{defaultZoomPercent};
 }; // class Preferences

--- a/tests/gui/preferencesTests.cpp
+++ b/tests/gui/preferencesTests.cpp
@@ -138,8 +138,8 @@ template <typename Widget> std::vector<Widget *> descendantsOfType(juce::Compone
 /// box arrived as a fourth and this said so.
 GUI::TitledComboBox &comboBoxOffering(Editor &editor, std::size_t const choices)
 {
-    /// Zoom and colour scheme, the page's three switches being LEDs.
-    std::size_t constexpr onTheInterfacePage{2};
+    /// Zoom, colour scheme and animations, the page's three switches being LEDs.
+    std::size_t constexpr onTheInterfacePage{3};
 
     auto const comboBoxes(descendantsOfType<GUI::TitledComboBox>(editor));
     REQUIRE(comboBoxes.size() == onTheInterfacePage);


### PR DESCRIPTION
A strip grows when it is added, shrinks when it is removed and slides when a slot ahead of it is filled or emptied, under a Module Animations setting on the Interface page offering None, Fast and Slow.

The shrink already existed -- it is what a destroyed strip did -- but only a delete at the end of the rack ever showed it. JUCE adds the snapshot it animates behind the strip it copied, and every survivor teleported into its new slot over the top of it, so a delete anywhere else looked like nothing at all. Making the survivors slide is what reveals the animation that was already there.

Every motion goes through ModuleUI::moveToSlot(), which is the one place a strip is placed, so a drag and a preset load animate for free. slot_ is assigned as it always was and only the pixels lag, which is why the rest of the editor reads slot() rather than getX().

The slide and the shrink are juce::ComponentAnimator's. The grow cannot be: its proxy snapshots the component at its current size, so it can animate away from a full-size strip and never towards one, and animating the real bounds is no good either because a strip's children sit at fixed offsets and a half-height one would show its top half rather than a small copy. So the grow is a scale transform, which is how ZoomedEditor already draws the editor at 150%.

Timings are one block at the top of gui/animation.hpp. A style is a slide duration and a grow or a shrink takes 1.2 of it -- equal durations are not equal speeds when a slide crosses a whole slot and a grow crosses half a strip.

Nothing animates off screen. That single test keeps the rack the editor builds in its own constructor instant, keeps an offscreen render from catching a strip mid-scale, and keeps the headless suites reading final positions rather than interpolated ones.

Part of #47

Assisted-by: Claude Opus 5 (1M context)