### PR TITLE
Lay the input buffers out the same way on every compiler

### DIFF
--- a/src/core/spectrumWorxCore.cpp
+++ b/src/core/spectrumWorxCore.cpp
@@ -189,27 +189,9 @@ bool SpectrumWorxCore::InputBuffers::resize(std::uint32_t const blockSize,
     std::size_t const blockBytes(std::size_t{blockSize} * sizeof(Engine::real_t));
     auto const channelDataStorage(align(blockBytes));
 
-    ////////////////////////////////////////////////////////////////////////////
-    ///
-    /// \note **A bound on the layout below, not a model of it.** Whether
-    /// SharedStorageBuffer::resize() aligns the two pointer arrays it carves is
-    /// decided by `std::is_pointer_v<T>`, and `T` here is `float * LE_RESTRICT`:
-    /// Clang answers true for a restrict-qualified pointer and GCC answers
-    /// false, so the same source aligns on one compiler and not on the other.
-    ///
-    ///   This used to reserve `align( channels * base )` -- exactly what Clang
-    /// consumes, with nothing spare -- so under GCC the second carve's alignment
-    /// and the fixup it pushed into the data region ran 16 bytes past the end.
-    /// A checked build asserted; a release one corrupted the heap and glibc
-    /// aborted somewhere else entirely. Mono is where it bit, because two
-    /// one-pointer arrays are what makes the carves land off alignment.
-    ///
-    ///   So each carve is reserved rounded up, and one alignment more covers the
-    /// data region starting wherever the arrays left off. The cost is at most
-    /// three alignments -- 48 bytes on every target here -- per instance.
-    ///
-    ////////////////////////////////////////////////////////////////////////////
-
+    /// \note A bound on the layout below, not a model of it: each carve is
+    /// reserved rounded up and one alignment more covers the data region, so no
+    /// alignment fixup can run past the end. Costs at most three alignments.
     auto const arrayStorage(align(numberOfMainChannels * baseChannelStorage) +
                             align(numberOfSideChannels * baseChannelStorage));
     auto const requiredStorage(arrayStorage + vectorAlignment +

--- a/src/core/spectrumWorxCore.hpp
+++ b/src/core/spectrumWorxCore.hpp
@@ -438,7 +438,7 @@ class SpectrumWorxCore : public Host2PluginInteropControler,
     class InputBuffers
     {
       public:
-        using Channels = Utility::SharedStorageBuffer<Engine::real_t *LE_RESTRICT>;
+        using Channels = Utility::SharedStorageBuffer<Engine::real_t *>;
 
         InputBuffers() : blockSize_(0), forceSideChannel_(false) {}
 

--- a/src/le/utility/buffers.hpp
+++ b/src/le/utility/buffers.hpp
@@ -297,15 +297,10 @@ template <typename T> class SharedStorageBuffer : public Span<T>
 
         using iterator = T *LE_RESTRICT;
 
-        bool const doAlign(!std::is_pointer_v<T>);
-
-        /// \note static_casting through void * (instead of reinterpret_casting
-        /// throguh std::size_t) fails with compiler errors on GCC 4.9 on ranges
-        /// of pointers (it complains about __restrict being inapliccable to
-        /// void).
-        ///                                   (24.12.2014.) (Domagoj Saric)
-        iterator const newBeginning(reinterpret_cast<T *>(reinterpret_cast<std::size_t>(
-            doAlign ? Math::align(storage.begin()) : storage.begin())));
+        /// \note Aligned whatever `T` is: keying this off the element type made
+        /// the layout compiler dependent, `is_pointer_v` not being portable for
+        /// a restrict qualified pointer.
+        iterator const newBeginning(static_cast<T *>(Math::align(storage.begin())));
         auto const alignmentFixup(
             static_cast<std::uint8_t>(reinterpret_cast<std::size_t>(newBeginning) -
                                       reinterpret_cast<std::size_t>(storage.begin())));
@@ -315,10 +310,8 @@ template <typename T> class SharedStorageBuffer : public Span<T>
         iterator const newEnd(
             reinterpret_cast<T *>(reinterpret_cast<std::size_t>(storage.begin())));
         LE_ASSERT_MSG(newBeginning <= newEnd, "Failed to generate a valid range.");
-        LE_ASSERT_MSG(
-            !doAlign ||
-                (reinterpret_cast<std::size_t>(newBeginning) % Constants::vectorAlignment == 0),
-            "Failed to generate a properly aligned range.");
+        LE_ASSERT_MSG(reinterpret_cast<std::size_t>(newBeginning) % Constants::vectorAlignment == 0,
+                      "Failed to generate a properly aligned range.");
         static_cast<Range &>(*this) = Range(newBeginning, newEnd);
         LE_ASSERT_MSG(size() == newSize / sizeof(T), "Generated range has an invalid size.");
 

--- a/src/le/utility/typeTraits.hpp
+++ b/src/le/utility/typeTraits.hpp
@@ -5,9 +5,13 @@
 ///
 ///   This used to teach the standard library's type traits about restrict
 /// qualified pointers, and to carry TR1 fallbacks for pre-2011 libstdc++.
-/// Both are gone: libc++, libstdc++ and the MS STL all answer is_pointer,
-/// is_trivially_default_constructible and is_trivially_destructible correctly
-/// for `T * __restrict` today, and C++20 makes specialising them ill-formed.
+/// Both are gone, and C++20 makes specialising them ill-formed anyway.
+///
+///   The traits are still not to be trusted on a restrict qualified pointer:
+/// `std::is_pointer_v<float * __restrict>` is 1 on libc++ and 0 on libstdc++
+/// (gcc 12.4, 13.3), `__restrict` being no part of standard C++. Nothing in
+/// the tree asks one that question any more -- see SharedStorageBuffer::resize(),
+/// where it laid the buffers out one way per compiler.
 ///
 /// Copyright (c) 2011 - 2016. Little Endian Ltd.
 /// SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
`InputBuffers::Channels` held its element type restrict qualified, and
`SharedStorageBuffer::resize()` decided whether to align a carve by asking
`std::is_pointer_v` about it — which libc++ answers true for a restrict qualified
pointer and libstdc++ answers false (measured: apple clang 21 → 1, gcc 12.4 and
13.3 → 0). The same source therefore aligned the two pointer arrays on one
compiler and not on the other, which is what overran the input storage in a mono
layout.

The qualifier bought nothing besides: `mainChannel()` / `sideChannel()` hand out
an unqualified `Span`, `process()` re-applies restrict in block scope where it
has meaning, and neither clang nor gcc emits a different `process()` without it.

- dropped `LE_RESTRICT` from the `Channels` typedef
- `resize()` aligns every carve outright rather than keying off the element type,
  so no trait is asked about a restrict qualified pointer any more
- `typeTraits.hpp` no longer claims the standard libraries agree on that question;
  it records what they answer
- the storage reserve from #253 stays: it bounds the layout rather than modelling
  it, which is right whichever way the carves land

Green on both trees here — `ctest` 647/647 in `cmake-build-debug` and in
`build-release` (goldens included), and the mono port tests are among them.
The divergence itself is only reproducible on a libstdc++ build, so CI is the
check that matters for it.

Closes #254