### PR TITLE
Check that Mix 0 hands back the input, and still does after a latency change

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(sw-plugin-tests
         clap/hostInteropTests.cpp
         clap/identityTests.cpp
         clap/midiInputTests.cpp
+        clap/mixThroughThePluginTests.cpp
         clap/parameterModelTests.cpp
         clap/parameterTextTests.cpp
         clap/pluginTests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(sw-dsp-tests
         core/chunkTransparencyTests.cpp
         core/engineOwnershipTests.cpp
         core/engineSetupTests.cpp
+        core/mixTransparencyTests.cpp
         core/protocolTests.cpp
         effects/amplifyingEffectsTests.cpp
         effects/comparingEffectsTests.cpp

--- a/tests/clap/mixThroughThePluginTests.cpp
+++ b/tests/clap/mixThroughThePluginTests.cpp
@@ -1,0 +1,221 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// mixThroughThePluginTests.cpp
+/// ----------------------------
+///
+///   `core/mixTransparencyTests.cpp` asks the engine whether Mix 0 returns the
+/// input. This asks the **plugin**: a real `clap_plugin` from the factory, five
+/// seconds of sweep through `process()` in host blocks, compared against the
+/// latency the plugin told the host through `clap_plugin_latency::get()`.
+///
+///   What that adds is everything between a host and the engine -- the input
+/// gain, the chunking `process()` does at the hop, the parameter edge a Mix of 0
+/// crosses, and the restart a spectral change needs.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "testHost.hpp"
+
+#include "core/mixResidue.hpp"
+#include "goldens/engineHarness.hpp"
+
+#include "le/parameters/parameter.hpp"
+#include "le/spectrumworx/engine/parameters.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+using namespace SWTest;
+namespace Globals = LE::SW::GlobalParameters;
+
+constexpr double sampleRate{48000};
+
+/// \note Not a multiple of any hop, so every block ends on the short call
+/// `SpectrumWorxCLAP::process()` cuts for itself. \see doc/tech/latency.md §4.
+constexpr std::uint32_t blockSize{500};
+
+constexpr std::uint32_t renderedFrames{5 * 48000};
+
+/// Where a global parameter sits in `GlobalParameters::Parameters`, which is
+/// what both the host id and `editGlobalParameter` are keyed on.
+template <class Parameter> constexpr std::uint8_t globalIndex()
+{
+    return LE::Parameters::IndexOf<Globals::Parameters, Parameter>::value;
+}
+
+std::uint32_t reportedLatency(clap_plugin const &plugin)
+{
+    auto const *const latency(
+        static_cast<clap_plugin_latency const *>(plugin.get_extension(&plugin, CLAP_EXT_LATENCY)));
+    REQUIRE(latency != nullptr);
+    return latency->get(&plugin);
+}
+
+/// \brief What the host reads back for \p id, so that "it was set" is checked
+/// rather than assumed.
+double readsBack(ActivePlugin const &plugin, clap_id const id)
+{
+    double value{-1};
+    REQUIRE(parameters(*plugin).get_value(&*plugin, id, &value));
+    return value;
+}
+
+struct Rendered
+{
+    std::vector<float> left, right;
+};
+
+/// \brief Five seconds of \p input through the plugin, in host blocks.
+Rendered render(ActivePlugin &plugin, std::span<float const> const input)
+{
+    Rendered out{std::vector<float>(input.size()), std::vector<float>(input.size())};
+
+    std::vector<float> leftIn(blockSize), rightIn(blockSize);
+    std::vector<float> leftOut(blockSize), rightOut(blockSize);
+
+    for (std::uint32_t at(0); at + blockSize <= input.size(); at += blockSize)
+    {
+        std::copy_n(input.begin() + at, blockSize, leftIn.begin());
+        rightIn = leftIn;
+        std::fill(leftOut.begin(), leftOut.end(), 0.0f);
+        std::fill(rightOut.begin(), rightOut.end(), 0.0f);
+
+        plugin.process(leftIn, rightIn, leftOut, rightOut);
+
+        std::copy_n(leftOut.begin(), blockSize, out.left.begin() + at);
+        std::copy_n(rightOut.begin(), blockSize, out.right.begin() + at);
+    }
+    return out;
+}
+
+void requireTransparent(Rendered const &rendered, std::span<float const> const input,
+                        std::uint32_t const latency, char const *const what)
+{
+    for (auto const *const channel : {&rendered.left, &rendered.right})
+    {
+        auto const residue(mixResidue(*channel, input, latency));
+        INFO(what << " at a declared latency of " << latency << ": worst " << residue.worst
+                  << " at " << residue.worstAt << " of " << residue.compared << ", residue "
+                  << residue.errorDb() << " dB, output peak " << residue.outputPeak
+                  << ", latency region peak " << leadingPeak(*channel, latency));
+
+        REQUIRE(residue.compared > 0);
+        CHECK(residue.worst == 0.0);
+        CHECK(leadingPeak(*channel, latency) == 0.0);
+    }
+}
+
+std::vector<float> sweep()
+{
+    std::vector<float> input(renderedFrames);
+    SWTest::generate(SWTest::Signal::Sweep, input, static_cast<float>(sampleRate));
+    return input;
+}
+
+/// \brief The id a host addresses a global parameter by.
+///
+/// \note The *module* field of `SWTest::parameterID` and not the parameter one:
+/// `ParameterID::Global` packs its index at bits 16-23. In the last field it
+/// addresses nothing, and a flush of it is dropped in silence.
+template <class Parameter> clap_id globalParameterID()
+{
+    return parameterID(globalType, globalIndex<Parameter>());
+}
+
+/// \brief Mix, set the way a host automating it does.
+void setMixThroughTheHost(ActivePlugin const &plugin, double const mix)
+{
+    OneParameterEvent const event(globalParameterID<Globals::MixPercentage>(), mix);
+    plugin.flush(&*event);
+    REQUIRE(readsBack(plugin, globalParameterID<Globals::MixPercentage>()) == mix);
+}
+
+} // anonymous namespace
+
+/// \note Mix through the host rather than the editor, because the conversion is
+/// part of the question: a mix a hair above zero leaks the wet path.
+TEST_CASE("Mix 0 through the plugin returns the input", "[clap][mix][latency]")
+{
+    Entry const entry;
+    TestHost host(TestHost::everything());
+    ActivePlugin plugin(sampleRate, blockSize, host);
+
+    setMixThroughTheHost(plugin, 0.0);
+
+    auto const input(sweep());
+    requireTransparent(render(plugin, input), input, reportedLatency(*plugin), "the default chain");
+
+    CHECK(host.misbehaviours().empty());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief The FFT size moved under a running instance, and the delay with it.
+///
+///   Playing at 2048, the settings page picks 1024, `drainCommands()` answers
+/// with `request_restart`, the host deactivates and reactivates, and `activate()`
+/// announces the new latency. The same instance then has to be transparent at
+/// the new number, everything underneath it having been rebuilt.
+///
+/// \note Downwards, so that a stale buffer is still large enough to write into
+/// and a stale *latency* is the only thing left to be wrong.
+///
+/// \note `editGlobalParameter` is the UI's route -- what
+/// `SpectrumWorxEditor::queueGlobalParameter` calls -- because the FFT size is
+/// deliberately not automatable. \see issue #171.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("Mix 0 survives the UI changing the FFT size under a running instance",
+          "[clap][mix][latency]")
+{
+    Entry const entry;
+    TestHost host(TestHost::everything());
+    ActivePlugin plugin(sampleRate, blockSize, host);
+
+    setMixThroughTheHost(plugin, 0.0);
+
+    auto const input(sweep());
+
+    auto const before(reportedLatency(*plugin));
+    CHECK(before == 2048); // the default, which this case is written around
+    requireTransparent(render(plugin, input), input, before, "before the change");
+
+    auto const restartsBefore(host.restartRequests.load());
+    auto const latencyChangesBefore(host.latencyChanges.load());
+
+    editorHostOf(*plugin).editGlobalParameter(globalIndex<Globals::FFTSize>(), 1024.0f);
+
+    // nothing drains the queue but process(), flush() and deactivate()
+    plugin.flush();
+    CHECK(host.restartRequests.load() > restartsBefore);
+
+    // still the old size until the host comes back, which is the contract
+    CHECK(reportedLatency(*plugin) == before);
+
+    plugin.restartIfAsked();
+
+    auto const after(reportedLatency(*plugin));
+    CHECK(after == 1024);
+    CHECK(host.latencyChanges.load() > latencyChangesBefore);
+
+    auto const rendered(render(plugin, input));
+    requireTransparent(rendered, input, after, "after the restart");
+
+    // and it really moved: the same audio against the delay it used to have
+    auto const atTheOldLatency(mixResidue(rendered.left, input, before));
+    INFO("at the old latency of " << before << ": worst " << atTheOldLatency.worst << ", residue "
+                                  << atTheOldLatency.errorDb() << " dB");
+    CHECK(atTheOldLatency.errorDb() > -20.0);
+
+    CHECK(host.misbehaviours().empty());
+}

--- a/tests/clap/testHost.hpp
+++ b/tests/clap/testHost.hpp
@@ -169,10 +169,13 @@ class TestHost
         /// calls a partially implemented one host misbehaviour and then refuses
         /// the extension outright (host-proxy.hxx:449-459).
         bool gui{false};
+        /// \note The one the plugin reports a new FFT size through: without it
+        /// `canUseLatency()` is false and a restart changes the delay silently.
+        bool latency{false};
     }; // struct Offers
 
     /// A host with everything, which is what a DAW is.
-    static Offers everything() { return {true, true, true, true, true}; }
+    static Offers everything() { return {true, true, true, true, true, true}; }
 
     explicit TestHost(Offers const offers)
         : offers_(offers), mainThread_(std::this_thread::get_id()),
@@ -203,6 +206,7 @@ class TestHost
                },
                [](clap_host const *) { return true; }, [](clap_host const *) { return true; },
                [](clap_host const *, bool) {}},
+          latency_{[](clap_host const *const pHost) { ++self(pHost).latencyChanges; }},
           host_{CLAP_VERSION, this, "sw-tests", "SpectrumWorx", "", "0", &getExtension,
                 // request_restart, request_process, request_callback -- in that
                 // order; the last is the one a deferred rescan asks for.
@@ -243,6 +247,9 @@ class TestHost
     std::atomic<unsigned> restartRequests{0};
     std::atomic<unsigned> processRequests{0};
     std::atomic<unsigned> dirtyMarks{0};
+    /// How often the plugin said its delay had moved, which only a restart or
+    /// the without-a-restart fallback does. \see SpectrumWorxCLAP::activate().
+    std::atomic<unsigned> latencyChanges{0};
     /// How often the plugin asked which thread it was on, which is the evidence
     /// that it asks at all rather than always taking the deferral.
     std::atomic<unsigned> threadChecks{0};
@@ -400,6 +407,8 @@ class TestHost
             return &host.log_;
         if (host.offers_.gui && (std::strcmp(id, CLAP_EXT_GUI) == 0))
             return &host.gui_;
+        if (host.offers_.latency && (std::strcmp(id, CLAP_EXT_LATENCY) == 0))
+            return &host.latency_;
         return nullptr;
     }
 
@@ -439,6 +448,7 @@ class TestHost
     clap_host_thread_check threadCheck_;
     clap_host_log log_;
     clap_host_gui gui_;
+    clap_host_latency latency_;
     clap_host host_;
 }; // class TestHost
 

--- a/tests/core/mixResidue.hpp
+++ b/tests/core/mixResidue.hpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file mixResidue.hpp
+/// --------------------
+///
+///   What "the output is not quite the input" is as a number: one rendered
+/// channel against the mono signal it was fed, at a stated delay.
+///
+/// \note Shared by core/mixTransparencyTests.cpp and
+/// clap/mixThroughThePluginTests.cpp, which ask the same question of the engine
+/// and of the plugin around it -- two copies of this would be two chances for
+/// the two to stop meaning the same thing.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#ifndef mixResidue_hpp__8E2B6C14_0A73_4F5D_BA96_C31E7D0428AF
+#define mixResidue_hpp__8E2B6C14_0A73_4F5D_BA96_C31E7D0428AF
+//------------------------------------------------------------------------------
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+
+namespace SWTest
+{
+
+struct Residue
+{
+    double worst{0};
+    std::uint32_t worstAt{0};
+    double errorRms{0};
+    double inputRms{0};
+    double outputPeak{0};
+    std::uint32_t compared{0};
+
+    double errorDb() const
+    {
+        return (errorRms > 0) ? 20 * std::log10(errorRms / inputRms) : -1000.0;
+    }
+};
+
+/// \brief `rendered[n + latency]` against `input[n]`, over everything they share.
+inline Residue mixResidue(std::span<float const> const rendered, std::span<float const> const input,
+                          std::uint32_t const latency)
+{
+    Residue residue;
+    if ((input.size() <= latency) || (rendered.size() <= latency))
+        return residue;
+    residue.compared =
+        static_cast<std::uint32_t>(std::min(input.size(), rendered.size() - latency));
+
+    double errorSquares{0}, inputSquares{0};
+    for (std::uint32_t frame(0); frame < residue.compared; ++frame)
+    {
+        auto const out(rendered[std::size_t{frame} + latency]);
+        auto const expected(input[frame]);
+        auto const difference(std::abs(static_cast<double>(out) - expected));
+        if (difference > residue.worst)
+        {
+            residue.worst = difference;
+            residue.worstAt = frame;
+        }
+        errorSquares += difference * difference;
+        inputSquares += double{expected} * expected;
+        residue.outputPeak = std::max(residue.outputPeak, std::abs(double{out}));
+    }
+    residue.errorRms = std::sqrt(errorSquares / residue.compared);
+    residue.inputRms = std::sqrt(inputSquares / residue.compared);
+    return residue;
+}
+
+/// \brief The latency region, which owes the host silence and nothing else.
+inline double leadingPeak(std::span<float const> const rendered, std::uint32_t const latency)
+{
+    double peak{0};
+    for (std::uint32_t frame(0); frame < latency && frame < rendered.size(); ++frame)
+        peak = std::max(peak, std::abs(double{rendered[frame]}));
+    return peak;
+}
+
+} // namespace SWTest
+
+#endif // mixResidue_hpp

--- a/tests/core/mixTransparencyTests.cpp
+++ b/tests/core/mixTransparencyTests.cpp
@@ -1,0 +1,207 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// mixTransparencyTests.cpp
+/// ------------------------
+///
+///   **At Mix 0 the output is the input, delayed by the latency the plugin
+/// reports and unchanged otherwise.** The wet term is multiplied by the mix and
+/// the consumed input hop added back at `1 - mix`, so at 0 the claim is
+/// exactness rather than a tolerance, and the FFT size, the overlap factor and
+/// whatever is loaded are all supposed to be invisible.
+///
+/// \see doc/tech/latency.md, and chunkTransparencyTests.cpp, which measures the
+/// same delay through the wet path.
+///
+/// Copyright (c) 2026 the SpectrumWorx contributors.
+/// SPDX-License-Identifier: GPL-3.0-or-later
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#include "core/mixResidue.hpp"
+#include "goldens/engineHarness.hpp"
+
+#include "le/spectrumworx/effects/configuration/constants.hpp"
+#include "le/spectrumworx/effects/configuration/effectNames.hpp"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace
+{
+namespace Effects = LE::SW::Effects;
+
+using SWTest::leadingPeak;
+using SWTest::mixResidue;
+
+constexpr std::uint32_t sampleRate{44100};
+constexpr std::uint8_t channels{2};
+constexpr std::uint32_t renderedFrames{5 * sampleRate};
+
+// not a multiple of any hop here, so every block ends on a short call
+constexpr std::uint32_t hostBlock{500};
+
+/// \brief One channel of an interleaved render, de-interleaved.
+std::vector<float> channelOf(std::span<float const> const interleaved, std::uint8_t const channel)
+{
+    std::vector<float> mono(interleaved.size() / channels);
+    for (std::size_t frame(0); frame < mono.size(); ++frame)
+        mono[frame] = interleaved[frame * channels + channel];
+    return mono;
+}
+
+std::vector<float> sweep()
+{
+    std::vector<float> input(renderedFrames);
+    SWTest::generate(SWTest::Signal::Sweep, input, static_cast<float>(sampleRate));
+    return input;
+}
+
+SWTest::RenderSetup setupFor(std::uint16_t const fftSize, std::uint8_t const overlapFactor)
+{
+    SWTest::RenderSetup setup{fftSize, overlapFactor, channels, sampleRate, hostBlock};
+    // what SpectrumWorxCLAP::process() cuts a host block into, clamped as it clamps
+    setup.callSize = std::min<std::uint32_t>(fftSize / overlapFactor, hostBlock);
+    setup.mix = 0.0f;
+    return setup;
+}
+
+void requireTransparent(SWTest::RenderSetup const &setup, std::span<float const> const input,
+                        std::span<float const> const rendered)
+{
+    for (std::uint8_t channel(0); channel < channels; ++channel)
+    {
+        auto const mono(channelOf(rendered, channel));
+        auto const residue(mixResidue(mono, input, setup.fftSize));
+        auto const leading(leadingPeak(mono, setup.fftSize));
+
+        INFO("fft " << setup.fftSize << '/' << unsigned(setup.overlapFactor) << ", channel "
+                    << unsigned(channel) << ": worst " << residue.worst << " at " << residue.worstAt
+                    << " of " << residue.compared << ", residue " << residue.errorDb()
+                    << " dB, output peak " << residue.outputPeak << ", latency region peak "
+                    << leading);
+
+        // or "worst 0" is a comparison of nothing against nothing
+        REQUIRE(residue.compared > 0);
+
+        // exact, because x * 0 + y * 1 is y; a tolerance would accept the report
+        CHECK(residue.worst == 0.0);
+        CHECK(leading == 0.0);
+    }
+}
+
+} // anonymous namespace
+
+TEST_CASE("Mix 0 returns the input at every FFT size", "[mix][latency]")
+{
+    // minimumFFTSize to maximumFFTSize: the whole of what a host can ask for
+    auto const fftSize(GENERATE(std::uint16_t{128}, 256, 512, 1024, 2048, 4096, 8192));
+    auto const setup(setupFor(fftSize, 4));
+
+    auto const input(sweep());
+    SWTest::Slot const bypassed[]{{-1, {}}};
+    requireTransparent(setup, input, SWTest::renderChain(setup, bypassed, input));
+}
+
+TEST_CASE("Mix 0 returns the input at every overlap factor", "[mix][latency]")
+{
+    auto const overlapFactor(GENERATE(std::uint8_t{1}, 2, 4, 8));
+    auto const setup(setupFor(2048, overlapFactor));
+
+    auto const input(sweep());
+    SWTest::Slot const bypassed[]{{-1, {}}};
+    requireTransparent(setup, input, SWTest::renderChain(setup, bypassed, input));
+}
+
+/// \note Every effect, because exactness survives a multiply by zero and a
+/// non-finite wet sample would not.
+TEST_CASE("Mix 0 makes every effect unobservable", "[mix]")
+{
+    auto const setup(setupFor(2048, 4));
+    auto const input(sweep());
+
+    for (int effect(0); effect < Effects::Constants::numberOfEffects; ++effect)
+    {
+        SWTest::Slot const loaded[]{{static_cast<std::int8_t>(effect), {}}};
+        auto const rendered(SWTest::renderChain(setup, loaded, input));
+        auto const residue(mixResidue(channelOf(rendered, 0), input, setup.fftSize));
+
+        INFO(Effects::effectStreamingName(effect)
+             << ": worst " << residue.worst << " at " << residue.worstAt << ", residue "
+             << residue.errorDb() << " dB, peak " << residue.outputPeak);
+        REQUIRE(residue.compared > 0);
+        CHECK(residue.worst == 0.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief That the comparison above can fail, which "worst 0" does not say.
+///
+///   Off by one sample the sweep disagrees with itself by 0.67 of full scale,
+/// and off by a hop by more than the signal -- so a dry path aligned to the
+/// wrong hop would be caught rather than merely sounding right.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A misaligned dry path would be visible", "[mix][latency]")
+{
+    auto const setup(setupFor(2048, 4));
+    auto const input(sweep());
+    SWTest::Slot const bypassed[]{{-1, {}}};
+    auto const rendered(SWTest::renderChain(setup, bypassed, input));
+
+    std::uint32_t const latencyIs(setup.fftSize);
+    auto const hop(latencyIs / setup.overlapFactor);
+    for (auto const latency : {latencyIs - hop, latencyIs - 1, latencyIs + 1, latencyIs + hop})
+    {
+        auto const residue(mixResidue(channelOf(rendered, 0), input, latency));
+        INFO("at " << latency << " rather than " << setup.fftSize << ": worst " << residue.worst
+                   << ", residue " << residue.errorDb() << " dB");
+        CHECK(residue.errorDb() > -20.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \brief What the two global gains do at Mix 0, which is not the same thing.
+///
+///   `outputScaling_` is `outputGain * mix`, so at 0 the Out control is dead;
+/// the dry is added at `1 - mix` with no gain of its own, so In reaches the
+/// output in full. Factory presets that ship In away from unity are therefore
+/// louder at Mix 0 than the track they are on, and Out cannot bring them back.
+///
+/// \note Pinned rather than fixed: either half is a change to what a preset
+/// sounds like at Mix 0.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("At Mix 0 the In gain reaches the output and the Out gain does not", "[mix]")
+{
+    auto const gain(GENERATE(0.5f, 2.0f));
+    auto const input(sweep());
+    SWTest::Slot const bypassed[]{{-1, {}}};
+
+    auto withInput(setupFor(2048, 4));
+    withInput.inputGain = gain;
+    auto const scaled(mixResidue(channelOf(SWTest::renderChain(withInput, bypassed, input), 0),
+                                 input, withInput.fftSize));
+
+    auto withOutput(setupFor(2048, 4));
+    withOutput.outputGain = gain;
+    auto const unscaled(mixResidue(channelOf(SWTest::renderChain(withOutput, bypassed, input), 0),
+                                   input, withOutput.fftSize));
+
+    REQUIRE(scaled.compared > 0);
+    REQUIRE(unscaled.compared > 0);
+    INFO("gain " << gain << ": in gives peak " << scaled.outputPeak << ", out gives peak "
+                 << unscaled.outputPeak);
+    CHECK(scaled.outputPeak == Catch::Approx(gain * 0.5).epsilon(1e-6));
+    CHECK(unscaled.worst == 0.0);
+}

--- a/tests/goldens/engineHarness.cpp
+++ b/tests/goldens/engineHarness.cpp
@@ -206,6 +206,9 @@ std::vector<float> renderChain(RenderSetup const &setup, std::span<Slot const> c
     engine.setBlockSize(setup.blockSize);
     engine.set<GlobalParameters::FFTSize>(setup.fftSize);
     engine.set<GlobalParameters::OverlapFactor>(setup.overlapFactor);
+    engine.set<GlobalParameters::MixPercentage>(setup.mix);
+    engine.set<GlobalParameters::InputGain>(setup.inputGain);
+    engine.set<GlobalParameters::OutputGain>(setup.outputGain);
 
     bool const initialised(engine.initialise());
     LE_ASSERT_MSG(initialised, "Test engine failed to initialise.");

--- a/tests/goldens/engineHarness.hpp
+++ b/tests/goldens/engineHarness.hpp
@@ -221,6 +221,15 @@ struct RenderSetup
     ////////////////////////////////////////////////////////////////////////////
     std::uint32_t callSize{0};
 
+    /// \brief The global dry/wet, 1 -- `MixPercentage`'s own default -- being the
+    /// all-wet path every render before this was made under.
+    float mix{1.0f};
+
+    /// \brief The two global gains, linear and not dB: 1 is unity, and the
+    /// display transform is the host's business rather than the engine's.
+    float inputGain{1.0f};
+    float outputGain{1.0f};
+
     std::uint32_t framesPerCall() const { return callSize ? callSize : blockSize; }
 };
 


### PR DESCRIPTION
Two test files, no behaviour change. A report that at Mix 0 the plugin does not
exactly produce its input had nothing to be checked against; now it has.

## What Mix 0 turns out to be

Exact. Not close — the worst absolute difference is `0.0`.

At Mix 0 the wet term is scaled by the mix and the consumed input hop added back
at `1 - mix`, so the arithmetic is `x * 0 + y * 1`. Five seconds of log sweep
against `output[n + fftSize]` agrees with that at every FFT size the engine
accepts, at every overlap factor, and with each of the fifty-seven effects
loaded, on both channels, with the latency region exactly silent.

The same holds through the plugin: a real `clap_plugin` from the factory, Mix set
by a host parameter event, blocks of 500 frames, compared against what the plugin
told the host through `clap_plugin_latency::get()`. So the input gain, the
hop-sized chunking `process()` does for itself and the parameter edge add
nothing.

## And across a restart

The second case is the sequence a user performs, on one instance:

| step | measured |
|---|---|
| active at 2048, Mix 0 | transparent, reported latency 2048 |
| the settings page picks 1024 | queued |
| `flush()` drains it | `request_restart` 0 → 1 |
| before the host acts | latency still 2048 — the contract |
| deactivate, reactivate | latency 1024, `latency.changed` 0 → 1 |
| render again | transparent at 1024 |

It also checks the new render against the *old* latency, so a render that never
moved cannot pass.

`TestHost` had to grow `clap.latency` to see any of that. Nothing offered it, so
`canUseLatency()` was false in every case and the plugin's `latencyChanged()`
call was unobservable — a restart could have moved the delay in silence and no
case would have known.

## That the comparisons can fail

`worst 0` from a comparison that cannot fail says nothing, so both halves are
checked by reversion. A misalignment case pins that one sample off the sweep
disagrees with itself by 0.67 of full scale and one hop off by more than the
signal. And the plugin case failed for real at first, at −137 dB — the all-wet
WOLA floor — because a global parameter addressed in the wrong field of
`SWTest::parameterID` addresses nothing: `get_value` answers false and a flush of
it is dropped without a word, which renders exactly like a plugin that ignores
Mix. It now reads the value back after setting it.

## What it found

One thing, and it is not the report: the two global gains are not symmetric at
Mix 0. `outputScaling_` is `outputGain * mix`, so Out is a wet-path gain and does
nothing at Mix 0, while In is baked into the dry and passes through in full. At
unity — every default — it is a non-effect, which is why everything above is
bit-exact. Pinned as it stands rather than changed, and written up as #256,
because either half changes what shipped presets sound like.

## Gates

`ctest` is 654/654 in a Release and a Debug tree. The first commit was built and
run on its own as well, so the bisect point is measured rather than assumed.

`RenderSetup` grows `mix` and the two gains, each defaulting to the parameter's
own default, so every existing render — the goldens included — is untouched.
