### PR TITLE
Put the main thread's Program back level after a full echo ring

### DIFF
--- a/doc/tech/threading_model.md
+++ b/doc/tech/threading_model.md
@@ -132,8 +132,8 @@ engine the main thread owns.
 
 | `core/threading/messages.hpp` | cases |
 |---|---|
-| `ToEngine` | `SetBaseParameter`, `SetSlot`, `MoveModule`, `SwapChain`, `SwapSample` |
-| `ToUI` | `BaseParameterChanged` — `Retire` on a ring of its own, and chain and timing changes on flags |
+| `ToEngine` | `SetBaseParameter`, `SetSlot`, `MoveModule`, `SwapChain`, `SwapSample`, `RepublishParameters` |
+| `ToUI` | `BaseParameterChanged`, `BaseParameterRepublished` — `Retire` on a ring of its own, and chain and timing changes on flags |
 
 Both are tagged unions, trivially copyable, owning nothing. Each case says which
 side is responsible for a pointer after it lands, and that is the entire
@@ -178,14 +178,49 @@ way into the array, and `push` declines rather than clobbering the unread tail.
 That is the one place it differs from `sst::cpputils::SimpleRingBuffer`, and it
 is the whole reason for having our own.
 
+**And a lost echo is put back.** An echo is the only thing that carries a host's
+write into `programMain_`, and no depth survives a host that automates hard with
+the callback starved — clap-validator's `param-fuzz-basic` lost thousands in one
+test (issue #198). So a refused echo raises `echoesLost_`, a flag for the reason
+the chain and timing news are: the echoes are gone, the news that they went is
+not. `drainEngineEvents()` drains the ring completely and then queues
+`ToEngine::RepublishParameters`, and the engine answers at the end of its next
+`drainCommands()` — after the batch, so an edit queued behind the request is in
+what it reads — with every parameter an effect owns, as
+`ToUI::BaseParameterRepublished`. Draining first is what makes room for them.
+
+Two ways the request can itself be lost, and neither is allowed to lose it. The
+command ring can be full, so the flag is put back up until a push succeeds. And a
+deactivated plugin drains no commands, so with the engine stopped the main thread
+— which owns it then — republishes on the spot rather than leaving `stateSave` to
+read the stale copy until the next `activate()`.
+
+**A republish is state, not a replay of writes.** The echoes replay what the
+engine was told, in order, so every side effect of a setter lands the same way on
+both copies. A republish is what the engine ended up holding, pushed through the
+same setters, and that is faithful except where a setter depends on what it
+writes over:
+
+- a module parameter's write is ignored while its LFO runs, so a republished one
+  is applied `WhileModulated::stored` — otherwise a base changed while the LFO was
+  briefly off could never come back;
+- a period snaps to the sync type its LFO has when the period is written, and the
+  parameter list puts the period first, so each LFO's sync type is republished
+  ahead of its period.
+
+A slot the republish moves is announced by the drain itself — a rack resync and a
+`RESCAN_INFO` — because the engine's own announcement ran when `programMain_` did
+not have it yet. The cost is every parameter pushed inside one block after a
+storm: no allocation and no lock, and chunking across blocks is there if it ever
+shows up in a measurement.
+
 **The mailbox sweeps with `exchange`.** `core/threading/valueMailbox.hpp` is a
 value per dense parameter index plus a bitset of what moved, so a write landing
 mid-sweep is carried into the next sweep rather than lost.
 
 **The timing change is where that rule was learned.** A host ramping the tempo
 reports a new bar duration on every block, some hundreds a second, and a ring it
-fills has dropped somebody's echo, which leaves the main thread's Program behind
-the engine for that parameter. It rode the ring behind a sender-side flag that
+fills has dropped somebody's echo, which costs a full republish to put back. It rode the ring behind a sender-side flag that
 capped it at one outstanding *message* rather than at none — so it still spent a
 slot, and a push that failed cleared its own flag and gave up, which at a fixed
 tempo meant the panel never caught up. As a flag it costs nothing and cannot be
@@ -429,7 +464,7 @@ The inventory the model is measured by.
 | What | Shared how | State |
 |---|---|---|
 | Parameter edits, interface → engine | `ToEngineQueue`, drained at the top of `process()`, in `paramsFlush()` and in `deactivate()`; freed unapplied at destruction | ✅ |
-| Base-value changes, engine → interface | `ToUIQueue`, drained in `onMainThread()` and in `deactivate()` | ✅ |
+| Base-value changes, engine → interface | `ToUIQueue`, drained in `onMainThread()` and in `deactivate()`; a refused echo raises `echoesLost_` and the engine republishes every parameter | ✅ |
 | Modulated values, for painting | `ValueMailbox`, written per block, swept at 30 Hz | ✅ |
 | Plugin → host notifications | `UIEdits` ring | ✅ |
 | Which thread is which | `Threading::{isMainThread,isAudioThread}` | ✅ |
@@ -516,6 +551,7 @@ result.
 | `tests/core/threadCheckTests.cpp` | thread identity, driven through the C entry point rather than read off the source |
 | `tests/core/engineOwnershipTests.cpp` | who may mutate the engine and when; that every block is written; that a spectral change waits and then lands; that a published chain comes back holding what it displaced |
 | `tests/core/protocolTests.cpp` | refusal when full, survival past the end of the storage, and two cases that run real threads — 100k messages through an eight-slot ring arriving once and in order, and a mailbox swept while a writer runs flat out |
+| `tests/clap/publishProtocolTests.cpp` | both halves of publish-and-retire in every build configuration; what each full ring costs; and the echo resync, asserted by comparing both copies parameter by parameter and as saved state — after a fuzzed storm, with an LFO running, with a synced period, with a slot moved under an open editor, with the command ring full, and deactivated before any callback |
 | `tests/gui/twoInstanceTests.cpp` | closing one editor leaves the other's `MessageManager` alive; selection is independent; ejecting a module and then its ghost |
 | `tests/clap/hostInteropTests.cpp` | `reset()` between blocks; flush conditional on `isActive()`; both arms of every `canUseThreadCheck()` branch |
 | `tests/clap/pluginTests.cpp` | *"A full rack with LFOs running and an editor open processes cleanly"* and *"Two instances process while their editors come and go"* — the latter with **two real audio threads** and a message thread opening and closing both windows underneath them |

--- a/src/core/host_interop/programWrite.hpp
+++ b/src/core/host_interop/programWrite.hpp
@@ -76,8 +76,9 @@ template <class Protocol> class ProgramParameterSetter
     using result_type = void;
 
     ProgramParameterSetter(Plugins::AutomatedParameterValue const value,
-                           LE::Parameters::LFO::Timing const &lfoTiming)
-        : value_(value), lfoTiming_(lfoTiming)
+                           LE::Parameters::LFO::Timing const &lfoTiming,
+                           WhileModulated const whileModulated)
+        : value_(value), lfoTiming_(lfoTiming), whileModulated_(whileModulated)
     {
     }
 
@@ -116,7 +117,7 @@ template <class Protocol> class ProgramParameterSetter
         auto const pModule(pProgram->moduleChain().moduleAs<Module>(parameterID.moduleIndex));
         if (pModule)
             pModule->setAutomatedParameter(parameterID.moduleParameterIndex, value_,
-                                           AutomatedParameter::normalised);
+                                           AutomatedParameter::normalised, whileModulated_);
     }
 
     /// \note The bounds fixup a `setAutomatedLFOParameter` can make to its
@@ -140,16 +141,19 @@ template <class Protocol> class ProgramParameterSetter
     /// \note The engine's bar: there is one clock per instance and this Program
     /// is the same instance's. \see issue #11.
     LE::Parameters::LFO::Timing const lfoTiming_;
+
+    WhileModulated const whileModulated_;
 }; // class ProgramParameterSetter
 
 /// \brief Applies \p value to \p parameterID in \p program. `[main-thread]`
 template <class Protocol>
 void setParameterIn(Program &program, ParameterID const parameterID,
                     Plugins::AutomatedParameterValue const value,
-                    LE::Parameters::LFO::Timing const &lfoTiming)
+                    LE::Parameters::LFO::Timing const &lfoTiming,
+                    WhileModulated const whileModulated = WhileModulated::ignored)
 {
     invokeFunctorOnIdentifiedParameter(
-        parameterID, ProgramParameterSetter<Protocol>{value, lfoTiming}, &program);
+        parameterID, ProgramParameterSetter<Protocol>{value, lfoTiming, whileModulated}, &program);
 }
 
 } // namespace LE::SW

--- a/src/core/modules/automatedModuleImpl.hpp
+++ b/src/core/modules/automatedModuleImpl.hpp
@@ -18,6 +18,13 @@
 namespace LE::SW
 {
 
+/// \brief What a write does to a parameter whose LFO is running.
+enum struct WhileModulated : bool
+{
+    ignored, ///< automation: the LFO has the parameter
+    stored   ///< another Program's state being copied \see issue #198
+};
+
 template <class InterfaceImpl> class AutomatedModuleImpl
 {
   public: // Parameters
@@ -30,7 +37,7 @@ template <class InterfaceImpl> class AutomatedModuleImpl
                                                            bool normalised) const;
 
     void setAutomatedParameter(std::uint8_t parameterIndex, Plugins::AutomatedParameterValue,
-                               bool normalised);
+                               bool normalised, WhileModulated = WhileModulated::ignored);
 
     char const *getParameterValueString(std::uint8_t parameterIndex,
                                         LE::Parameters::AutomatedParameterPrinter const &) const;

--- a/src/core/modules/automatedModuleImpl.inl
+++ b/src/core/modules/automatedModuleImpl.inl
@@ -79,14 +79,16 @@ AutomatedModuleImpl<Impl>::getAutomatedParameter(std::uint8_t const parameterInd
 template <class Impl>
 void AutomatedModuleImpl<Impl>::setAutomatedParameter(std::uint8_t const parameterIndex,
                                                       Plugins::AutomatedParameterValue const value,
-                                                      bool const normalised)
+                                                      bool const normalised,
+                                                      WhileModulated const whileModulated)
 {
     //...mrmlj...LE_ASSUME( parameterIndex < SW::Constants::maxNumberOfParametersPerModule );
 
     if (parameterIndex >= impl().numberOfParameters())
         return; // index out of range
 
-    if (parameterIndex != 0 && impl().lfo(parameterIndex - 1).enabled()) //...mrmlj...skip bypass
+    if ((whileModulated == WhileModulated::ignored) && parameterIndex != 0 &&
+        impl().lfo(parameterIndex - 1).enabled()) //...mrmlj...skip bypass
         return; // skip automation if the parameter's LFO is enabled
 
     if (parameterIndex < impl().numberOfBaseParameters)

--- a/src/core/threading/messages.hpp
+++ b/src/core/threading/messages.hpp
@@ -62,7 +62,10 @@ struct ToEngine
         /// one user act ("play this file", "take the host's port") and because a
         /// block that saw one without the other would be a block fed from the
         /// wrong place. \see SideChainSource.
-        SwapSample
+        SwapSample,
+        /// Every parameter's base value, echoed back. Asked for when an echo was
+        /// lost on a full ToUI ring; nothing travels.
+        RepublishParameters
     };
 
     Kind kind{Kind::None};
@@ -143,6 +146,9 @@ struct ToUI
         /// A base value the engine settled on, after snapping or after a host
         /// automation event. Latchable: the model takes it and the host is told.
         BaseParameterChanged,
+        /// The same payload, answering ToEngine::RepublishParameters: the
+        /// engine's state rather than a write, so it lands under a running LFO.
+        BaseParameterRepublished,
         /// Something the audio thread unlinked and the main thread must delete.
         /// Dropping one of these is a leak, which is why it is a ring and not a
         /// mailbox -- and its own ring, so that echo traffic cannot fill it.
@@ -256,10 +262,25 @@ inline ToEngine swapSample(void *const pSample, bool const replacesSample,
     return message;
 }
 
+inline ToEngine republishParameters()
+{
+    ToEngine message{};
+    message.kind = ToEngine::Kind::RepublishParameters;
+    return message;
+}
+
 inline ToUI baseParameterChanged(std::uint32_t const parameterID, float const value)
 {
     ToUI message{};
     message.kind = ToUI::Kind::BaseParameterChanged;
+    message.baseParameterChanged = {parameterID, value};
+    return message;
+}
+
+inline ToUI baseParameterRepublished(std::uint32_t const parameterID, float const value)
+{
+    ToUI message{};
+    message.kind = ToUI::Kind::BaseParameterRepublished;
     message.baseParameterChanged = {parameterID, value};
     return message;
 }

--- a/src/spectrumWorxCLAP.cpp
+++ b/src/spectrumWorxCLAP.cpp
@@ -236,6 +236,7 @@ void SpectrumWorxCLAP::discardQueuedCommands()
         case Threading::ToEngine::Kind::None:
         case Threading::ToEngine::Kind::SetBaseParameter:
         case Threading::ToEngine::Kind::MoveModule:
+        case Threading::ToEngine::Kind::RepublishParameters:
             break;
         }
     }
@@ -1045,15 +1046,8 @@ bool SpectrumWorxCLAP::handleEvent(clap_event_header const *const header)
     //
     // only when the engine took it -- setParameter declines a slot selector
     // that would leave a hole in the rack
-    //
-    // a dropped echo leaves programMain_ behind the engine for that parameter
-    // permanently, this being the only thing that carries a host's write across
     if (applied == Plugins::ErrorCode<Protocol>::Success)
-    {
-        pushed(toUI_.push(Threading::baseParameterChanged(parameterID.binaryValue, value)),
-               "The echo queue is full; the main thread's Program is now behind the engine.");
-        requestEchoDrain();
-    }
+        echo(Threading::baseParameterChanged(parameterID.binaryValue, value));
 
     // only a module-chain parameter changes what the *other* parameters are: it
     // decides which effect a slot holds, and so how many that slot has and what
@@ -1504,12 +1498,19 @@ void SpectrumWorxCLAP::onMainThread() noexcept
 /// calling `process()` at all.
 void SpectrumWorxCLAP::drainCommands()
 {
+    bool republish(false);
+
     Threading::ToEngine command;
     while (toEngine_.pop(command))
     {
         switch (command.kind)
         {
         case Threading::ToEngine::Kind::None:
+            break;
+
+        // after the loop, so an edit queued behind the request is in what is read
+        case Threading::ToEngine::Kind::RepublishParameters:
+            republish = true;
             break;
 
         case Threading::ToEngine::Kind::SetBaseParameter:
@@ -1568,6 +1569,9 @@ void SpectrumWorxCLAP::drainCommands()
         }
     }
 
+    if (republish)
+        republishParameters();
+
     // once per batch rather than per command: a preset that moves the FFT size
     // and the overlap factor together is one restart, not two
     //
@@ -1582,9 +1586,8 @@ void SpectrumWorxCLAP::drainCommands()
 ///
 /// \brief The one answer to "what happens when a ring is full".
 ///
-/// \note It counts; it does not repair. A dropped echo, edit or gesture is
-/// *gone*: the other side has already moved by the time the push fails, and the
-/// ring was where the information to put it back would have been.
+/// \note It counts; it does not repair. A dropped edit or gesture is *gone*: the
+/// other side has already moved by the time the push fails. echo() repairs its own.
 ///
 /// \note A counter and not an assertion, so it reads the same in a checked build
 /// and a shipped one, and a case that fills a ring on purpose can measure rather
@@ -1615,6 +1618,52 @@ void SpectrumWorxCLAP::retire(Threading::ToUI::Retired const what, void *const p
         return;
 
     LE_ASSERT_MSG(false, "The retire queue is full; something will be leaked.");
+}
+
+void SpectrumWorxCLAP::echo(Threading::ToUI const message)
+{
+    if (!pushed(toUI_.push(message),
+                "The echo queue is full; the main thread's Program is now behind the engine."))
+        echoesLost_.store(true, std::memory_order_release);
+    requestEchoDrain();
+}
+
+/// \note Every parameter in one block: a spike after a storm, with no allocation or lock.
+///
+/// \note In `parameterIDs_` order, so a slot selector lands before what depends on it.
+void SpectrumWorxCLAP::republishParameters()
+{
+    LE_ASSERT(currentThreadMayMutateEngineState());
+
+    using LE::Parameters::IndexOf;
+    auto const periodScale(IndexOf<LFO::Parameters, LFO::PeriodScale>::value);
+    auto const syncTypes(IndexOf<LFO::Parameters, LFO::SyncTypes>::value);
+
+    Plugins::ParameterInformation<Protocol> ranges;
+    auto const republish([&](ParameterID const parameterID) {
+        // the filter a host's write passes in handleEvent()
+        if (liveRanges(parameterID, ranges, program()))
+            echo(Threading::baseParameterRepublished(parameterID.binaryValue,
+                                                     getParameter(parameterID, program())));
+    });
+
+    for (auto const &exported : parameterIDs_)
+    {
+        ParameterID parameterID{exported};
+        bool const isLFO(parameterID.type() == ParameterID::LFOParameter);
+
+        // a period snaps to the sync type it is written under, so it follows its own
+        if (isLFO && (parameterID.value._.lfo.lfoParameterIndex == periodScale))
+            continue;
+
+        republish(parameterID);
+
+        if (isLFO && (parameterID.value._.lfo.lfoParameterIndex == syncTypes))
+        {
+            parameterID.value._.lfo.lfoParameterIndex = periodScale;
+            republish(parameterID);
+        }
+    }
 }
 
 /// \note And says the session needs saving. Whether it is an *edit* is what the
@@ -1701,9 +1750,9 @@ void SpectrumWorxCLAP::publishModulatedValues()
     });
 }
 
-void SpectrumWorxCLAP::drainEngineEvents()
+bool SpectrumWorxCLAP::drainEchoes()
 {
-    LE_ASSERT(Threading::isMainThread() || !Threading::isAudioThread());
+    bool slotMoved(false);
 
     Threading::ToUI event;
     while (toUI_.pop(event))
@@ -1717,11 +1766,24 @@ void SpectrumWorxCLAP::drainEngineEvents()
         // paramsValue and stateSave answer from programMain_ with the window
         // shut, and a strip that then redraws reads a copy that already agrees
         case Threading::ToUI::Kind::BaseParameterChanged:
+        case Threading::ToUI::Kind::BaseParameterRepublished:
         {
             ParameterID const parameterID{
                 Plugins::ParameterID{event.baseParameterChanged.parameterID}};
+            bool const isSlotSelector(parameterID.type() == ParameterID::ModuleChainParameter);
+            auto const &chain(programMain_.moduleChain());
+            auto const slot(parameterID.value._.moduleChain.moduleIndex);
+            auto const effectBefore(isSlotSelector ? chain.getParameterForIndex(slot).getValue()
+                                                   : noModule);
+
+            // a write replays what the engine was told, state is what it has
             setParameterIn<Protocol>(programMain_, parameterID, event.baseParameterChanged.value,
-                                     lfoTimer().timing());
+                                     lfoTimer().timing(),
+                                     (event.kind == Threading::ToUI::Kind::BaseParameterRepublished)
+                                         ? WhileModulated::stored
+                                         : WhileModulated::ignored);
+            slotMoved |=
+                isSlotSelector && (chain.getParameterForIndex(slot).getValue() != effectBefore);
             if (pEditor_)
                 pEditor_->parameterChangedElsewhere(parameterID, event.baseParameterChanged.value);
             break;
@@ -1735,15 +1797,43 @@ void SpectrumWorxCLAP::drainEngineEvents()
             break;
         }
     }
+    return slotMoved;
+}
+
+void SpectrumWorxCLAP::drainEngineEvents()
+{
+    LE_ASSERT(Threading::isMainThread() || !Threading::isAudioThread());
+
+    bool slotMoved(drainEchoes());
+
+    // after the ring is empty, so the republished values have room in it
+    if (echoesLost_.exchange(false, std::memory_order_acquire))
+    {
+        // a stopped engine is this thread's; a queued request would wait for activate()
+        if (!engineIsRunning())
+        {
+            republishParameters();
+            slotMoved |= drainEchoes();
+        }
+        // the flag outlives a full command ring, or the resync is lost as the echoes were
+        else if (!pushed(toEngine_.push(Threading::republishParameters()),
+                         "The command queue is full; the echo resync will be asked for again."))
+            echoesLost_.store(true, std::memory_order_release);
+    }
+
+    // the engine's own announcement may have read this copy before the slot moved
+    if (slotMoved)
+        requestRescan(CLAP_PARAM_RESCAN_INFO | CLAP_PARAM_RESCAN_TEXT | CLAP_PARAM_RESCAN_VALUES);
 
     // cleared before the resync, so a chain that changes again while the rack
     // redraws is announced rather than swallowed
-    if (chainChangedPending_.exchange(false, std::memory_order_acquire) && pEditor_)
+    if ((chainChangedPending_.exchange(false, std::memory_order_acquire) || slotMoved) && pEditor_)
         pEditor_->resyncModuleRack();
 
     // after the announcements, which is the order the engine made them in: a
     // module is unlinked and said to be gone before the reference it left is
     // dropped, and the strip holding the other reference goes with the resync
+    Threading::ToUI event;
     while (retire_.pop(event))
     {
         switch (event.retire.what)

--- a/src/spectrumWorxCLAP.hpp
+++ b/src/spectrumWorxCLAP.hpp
@@ -452,10 +452,19 @@ class SpectrumWorxCLAP final
     /// \brief Applies everything the audio thread has reported, on the main
     /// thread. `[main-thread]`
     void drainEngineEvents();
+    /// \return whether an echo changed what a slot holds
+    bool drainEchoes();
 
     /// \brief Hands \p pObject back for the main thread to destroy.
     /// `[audio-thread]` \see the definition.
     void retire(Threading::ToUI::Retired, void *pObject);
+
+    /// \brief A base value for `programMain_`, raising `echoesLost_` on a full
+    /// ring. `[audio-thread]`, or main with the engine stopped.
+    void echo(Threading::ToUI);
+
+    /// \brief Every owned parameter's value, as state. Thread as echo(). \see #198
+    void republishParameters();
 
   public:
     /// \brief The one reference \p module carries, handed back for the main
@@ -717,6 +726,10 @@ class SpectrumWorxCLAP final
     /// Draining the ring is not the same errand as telling the host to save.
     std::atomic<bool> pendingEchoDrain_{false};
 
+    /// \brief An echo was refused, so `programMain_` is behind by parameters nobody
+    /// can name. A flag cannot overflow. \see drainEngineEvents(), issue #198
+    std::atomic<bool> echoesLost_{false};
+
     /// What the editor moved, waiting for a process() or flush() to carry it to
     /// the host.
     ///
@@ -751,8 +764,8 @@ class SpectrumWorxCLAP final
     ///   Every one is a divergence between the two `Program` copies, or between
     /// one of them and the host, that nothing can put right afterwards -- the
     /// ring is where the information was. A slot change and a chain change are
-    /// undone by their publisher; an echo, an edit and a gesture cannot be,
-    /// because by the time the push fails the other side has already moved.
+    /// undone by their publisher, and an echo by a republish; an edit and a gesture
+    /// cannot be, because by the time the push fails the other side has moved.
     ///
     ///   1024 deep against a ring drained every block, so a non-zero value means
     /// something is wrong upstream rather than that the user was quick.

--- a/tests/clap/publishProtocolTests.cpp
+++ b/tests/clap/publishProtocolTests.cpp
@@ -34,14 +34,23 @@
 #include "clap/testHost.hpp"
 
 #include "core/modules/moduleDSPAndGUI.hpp"
+// getParameter(id, Program) instantiates both; the plugin's TU may inline its copies away
+#include "core/host_interop/plugin2HostImpl.inl"
+#include "core/modules/automatedModuleImpl.inl"
 #include "external_audio/sample.hpp"
+#include "gui/editor/spectrumWorxEditor.hpp"
+#include "gui/modules/moduleUI.hpp"
 
+#include "le/spectrumworx/presets.hpp"
 #include "le/utility/intrusivePtr.hpp"
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <cmath>
 #include <cstdint>
+#include <random>
+#include <string>
 #include <vector>
 //------------------------------------------------------------------------------
 namespace
@@ -66,11 +75,12 @@ LE::SW::SpectrumWorxCLAP &implementationOf(clap_plugin const &plugin)
 
 /// \brief One block of silence, which is all these cases want from `process()`:
 /// it is the only thing that drains the command ring.
-void runOneBlock(ActivePlugin &plugin)
+void runOneBlock(ActivePlugin &plugin, std::vector<TimedParameterEvents::At> const &events = {})
 {
+    TimedParameterEvents const list(events);
     std::vector<float> leftIn(blockSize, 0), rightIn(blockSize, 0);
     std::vector<float> leftOut(blockSize, 0), rightOut(blockSize, 0);
-    plugin.process(leftIn, rightIn, leftOut, rightOut);
+    plugin.process(leftIn, rightIn, leftOut, rightOut, nullptr, &*list);
 }
 
 /// The effect in each slot of \p chain, in chain order.
@@ -191,11 +201,8 @@ TEST_CASE("A module the engine displaces is released rather than leaked", "[clap
 /// cases make it an answer: the message is gone, the two copies have diverged,
 /// and `droppedMessages()` is the plugin admitting it.
 ///
-///   They deliberately assert the *divergence* as well as the count. The counter
-/// is not a repair and pretending otherwise would be the same mistake in a
-/// different place -- what is lost is lost, because the ring is where the
-/// information to put it back would have been. A lossless echo would make this
-/// unreachable, and is a bigger change than a bug fix.
+///   The counter is not a repair. The echo ring is the one with a repair behind
+/// it, so its cases assert the two copies agree afterwards. \see issue #198.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -210,6 +217,84 @@ constexpr unsigned overflowingEchoes{LE::SW::Threading::ToUIQueue::capacity + 1}
 LE::SW::ParameterID globalParameterID(unsigned const index)
 {
     return LE::SW::ParameterID{LE::Plugins::ParameterID{parameterID(globalType, index)}};
+}
+
+/// Every parameter on which the engine's Program and the main thread's differ.
+std::vector<std::string> disagreements(clap_plugin const &plugin)
+{
+    auto &implementation(implementationOf(plugin));
+    auto &host(editorHostOf(plugin));
+
+    std::vector<std::string> found;
+    for (auto const &info : allParameterInfo(plugin, parameters(plugin)))
+    {
+        LE::SW::ParameterID const id{LE::Plugins::ParameterID{info.id}};
+        auto const engine(implementation.getParameter(id, implementation.program()));
+        auto const main(implementation.getParameter(id, host.programMain()));
+        if (engine != main)
+            found.push_back(std::string(info.module) + " / " + info.name + ": engine " +
+                            std::to_string(engine) + ", main " + std::to_string(main));
+    }
+    return found;
+}
+
+/// What stateSave would write, from either copy.
+std::string asSaved(LE::SW::Program const &program)
+{
+    return LE::SW::savePreset({}, LE::SW::defaultSideChainSource, {}, {}, program);
+}
+
+void checkLevel(clap_plugin const &plugin)
+{
+    auto const differing(disagreements(plugin));
+    for (auto const &line : differing)
+        UNSCOPED_INFO(line);
+    CHECK(differing.empty());
+
+    CHECK(asSaved(editorHostOf(plugin).programMain()) ==
+          asSaved(implementationOf(plugin).program()));
+}
+
+/// A ring and one more of one parameter's automation, each value new, in one block.
+void overflowTheEchoRing(ActivePlugin &plugin)
+{
+    std::vector<TimedParameterEvents::At> ramp;
+    for (unsigned echo(0); echo < overflowingEchoes; ++echo)
+        ramp.push_back({0, parameterID(globalType, 0), 0.25 + (0.5 * echo) / overflowingEchoes});
+    runOneBlock(plugin, ramp);
+    REQUIRE(implementationOf(*plugin).droppedMessages() > 0);
+}
+
+/// Each automatable parameter somewhere in its range, as a host's fuzzer writes it.
+std::vector<TimedParameterEvents::At>
+everyParameterAtRandom(std::vector<clap_param_info> const &infos, std::mt19937 &random,
+                       unsigned const firstMovingSlot)
+{
+    std::vector<TimedParameterEvents::At> events;
+    for (auto const &info : infos)
+    {
+        // the spectral three restart the plugin, which is not this case's subject
+        if (!(info.flags & CLAP_PARAM_IS_AUTOMATABLE))
+            continue;
+        if (((info.id >> 24) == moduleChainType) && (((info.id >> 16) & 0xff) < firstMovingSlot))
+            continue;
+        // the ends a third of the time each: a boolean on a 0..1 edge is off at 0 alone
+        std::uniform_real_distribution<double> range(info.min_value, info.max_value);
+        auto value(range(random));
+        switch (random() % 3)
+        {
+        case 0:
+            value = info.min_value;
+            break;
+        case 1:
+            value = info.max_value;
+            break;
+        }
+        if (info.flags & CLAP_PARAM_IS_STEPPED)
+            value = std::round(value);
+        events.push_back({0, info.id, value});
+    }
+    return events;
 }
 } // anonymous namespace
 
@@ -232,7 +317,7 @@ TEST_CASE("A full command ring is counted rather than ignored", "[clap][protocol
     CHECK(implementation.droppedMessages() > 0);
 }
 
-TEST_CASE("A full echo ring leaves the main thread's Program behind, and says so",
+TEST_CASE("A full echo ring leaves the main thread's Program behind until it resyncs",
           "[clap][protocol][hostile]")
 {
     Entry const entry;
@@ -257,26 +342,262 @@ TEST_CASE("A full echo ring leaves the main thread's Program behind, and says so
 
     REQUIRE(implementation.droppedMessages() > 0);
 
-    // Now let the main thread catch up with everything that did fit.
-    plugin.pumpMainThread();
-
-    ////////////////////////////////////////////////////////////////////////////
-    ///
-    /// \note And this is the cost, stated rather than implied: what the host
-    /// reads back is not what the engine is running, and no further drain will
-    /// fix it. Before this change the two simply differed with nothing recorded.
-    ///
-    ////////////////////////////////////////////////////////////////////////////
-    double asTheHostSeesIt{-1};
-    REQUIRE(params.get_value(&*plugin, id, &asTheHostSeesIt));
-
     auto const asTheEngineHasIt(implementation.program()
                                     .parameters()
                                     .get<LE::SW::GlobalParameters::InputGain>()
                                     .getValue());
+    auto const hostReads([&] {
+        double value{-1};
+        REQUIRE(params.get_value(&*plugin, id, &value));
+        return value;
+    });
 
-    UNSCOPED_INFO("host reads " << asTheHostSeesIt << ", engine holds " << asTheEngineHasIt);
-    CHECK(asTheHostSeesIt != Catch::Approx(asTheEngineHasIt));
+    // the drain takes what fit, which is stale, and asks for the rest
+    plugin.pumpMainThread();
+    CHECK(hostReads() != Catch::Approx(asTheEngineHasIt));
+
+    // the engine answers on its next block and the one after drains it
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+    CHECK(hostReads() == Catch::Approx(asTheEngineHasIt));
+    checkLevel(*plugin);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note clap-validator's param-fuzz: every parameter, every block, callback
+/// starved. The republish is state rather than writes, so order matters here.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A parameter storm that overflows the echo ring ends with both Programs level",
+          "[clap][protocol][hostile]")
+{
+    Entry const entry;
+
+    ActivePlugin plugin(sampleRate, blockSize);
+    auto &host(editorHostOf(*plugin));
+    auto &implementation(implementationOf(*plugin));
+
+    for (std::uint8_t slot(0); slot < LE::SW::Constants::maxNumberOfModules; ++slot)
+        REQUIRE(host.editSlot(slot, static_cast<std::int8_t>(slot + 2)));
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+    checkLevel(*plugin);
+
+    auto const infos(allParameterInfo(*plugin, parameters(*plugin)));
+    std::mt19937 random(198);
+
+    // only what an effect owns is echoed, so count drops rather than blocks
+    //
+    // three slots never move: a fresh module has every LFO off, hiding what a running one does
+    constexpr unsigned firstMovingSlot{3};
+    unsigned blocks(0);
+    while (implementation.droppedMessages() < overflowingEchoes)
+    {
+        REQUIRE(++blocks < 1000);
+        runOneBlock(plugin, everyParameterAtRandom(infos, random, firstMovingSlot));
+    }
+
+    plugin.pumpMainThread();
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+
+    checkLevel(*plugin);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note A module parameter's write is skipped while its LFO runs, so a replay
+/// of state through that setter cannot move a base with the LFO on in both copies.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A resync moves the base of a parameter whose LFO is running",
+          "[clap][protocol][hostile]")
+{
+    Entry const entry;
+
+    ActivePlugin plugin(sampleRate, blockSize);
+    auto &host(editorHostOf(*plugin));
+
+    REQUIRE(host.editSlot(0, secondEffect));
+    runOneBlock(plugin);
+
+    auto const gain(parameterID(moduleType, 0, 1 << 8));
+    auto const gainLFOEnabled(parameterID(lfoType, 0, 0));
+
+    runOneBlock(plugin, {{0, gain, 0.2}, {0, gainLFOEnabled, 1}});
+    plugin.pumpMainThread();
+    checkLevel(*plugin);
+
+    overflowTheEchoRing(plugin);
+    runOneBlock(plugin, {{0, gainLFOEnabled, 0}, {0, gain, 0.8}, {0, gainLFOEnabled, 1}});
+
+    plugin.pumpMainThread();
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+
+    checkLevel(*plugin);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note A period snaps to the grid of the sync type its LFO has when it is
+/// written, and the period comes before the sync type in the parameter list.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A resync lands a synced period on the grid the engine has it on",
+          "[clap][protocol][hostile]")
+{
+    Entry const entry;
+
+    ActivePlugin plugin(sampleRate, blockSize);
+    auto &host(editorHostOf(*plugin));
+
+    REQUIRE(host.editSlot(0, secondEffect));
+    runOneBlock(plugin);
+
+    auto const lfoParameter([](unsigned const lfo, unsigned const which) {
+        return parameterID(lfoType, 0, (lfo << 8) | which);
+    });
+    constexpr unsigned period{1}, syncTypes{5};
+    constexpr double note{1}, triplet{2};
+    constexpr unsigned lfos{5};
+
+    std::vector<TimedParameterEvents::At> onTriplets, onNotes;
+    for (unsigned lfo(0); lfo < lfos; ++lfo)
+    {
+        onTriplets.push_back({0, lfoParameter(lfo, syncTypes), triplet});
+        onNotes.push_back({0, lfoParameter(lfo, syncTypes), note});
+        onNotes.push_back({0, lfoParameter(lfo, period), 0.15 + 0.17 * lfo});
+    }
+
+    runOneBlock(plugin, onTriplets);
+    plugin.pumpMainThread();
+    checkLevel(*plugin);
+
+    overflowTheEchoRing(plugin);
+    runOneBlock(plugin, onNotes);
+
+    plugin.pumpMainThread();
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+
+    checkLevel(*plugin);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note A lost slot selector means the rack resync and the host's rescan ran
+/// against the stale copy, so the republish that moves the slot has to say so.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A slot the resync moves is redrawn and announced to the host",
+          "[clap][protocol][hostile][gui]")
+{
+    using Editor = LE::SW::GUI::SpectrumWorxEditor;
+
+    Entry const entry;
+    juce::ScopedJuceInitialiser_GUI const juceIsUp;
+
+    TestHost testHost{{.params = true}};
+    ActivePlugin plugin(sampleRate, blockSize, testHost);
+    auto &host(editorHostOf(*plugin));
+    auto &implementation(implementationOf(*plugin));
+    auto const &params(parameters(*plugin));
+
+    auto editor(std::make_unique<Editor>(host, Editor::PanelPlacement::overlay));
+
+    REQUIRE(host.editSlot(0, secondEffect));
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+    editor->resyncModuleRack();
+    REQUIRE(editor->regionInSlot(0) != nullptr);
+
+    auto const selector(slotSelector(*plugin, params, 0));
+
+    overflowTheEchoRing(plugin);
+    runOneBlock(plugin, {{0, selector.id, aDifferentValue(*plugin, params, selector)}});
+
+    auto const engineEffect(
+        implementation.program().moduleChain().moduleAs<LE::SW::Module>(0)->effectTypeIndex());
+    REQUIRE(engineEffect != secondEffect);
+
+    // the callback the slot change asked for, run against the stale copy
+    plugin.pumpMainThread();
+    auto const rescansBefore(testHost.rescanCalls.load());
+    testHost.rescanFlags = 0;
+
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+
+    checkLevel(*plugin);
+    CHECK(testHost.rescanCalls.load() > rescansBefore);
+    CHECK((testHost.rescanFlags.load() & CLAP_PARAM_RESCAN_INFO) != 0);
+    REQUIRE(editor->regionInSlot(0) != nullptr);
+    CHECK(editor->regionInSlot(0)->module().effectTypeIndex() == engineEffect);
+
+    editor.reset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note A host need not run the callback before deactivating, and a stopped
+/// engine drains no commands, so a queued request would leave stateSave stale.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A plugin deactivated straight after a storm is level before it saves",
+          "[clap][protocol][hostile]")
+{
+    Entry const entry;
+
+    ActivePlugin plugin(sampleRate, blockSize);
+
+    overflowTheEchoRing(plugin);
+
+    plugin.whileDeactivated([](clap_plugin const &deactivated) { checkLevel(deactivated); });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \note The request is itself a command, and the command ring can be full when
+/// it is made; the news that echoes were lost has to outlive that.
+///
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE("A resync asked for on a full command ring is asked for again",
+          "[clap][protocol][hostile]")
+{
+    Entry const entry;
+
+    ActivePlugin plugin(sampleRate, blockSize);
+    auto &host(editorHostOf(*plugin));
+    auto &implementation(implementationOf(*plugin));
+
+    overflowTheEchoRing(plugin);
+
+    // another parameter, at the value it has, so the edits that do not fit cost nothing
+    auto const edited(globalParameterID(1));
+    auto const editedTo(implementation.getParameter(edited, implementation.program()));
+    auto const echoesDropped(implementation.droppedMessages());
+    for (unsigned edit(0); edit < overflowingCommands; ++edit)
+        host.editParameter(edited, editedTo);
+    REQUIRE(implementation.droppedMessages() > echoesDropped);
+
+    // the request cannot be queued, and the block drains only the edits
+    auto const beforeRequest(implementation.droppedMessages());
+    plugin.pumpMainThread();
+    CHECK(implementation.droppedMessages() > beforeRequest);
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+    runOneBlock(plugin);
+    plugin.pumpMainThread();
+
+    checkLevel(*plugin);
 }
 
 TEST_CASE("A sample the engine never received is not recorded as loaded",

--- a/tests/clap/testHost.hpp
+++ b/tests/clap/testHost.hpp
@@ -622,7 +622,13 @@ class TimedParameterEvents
         double value;
     };
 
-    TimedParameterEvents(std::initializer_list<At> const events) : list_{this, size, get}
+    TimedParameterEvents(std::initializer_list<At> const events)
+        : TimedParameterEvents(std::vector<At>(events))
+    {
+    }
+
+    // for a block built in a loop
+    explicit TimedParameterEvents(std::vector<At> const &events) : list_{this, size, get}
     {
         std::uint32_t previous(0);
         for (auto const &[time, id, value] : events)


### PR DESCRIPTION
Issue #198.

A host automating hard with `on_main_thread` starved fills the echo ring, and every
echo it refuses leaves `programMain_` — what `paramsValue` and `stateSave` read —
behind the engine for that parameter until something writes it again.

### The plan in the issue, as written

- `echo()` pushes, and on a full ring raises `echoesLost_`.
- `drainEngineEvents()` drains the ring completely, then queues
  `ToEngine::RepublishParameters`. A refused request puts the flag back up.
- `drainCommands()` notes the request and republishes **after** the batch, so an
  edit queued behind the request is in what it reads. Every owned parameter goes
  back as `ToUI::BaseParameterRepublished`, in `parameterIDs_` order, so slot
  selectors land before what depends on them.

### What the plan needed on top

**A republish is state, not a replay of writes.** The echoes replay what the
engine was told in order, so every setter side effect lands the same on both
copies. Replaying *final values* through the same setters is not faithful in two
places, each found by a deterministic case failing against the plan as written:

- A module parameter's write is ignored while its LFO runs. LFO on, base moved
  while it was briefly off, LFO back on — the base can never come back.
  `setAutomatedParameter` takes a `WhileModulated`, and republished values are
  applied `stored`.
- A period snaps to the sync type its LFO has *when the period is written*, and
  the parameter list puts the period first. Each LFO's sync type is republished
  ahead of its period.

**A stopped engine republishes on the spot.** A deactivated plugin drains no
commands, so a queued request would leave `stateSave` stale until the next
`activate()` — a host is not obliged to run the callback before deactivating.

**A slot the republish moves is announced by the drain.** When the lost echo was
a slot selector, the engine's rack resync and `RESCAN_INFO` both ran against the
stale copy. `drainEchoes()` now reports a slot it changed, and the drain resyncs
the rack and asks for `INFO | TEXT | VALUES` (coalesced with the engine's own
request on the ordinary path).

### Tests

All in `tests/clap/publishProtocolTests.cpp`, and all assert at the far end:
every parameter's value in both Programs, and `savePreset` of both.

- *A full echo ring leaves the main thread's Program behind until it resyncs* —
  the case that pinned the divergence, inverted: stale after the first drain,
  level after the next block and drain.
- *A parameter storm that overflows the echo ring ends with both Programs level* —
  param-fuzz shaped: every automatable parameter every block, no main-thread turn,
  until a ring's worth is dropped.
- *A resync moves the base of a parameter whose LFO is running*
- *A resync lands a synced period on the grid the engine has it on*
- *A slot the resync moves is redrawn and announced to the host* — open editor,
  `TestHost` with `clap.params`.
- *A plugin deactivated straight after a storm is level before it saves*
- *A resync asked for on a full command ring is asked for again*

**The first storm was blind.** It passed against the republish that was wrong:
uniform 0..1 values kept every normalised LFO Enable on, and random slot writes
gave both copies fresh modules with every LFO off. It now writes each range's
ends a third of the time and holds three slots still, and fails on the LFO
reversion by itself.

Each fix was checked by reversion. With all five reverted in one build, exactly
the six cases covering them fail and the other seven protocol cases pass.

### Verified

- `ctest` 672/672 in `cmake-build-debug` and in `build-release`, goldens included.
- clap-validator 0.4.1 against both builds: 37 passed, 0 failed, 7 skipped.
- `scripts/check_format.sh` clean.

### Worth knowing

- The republish is every owned parameter pushed inside one block after a storm:
  no allocation and no lock, but a block-time spike if someone later measures an
  outlier. Chunking across blocks is available if it matters.
- A knob edit made between the republish and its drain is overwritten by the
  engine's older value. That is the window every ordinary echo already has,
  widened to every parameter for one callback.
- `publishProtocolTests.cpp` includes `plugin2HostImpl.inl`: the release build
  inlines `getParameter(id, Program)` away and the test would not link otherwise.

Docs: `threading_model.md` §3 (the resync and why it is state), the §7 row, and
a §8 row for the test file.

Assisted-by: Claude Opus 5
