### PR TITLE
Paint a knob bipolar because its range is, not because of how it was spelt

### DIFF
--- a/src/gui/modules/moduleUI.hpp
+++ b/src/gui/modules/moduleUI.hpp
@@ -697,6 +697,44 @@ template <typename Parameter> struct ParameterWidget
 
 ////////////////////////////////////////////////////////////////////////////
 ///
+/// \var isBipolar
+///
+////////////////////////////////////////////////////////////////////////////
+
+/// \brief Which end a knob's wedge opens from: read off the parameter's range,
+/// not off which of the spellings happened to declare it.
+///
+///   Bipolar painting opens the wedge from twelve o'clock, which is the centre
+/// of the knob's *travel*; that coincides with the value zero only where the
+/// range is symmetric about it. So range symmetry is the question, and
+/// SymmetricInteger and SymmetricFloat -- which build their range as
+/// [ -MaximumOffset, +MaximumOffset ] and carry SymmetricParameterTag for it --
+/// are one way of arriving at the answer rather than the definition of it.
+///
+///   The tag was the whole test until 09.2026, and Imploder/Exploder's Glissando
+/// is what that got wrong: +/-300 cents, as bipolar as Pitch Shifter's Cents,
+/// and painted from the left stop. Nothing is wrong with the parameter. It is
+/// spelt LinearSignedInteger because its default is -100, and a Symmetric
+/// parameter's default is always zero -- Symmetric derives its entire range from
+/// the one offset, so it cannot say "symmetric range, off-centre default" at
+/// all. Talking Wind's envelope gain, +/-10 dB, was the same mistake in a float.
+///
+/// \note A range that merely reaches below zero is not this: Imploder's
+/// Threshold runs -120 .. 0 dB, whose centre is -60 dB, and a wedge opening from
+/// there would be growing out of a value that means nothing.
+///
+/// \note The unscaled bounds rather than minimum() and maximum(): those are
+/// functions, while these are the compile-time integers every knob-bearing
+/// parameter has -- linear, symmetric and power-of-two alike -- and for a float
+/// parameter the accessors return a value already divided by the denominator
+/// that both bounds share and symmetry does not care about.
+template <class Parameter>
+bool constexpr isBipolar{(static_cast<std::int64_t>(Parameter::unscaledMaximum) > 0) &&
+                         (static_cast<std::int64_t>(Parameter::unscaledMinimum) ==
+                          -static_cast<std::int64_t>(Parameter::unscaledMaximum))};
+
+////////////////////////////////////////////////////////////////////////////
+///
 /// \class WidgetInitialiser
 ///
 ////////////////////////////////////////////////////////////////////////////
@@ -718,12 +756,9 @@ struct WidgetInitialiser
 
     template <class Parameter> static void setup(ModuleControlImpl<ModuleKnob> &knob)
     {
-        knob.setupForParameter(
-            std::is_base_of<LE::Parameters::SymmetricParameterTag, typename Parameter::Tag>::value
-                ? ModuleKnob::Bipolar
-                : ModuleKnob::Unipolar,
-            ModuleKnob::diameter, ModuleKnob::QuantizationFor<Parameter>::value,
-            Parameter::discreteValueDistance);
+        knob.setupForParameter(isBipolar<Parameter> ? ModuleKnob::Bipolar : ModuleKnob::Unipolar,
+                               ModuleKnob::diameter, ModuleKnob::QuantizationFor<Parameter>::value,
+                               Parameter::discreteValueDistance);
     }
 }; // struct WidgetInitialiser
 

--- a/tests/gui/knobPaintingTests.cpp
+++ b/tests/gui/knobPaintingTests.cpp
@@ -39,6 +39,11 @@
 #include "gui/gui.hpp"
 #include "gui/modules/moduleUI.hpp"
 
+#include "le/spectrumworx/effects/eximploder/exImploder.hpp"
+#include "le/spectrumworx/effects/pitch_shifter/pitchShifter.hpp"
+#include "le/spectrumworx/effects/pitch_spring/pitchSpring.hpp"
+#include "le/spectrumworx/effects/talking_wind/talkingWind.hpp"
+
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -163,4 +168,40 @@ TEST_CASE("Both knobs sweep through the same arc", "[gui][knob]")
     STATIC_CHECK(GUI::KnobPainter::angleFor(0.0f) == -GUI::KnobPainter::halfSweepDegrees);
     STATIC_CHECK(GUI::KnobPainter::angleFor(0.5f) == 0.0f);
     STATIC_CHECK(GUI::KnobPainter::angleFor(1.0f) == GUI::KnobPainter::halfSweepDegrees);
+}
+
+TEST_CASE("A knob's polarity is read off the range, not the spelling", "[gui][knob]")
+{
+    using namespace LE::SW::Effects;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
+    ///   Bipolar painting opens the wedge from twelve o'clock, which is the
+    /// centre of the knob's *travel*; that is the value zero only where the
+    /// range is symmetric about it. So the question the painter is really
+    /// asking is whether the range is symmetric -- and SymmetricInteger, which
+    /// builds its range as [ -MaximumOffset, +MaximumOffset ] and tags itself
+    /// for it, is one way of arriving there rather than the definition of it.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    // The spelling that says so: Pitch Shifter's Cents, +/-100 ct.
+    STATIC_CHECK(GUI::Detail::isBipolar<Detail::PitchShifterBase::Cents>);
+
+    //   ...and the spelling that does not. Imploder/Exploder's Glissando is
+    // +/-300 cents and every bit as bipolar, declared with LinearSignedInteger
+    // for one reason: its default is -100, and a Symmetric parameter's default
+    // is always zero. It painted unipolar for that reason alone.
+    STATIC_CHECK(GUI::Detail::isBipolar<Detail::ExImPloder::Gliss>);
+
+    // Talking Wind's envelope gain, +/-10 dB, is the same case in a float.
+    STATIC_CHECK(GUI::Detail::isBipolar<TalkingWind::EnvelopeGain>);
+
+    ///   And the negative that keeps the rule from being "reaches below zero":
+    /// Imploder's threshold runs -120 .. 0 dB, whose centre is -60 dB. A wedge
+    /// opening from there would be growing out of a value that means nothing.
+    STATIC_CHECK_FALSE(GUI::Detail::isBipolar<Detail::ExImPloder::Threshold>);
+
+    // ...and the plain unipolar one, for the other side of the fence.
+    STATIC_CHECK_FALSE(GUI::Detail::isBipolar<Detail::PitchSpringBase::Depth>);
 }


### PR DESCRIPTION
Imploder/Exploder's Glissando runs +/-300 cents and painted from the left stop, because the polarity was decided by `SymmetricParameterTag `rather than by the range. Nothing is wrong with the parameter: `Symmetric` derives its whole range from one `MaximumOffset` and so its default is always zero, and Glissando's is -100, which is why it is spelt `LinearSignedInteger` and why the tag test never reached it. Talking Wind's envelope gain, +/-10 dB, was the same case in a float.

So ask the range instead, and ask it exactly: `abs(minimum) == maximum`. The wedge opens from twelve o'clock, which is the centre of the knob's travel, and that is the value zero only where the range is symmetric about it -- a range that merely reaches below zero is not this. Imploder's own Threshold, -120 .. 0 dB, keeps painting unipolar, as does Octaver's -48 .. +24 dB gain; drawing those from twelve o'clock would grow the wedge out of -60 and -12 dB respectively. Every `Symmetric` parameter still answers true, now for its range rather than for its tag.

The five `STATIC_CHECK`s are the decision rather than the drawing, which is why they sit beside the painter's own cases instead of in a render: two parameters that are bipolar by range in each spelling, and the two negatives that keep the rule from loosening into "reaches below zero".

Fixes #251

Assisted-by: Claude Opus 5